### PR TITLE
Remove dependency on lazyWeave

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Imports:
     Hmisc (>= 4.0-3),
     htmltools (>= 0.3.6),
     knitr (>= 1.15.1),
-    lazyWeave (>= 3.0.1),
     lubridate (>= 1.6.0),
     magrittr (>= 1.5),
     mailR (>= 0.4.1),

--- a/R/utils.R
+++ b/R/utils.R
@@ -689,17 +689,17 @@ pb_notify <- function(agent,
     select(-tbl_name_chars, -tbl_name_abbrev) %>%
     dplyr::mutate(f_failed = paste0(as.character(f_failed * 100), "%")) %>%
     dplyr::mutate(f_passed = paste0(as.character(f_passed * 100), "%")) %>%
-    dplyr::rename(`Step` = step) %>%
-    dplyr::rename(`Table Name` = tbl_name) %>%
-    dplyr::rename(`Database Type` = db_type) %>%
-    dplyr::rename(`Assertion` = assertion_type) %>%
-    dplyr::rename(`Column` = column) %>%
-    dplyr::rename(`Number Passed` = n_passed) %>%
-    dplyr::rename(`Number Failed` = n_failed) %>%
-    dplyr::rename(` % Passed` = f_passed) %>%
-    dplyr::rename(` % Failed` = f_failed) %>%
     pixiedust::dust() %>%
     pixiedust::sprinkle_print_method("html") %>%
+    pixiedust::sprinkle_colnames(step = "Step",
+                                 tbl_name = "Table Name",
+                                 db_type = "Database Type",
+                                 assertion_type = "Assertion",
+                                 column = "Column",
+                                 n_passed = "Number Passed",
+                                 n_failed = "Number Failed",
+                                 f_passed = " % Passed",
+                                 f_failed = " % Failed") %>%
     pixiedust::sprinkle(
       part = "head",
       border = "top",


### PR DESCRIPTION
I will be submitting `pixiedust` to CRAN shortly.  In the update, I've taken away the dependency on `lazyWeave`.  I've removed it from the dependencies of `pointblank`. I did not change the minimum required version; even though I reported a critical bug, that bug only impacts LaTeX output.  Since you fix your output to HTML, it shouldn't be an issue for you to use 0.7.5.  I'll leave it to your discretion on whether to require 0.8.0.

I also made a code change in `utils.R`.  I recommended using `sprinkle_colnames` to rename columns in the table rather than `dplyr::rename`.  It's trivial, and I won't be hurt if you reject it.  