### PR TITLE
Repurpose `preconditions` to be used for exprs

### DIFF
--- a/R/col_vals_between.R
+++ b/R/col_vals_between.R
@@ -69,9 +69,7 @@ col_vals_between <- function(x,
   right <- stats::setNames(right, inclusive[2])
   
   if (inherits(x, c("data.frame", "tbl_df", "tbl_dbi"))) {
-    
-    preconditions <- rlang::enquo(preconditions)
-    
+
     return(
       x %>%
         evaluate_single(
@@ -92,17 +90,6 @@ col_vals_between <- function(x,
   }
   
   agent <- x
-  
-  # Get the preconditions
-  preconditions <- 
-    rlang::enquo(preconditions) %>%
-    rlang::expr_text() %>%
-    stringr::str_replace_all("~", "") %>%
-    stringr::str_replace_all("\"", "'")
-  
-  if (length(preconditions) == 0) {
-    preconditions <- NULL
-  }
   
   if (is.null(brief)) {
     

--- a/R/col_vals_equal.R
+++ b/R/col_vals_equal.R
@@ -7,6 +7,8 @@
 #' @param value A numeric value used to test for equality.
 #' 
 #' @examples
+#' library(dplyr)
+#' 
 #' # Create a simple data frame
 #' # with 2 columns of numerical values
 #' df <-
@@ -23,7 +25,8 @@
 #'   col_vals_equal(
 #'     column = b,
 #'     value = 5,
-#'     preconditions = a == 1) %>%
+#'     preconditions = ~ tbl %>% dplyr::filter(a == 1)
+#'   ) %>%
 #'   interrogate()
 #' 
 #' # Determine if these column

--- a/R/col_vals_equal.R
+++ b/R/col_vals_equal.R
@@ -62,8 +62,6 @@ col_vals_equal <- function(x,
   
   if (inherits(x, c("data.frame", "tbl_df", "tbl_dbi"))) {
     
-    preconditions <- rlang::enquo(preconditions)
-    
     return(
       x %>%
         evaluate_single(
@@ -82,17 +80,6 @@ col_vals_equal <- function(x,
   }
   
   agent <- x
-  
-  # Get the preconditions
-  preconditions <- 
-    rlang::enquo(preconditions) %>%
-    rlang::expr_text() %>%
-    stringr::str_replace_all("~", "") %>%
-    stringr::str_replace_all("\"", "'")
-  
-  if (length(preconditions) == 0) {
-    preconditions <- NULL
-  }
   
   if (is.null(brief)) {
     

--- a/R/col_vals_gt.R
+++ b/R/col_vals_gt.R
@@ -12,15 +12,13 @@
 #'   are considered passing.
 #' @param incl_na Should `NA` values be a part of the condition? This is by
 #'   default `FALSE`.
-#' @param preconditions An optional statement of filtering conditions that may
-#'   reduce the number of rows for validation for the current validation step.
-#'   The statements are executed for every row of the table in focus and are
-#'   often referred as predicate statements (they either return `TRUE` or
-#'   `FALSE` for every row evaluated, where rows evaluated as `TRUE` are the
-#'   rows that are retained for the validation step). For example, if a table
-#'   has columns `a`, `b`, and `c`, and, column `a` has numerical data, we can
-#'   write a statement `a < 5` that filters all rows in the table where values
-#'   in column a are less than five.
+#' @param preconditions expressions used for mutating the input table before
+#'   proceeding with the validation. This is ideally as a one-sided R formula
+#'   using a leading `~`. In the formula representation, the `tbl` serves as the
+#'   input data table to be transformed (e.g.,
+#'   `~ tbl %>% dplyr::mutate(col = col + 10)`. A series of expressions can be
+#'   used by enclosing the set of statements with `{ }` but note that the `tbl`
+#'   object must be ultimately returned.
 #' @param brief An optional, text-based description for the validation step.
 #' @param warn_count,notify_count The threshold number for individual
 #'   validations returning a `FALSE` result before applying the `warn` or
@@ -108,9 +106,7 @@ col_vals_gt <- function(x,
     stringr::str_replace_all("~", "") %>%
     stringr::str_replace_all("\"", "'")
   
-  if (inherits(x , c("data.frame", "tbl_df", "tbl_dbi"))) {
-    
-    preconditions <- rlang::enquo(preconditions)
+  if (inherits(x, c("data.frame", "tbl_df", "tbl_dbi"))) {
     
     return(
       x %>%
@@ -131,18 +127,7 @@ col_vals_gt <- function(x,
   }
   
   agent <- x
-  
-  # Get the preconditions
-  preconditions <- 
-    rlang::enquo(preconditions) %>%
-    rlang::expr_text() %>%
-    stringr::str_replace_all("~", "") %>%
-    stringr::str_replace_all("\"", "'")
-  
-  if (length(preconditions) == 0) {
-    preconditions <- NULL
-  }
-  
+
   if (is.null(brief)) {
     
     brief <-

--- a/R/col_vals_gte.R
+++ b/R/col_vals_gte.R
@@ -61,8 +61,6 @@ col_vals_gte <- function(x,
   
   if (inherits(x, c("data.frame", "tbl_df", "tbl_dbi"))) {
     
-    preconditions <- rlang::enquo(preconditions)
-    
     return(
       x %>%
         evaluate_single(
@@ -81,17 +79,6 @@ col_vals_gte <- function(x,
   }
   
   agent <- x
-  
-  # Get the preconditions
-  preconditions <- 
-    rlang::enquo(preconditions) %>%
-    rlang::expr_text() %>%
-    stringr::str_replace_all("~", "") %>%
-    stringr::str_replace_all("\"", "'")
-  
-  if (length(preconditions) == 0) {
-    preconditions <- NULL
-  }
   
   if (is.null(brief)) {
     

--- a/R/col_vals_in_set.R
+++ b/R/col_vals_in_set.R
@@ -70,8 +70,6 @@ col_vals_in_set <- function(x,
   
   if (inherits(x, c("data.frame", "tbl_df", "tbl_dbi"))) {
     
-    preconditions <- rlang::enquo(preconditions)
-    
     return(
       x %>%
         evaluate_single(
@@ -90,18 +88,7 @@ col_vals_in_set <- function(x,
   }
   
   agent <- x
-  
-  # Get the preconditions
-  preconditions <- 
-    rlang::enquo(preconditions) %>%
-    rlang::expr_text() %>%
-    stringr::str_replace_all("~", "") %>%
-    stringr::str_replace_all("\"", "'")
-  
-  if (length(preconditions) == 0) {
-    preconditions <- NULL
-  }
-  
+
   if (is.null(brief)) {
     
     brief <-

--- a/R/col_vals_lt.R
+++ b/R/col_vals_lt.R
@@ -62,8 +62,6 @@ col_vals_lt <- function(x,
   
   if (inherits(x, c("data.frame", "tbl_df", "tbl_dbi"))) {
     
-    preconditions <- rlang::enquo(preconditions)
-    
     return(
       x %>%
         evaluate_single(
@@ -82,17 +80,6 @@ col_vals_lt <- function(x,
   }
   
   agent <- x
-  
-  # Get the preconditions
-  preconditions <- 
-    rlang::enquo(preconditions) %>%
-    rlang::expr_text() %>%
-    stringr::str_replace_all("~", "") %>%
-    stringr::str_replace_all("\"", "'")
-  
-  if (length(preconditions) == 0) {
-    preconditions <- NULL
-  }
   
   if (is.null(brief)) {
     

--- a/R/col_vals_lte.R
+++ b/R/col_vals_lte.R
@@ -64,8 +64,6 @@ col_vals_lte <- function(x,
   
   if (inherits(x, c("data.frame", "tbl_df", "tbl_dbi"))) {
     
-    preconditions <- rlang::enquo(preconditions)
-    
     return(
       x %>%
         evaluate_single(
@@ -84,17 +82,6 @@ col_vals_lte <- function(x,
   }
   
   agent <- x
-  
-  # Get the preconditions
-  preconditions <- 
-    rlang::enquo(preconditions) %>%
-    rlang::expr_text() %>%
-    stringr::str_replace_all("~", "") %>%
-    stringr::str_replace_all("\"", "'")
-  
-  if (length(preconditions) == 0) {
-    preconditions <- NULL
-  }
   
   if (is.null(brief)) {
     

--- a/R/col_vals_not_between.R
+++ b/R/col_vals_not_between.R
@@ -70,9 +70,7 @@ col_vals_not_between <- function(x,
   right <- stats::setNames(right, inclusive[2])
   
   if (inherits(x, c("data.frame", "tbl_df", "tbl_dbi"))) {
-    
-    preconditions <- rlang::enquo(preconditions)
-    
+
     return(
       x %>%
         evaluate_single(
@@ -93,17 +91,6 @@ col_vals_not_between <- function(x,
   }
   
   agent <- x
-  
-  # Get the preconditions
-  preconditions <- 
-    rlang::enquo(preconditions) %>%
-    rlang::expr_text() %>%
-    stringr::str_replace_all("~", "") %>%
-    stringr::str_replace_all("\"", "'")
-  
-  if (length(preconditions) == 0) {
-    preconditions <- NULL
-  }
   
   if (is.null(brief)) {
     

--- a/R/col_vals_not_equal.R
+++ b/R/col_vals_not_equal.R
@@ -7,6 +7,8 @@
 #' @param value a numeric value used to test for non-equality.
 #' 
 #' @examples
+#' library(dplyr)
+#' 
 #' # Create a simple data frame
 #' # with 2 columns of numerical values
 #' df <-
@@ -24,7 +26,7 @@
 #'   col_vals_not_equal(
 #'     column = b,
 #'     value = 5,
-#'     preconditions = a == 2
+#'     preconditions = ~ tbl %>% dplyr::filter(a == 2)
 #'   ) %>%
 #'   interrogate()
 #' 

--- a/R/col_vals_not_equal.R
+++ b/R/col_vals_not_equal.R
@@ -63,8 +63,6 @@ col_vals_not_equal <- function(x,
   
   if (inherits(x, c("data.frame", "tbl_df", "tbl_dbi"))) {
     
-    preconditions <- rlang::enquo(preconditions)
-    
     return(
       x %>%
         evaluate_single(
@@ -83,18 +81,7 @@ col_vals_not_equal <- function(x,
   }
   
   agent <- x
-  
-  # Get the preconditions
-  preconditions <- 
-    rlang::enquo(preconditions) %>%
-    rlang::expr_text() %>%
-    stringr::str_replace_all("~", "") %>%
-    stringr::str_replace_all("\"", "'")
-  
-  if (length(preconditions) == 0) {
-    preconditions <- NULL
-  }
-  
+
   if (is.null(brief)) {
     
     brief <-

--- a/R/col_vals_not_in_set.R
+++ b/R/col_vals_not_in_set.R
@@ -70,8 +70,6 @@ col_vals_not_in_set <- function(x,
   
   if (inherits(x, c("data.frame", "tbl_df", "tbl_dbi"))) {
     
-    preconditions <- rlang::enquo(preconditions)
-    
     return(
       x %>%
         evaluate_single(
@@ -90,18 +88,7 @@ col_vals_not_in_set <- function(x,
   }
   
   agent <- x
-  
-  # Get the preconditions
-  preconditions <- 
-    rlang::enquo(preconditions) %>%
-    rlang::expr_text() %>%
-    stringr::str_replace_all("~", "") %>%
-    stringr::str_replace_all("\"", "'")
-  
-  if (length(preconditions) == 0) {
-    preconditions <- NULL
-  }
-  
+
   if (is.null(brief)) {
     
     brief <-

--- a/R/col_vals_not_null.R
+++ b/R/col_vals_not_null.R
@@ -61,8 +61,6 @@ col_vals_not_null <- function(x,
   
   if (inherits(x, c("data.frame", "tbl_df", "tbl_dbi"))) {
     
-    preconditions <- rlang::enquo(preconditions)
-    
     return(
       x %>%
         evaluate_single(
@@ -80,17 +78,6 @@ col_vals_not_null <- function(x,
   }
   
   agent <- x
-  
-  # Get the preconditions
-  preconditions <- 
-    rlang::enquo(preconditions) %>%
-    rlang::expr_text() %>%
-    stringr::str_replace_all("~", "") %>%
-    stringr::str_replace_all("\"", "'")
-  
-  if (length(preconditions) == 0) {
-    preconditions <- NULL
-  }
   
   if (is.null(brief)) {
     

--- a/R/col_vals_not_null.R
+++ b/R/col_vals_not_null.R
@@ -6,6 +6,8 @@
 #' @inheritParams col_vals_gt
 #' 
 #' @examples
+#' library(dplyr)
+#' 
 #' # Create a simple data frame with
 #' # 2 columns of numerical values
 #' df <-
@@ -23,7 +25,8 @@
 #'   focus_on(tbl_name = "df") %>%
 #'   col_vals_not_null(
 #'     column = a,
-#'     preconditions = b == 2) %>%
+#'     preconditions = ~ tbl %>% dplyr::filter(b == 2)
+#'   ) %>%
 #'   interrogate()
 #' 
 #' # Determine if these column

--- a/R/col_vals_null.R
+++ b/R/col_vals_null.R
@@ -6,6 +6,8 @@
 #' @inheritParams col_vals_gt
 #'   
 #' @examples
+#' library(dplyr)
+#' 
 #' # Create a simple data frame with
 #' # 2 columns of numerical values
 #' df <-
@@ -23,7 +25,8 @@
 #'   focus_on(tbl_name = "df") %>%
 #'   col_vals_null(
 #'     column = a,
-#'     preconditions = b == 5) %>%
+#'     preconditions = ~ tbl %>% dplyr::filter(b >= 5)
+#'   ) %>%
 #'   interrogate()
 #' 
 #' # Determine if these column

--- a/R/col_vals_null.R
+++ b/R/col_vals_null.R
@@ -61,8 +61,6 @@ col_vals_null <- function(x,
   
   if (inherits(x, c("data.frame", "tbl_df", "tbl_dbi"))) {
     
-    preconditions <- rlang::enquo(preconditions)
-    
     return(
       x %>%
         evaluate_single(
@@ -80,17 +78,6 @@ col_vals_null <- function(x,
   }
   
   agent <- x
-  
-  # Get the preconditions
-  preconditions <- 
-    rlang::enquo(preconditions) %>%
-    rlang::expr_text() %>%
-    stringr::str_replace_all("~", "") %>%
-    stringr::str_replace_all("\"", "'")
-  
-  if (length(preconditions) == 0) {
-    preconditions <- NULL
-  }
   
   if (is.null(brief)) {
     

--- a/R/col_vals_regex.R
+++ b/R/col_vals_regex.R
@@ -61,8 +61,6 @@ col_vals_regex <- function(x,
   
   if (inherits(x, c("data.frame", "tbl_df", "tbl_dbi"))) {
     
-    preconditions <- rlang::enquo(preconditions)
-    
     return(
       x %>%
         evaluate_single(
@@ -81,18 +79,7 @@ col_vals_regex <- function(x,
   }
   
   agent <- x
-  
-  # Get the preconditions
-  preconditions <- 
-    rlang::enquo(preconditions) %>%
-    rlang::expr_text() %>%
-    stringr::str_replace_all("~", "") %>%
-    stringr::str_replace_all("\"", "'")
-  
-  if (length(preconditions) == 0) {
-    preconditions <- NULL
-  }
-  
+
   if (is.null(brief)) {
     
     brief <-

--- a/R/create_agent.R
+++ b/R/create_agent.R
@@ -99,6 +99,7 @@ create_agent <- function(validation_name = NULL) {
           value = numeric(0),
           set = list(NULL),
           regex = character(0),
+          preconditions = list(NULL),
           all_passed = logical(0),
           n = integer(0),
           n_passed = integer(0),
@@ -120,8 +121,7 @@ create_agent <- function(validation_name = NULL) {
           col_types = character(0),
           time_processed = as.POSIXct(NA)[-1],
           proc_duration_s = numeric(0)
-        ),
-      preconditions = list()
+        )
     )
   
   # Add the agent name to the object

--- a/R/get_interrogation_summary.R
+++ b/R/get_interrogation_summary.R
@@ -21,18 +21,26 @@ get_interrogation_summary <- function(agent) {
           dplyr::filter(!(component_name %in% c("create_agent", "focus_on"))) %>%
           dplyr::pull(brief)
       )
-    
+
     interrogation_summary <-
       validation_set %>%
-      dplyr::select(1:10, f_passed, warn, notify, brief) %>%
+      dplyr::select(
+        tbl_name, db_type, assertion_type, column, value, set, regex,
+        preconditions, all_passed, n, f_passed, n_passed, f_passed,
+        warn, notify, brief
+      ) %>%
       dplyr::mutate(
         action = dplyr::case_when(
           .$warn == FALSE & .$notify == FALSE ~ as.character(NA),
           .$warn == TRUE & .$notify == FALSE ~ "warn",
           .$warn == FALSE & .$notify == TRUE ~ "notify",
-          .$warn == TRUE & .$notify == TRUE ~ "notify")) %>%
-      dplyr::select(-warn, -notify) %>%
-      dplyr::select(1:11, action, brief)
+          .$warn == TRUE & .$notify == TRUE ~ "notify")
+      ) %>%
+      dplyr::select(
+        tbl_name, db_type, assertion_type, column, value, set, regex,
+        preconditions, all_passed, n, f_passed, n_passed, f_passed,
+        action, brief
+      )
     
     return(interrogation_summary)
     

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -25,6 +25,8 @@
 #'   when sampling non-passing rows using the `sample_frac` option.
 #'   
 #' @examples 
+#' library(dplyr)
+#' 
 #' # Create 2 simple data frames
 #' # with 2 columns of numerical
 #' # values in each
@@ -53,7 +55,8 @@
 #'   col_vals_equal(
 #'     column = c,
 #'     value = 8,
-#'     preconditions = d >= 5) %>%
+#'     preconditions = ~ tbl %>% dplyr::filter(d >= 5)
+#'   ) %>%
 #'   interrogate()
 #'   
 #' # Get a basic summary with

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -69,7 +69,7 @@ interrogate <- function(agent,
                         sample_n = NULL,
                         sample_frac = NULL,
                         sample_limit = 5000) {
-  
+
   # Add the starting time to the `agent` object
   agent$validation_time <- Sys.time()
   
@@ -83,7 +83,7 @@ interrogate <- function(agent,
     
     # Use preconditions to modify the table
     table <- apply_preconditions_to_tbl(agent, idx = i, tbl = table)
-    
+
     # Get the assertion type for this verification step
     assertion_type <- get_assertion_type_at_idx(agent, idx = i)
     
@@ -291,7 +291,9 @@ interrogate_comparison <- function(agent, idx, table, assertion_type) {
   value <- get_column_value_at_idx(agent = agent, idx = idx)
   
   # Obtain the target column as a symbol
-  column <- get_column_as_sym_at_idx(agent = agent, idx = idx) %>% as_label()
+  column <- 
+    get_column_as_sym_at_idx(agent = agent, idx = idx) %>%
+    rlang::as_label()
   
   # Get operator values for all assertion types involving
   # simple operator comparisons
@@ -312,7 +314,7 @@ interrogate_comparison <- function(agent, idx, table, assertion_type) {
   # Perform rowwise validations for the column
   tbl_checked <-
     table %>%
-    dplyr::mutate(pb_is_good_ = !!parse_expr(expression))
+    dplyr::mutate(pb_is_good_ = !!rlang::parse_expr(expression))
   
   tbl_checked
 }
@@ -356,10 +358,13 @@ interrogate_duplicated <- function(agent, idx, table) {
   if (!is.na(agent$validation_set$column[idx])) {
     
     column_names <- 
-      get_column_as_sym_at_idx(agent = agent, idx = idx) %>% as.character()
+      get_column_as_sym_at_idx(agent = agent, idx = idx) %>%
+      as.character()
     
     if (grepl("(,|&)", column_names)) {
-      column_names <- strsplit(split = "(, |,|&)", column_names) %>% unlist()
+      column_names <- 
+        strsplit(split = "(, |,|&)", column_names) %>%
+        unlist()
     }
     
   } else if (is.na(agent$validation_set$column[idx])) {
@@ -403,7 +408,9 @@ interrogate_duplicated <- function(agent, idx, table) {
   # Perform rowwise validations for the column
   tbl_checked <- 
     table %>%
-    dplyr::mutate(pb_is_good_ = ifelse(dplyr::row_number() %in% duplicate_row_idx, FALSE, TRUE))
+    dplyr::mutate(pb_is_good_ = ifelse(
+      dplyr::row_number() %in% duplicate_row_idx, FALSE, TRUE)
+    )
   
   tbl_checked
 }
@@ -455,7 +462,6 @@ add_reporting_data <- function(agent,
     agent$validation_set$all_passed[idx] <- FALSE
     
     # Collect problem rows if requested
-    
     if (isTRUE(get_problem_rows)) {
       
       problem_rows <- 

--- a/R/rows_not_duplicated.R
+++ b/R/rows_not_duplicated.R
@@ -72,17 +72,6 @@ rows_not_duplicated <- function(x,
     cols <- NULL
   }
   
-  # Get the preconditions
-  preconditions <- 
-    rlang::enquo(preconditions) %>%
-    rlang::expr_text() %>%
-    stringr::str_replace_all("~", "") %>%
-    stringr::str_replace_all("\"", "'")
-  
-  if (length(preconditions) == 0) {
-    preconditions <- NULL
-  }
-  
   if (is.null(brief)) {
     
     brief <-

--- a/man/col_vals_between.Rd
+++ b/man/col_vals_between.Rd
@@ -44,15 +44,13 @@ bound value in addition to values lower than \code{right}.}
 \item{incl_na}{Should \code{NA} values be a part of the condition? This is by
 default \code{FALSE}.}
 
-\item{preconditions}{An optional statement of filtering conditions that may
-reduce the number of rows for validation for the current validation step.
-The statements are executed for every row of the table in focus and are
-often referred as predicate statements (they either return \code{TRUE} or
-\code{FALSE} for every row evaluated, where rows evaluated as \code{TRUE} are the
-rows that are retained for the validation step). For example, if a table
-has columns \code{a}, \code{b}, and \code{c}, and, column \code{a} has numerical data, we can
-write a statement \code{a < 5} that filters all rows in the table where values
-in column a are less than five.}
+\item{preconditions}{expressions used for mutating the input table before
+proceeding with the validation. This is ideally as a one-sided R formula
+using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+input data table to be transformed (e.g.,
+\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
+used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
+object must be ultimately returned.}
 
 \item{brief}{An optional, text-based description for the validation step.}
 

--- a/man/col_vals_equal.Rd
+++ b/man/col_vals_equal.Rd
@@ -34,15 +34,13 @@ columns (e.g., \code{a + b} or \code{a + sum(a)}).}
 
 \item{value}{A numeric value used to test for equality.}
 
-\item{preconditions}{An optional statement of filtering conditions that may
-reduce the number of rows for validation for the current validation step.
-The statements are executed for every row of the table in focus and are
-often referred as predicate statements (they either return \code{TRUE} or
-\code{FALSE} for every row evaluated, where rows evaluated as \code{TRUE} are the
-rows that are retained for the validation step). For example, if a table
-has columns \code{a}, \code{b}, and \code{c}, and, column \code{a} has numerical data, we can
-write a statement \code{a < 5} that filters all rows in the table where values
-in column a are less than five.}
+\item{preconditions}{expressions used for mutating the input table before
+proceeding with the validation. This is ideally as a one-sided R formula
+using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+input data table to be transformed (e.g.,
+\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
+used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
+object must be ultimately returned.}
 
 \item{brief}{An optional, text-based description for the validation step.}
 

--- a/man/col_vals_equal.Rd
+++ b/man/col_vals_equal.Rd
@@ -107,6 +107,8 @@ Verification step where numeric values in a table column should be equal to a
 specified value.
 }
 \examples{
+library(dplyr)
+
 # Create a simple data frame
 # with 2 columns of numerical values
 df <-
@@ -123,7 +125,8 @@ agent <-
   col_vals_equal(
     column = b,
     value = 5,
-    preconditions = a == 1) \%>\%
+    preconditions = ~ tbl \%>\% dplyr::filter(a == 1)
+  ) \%>\%
   interrogate()
 
 # Determine if these column

--- a/man/col_vals_gt.Rd
+++ b/man/col_vals_gt.Rd
@@ -39,15 +39,13 @@ are considered passing.}
 \item{incl_na}{Should \code{NA} values be a part of the condition? This is by
 default \code{FALSE}.}
 
-\item{preconditions}{An optional statement of filtering conditions that may
-reduce the number of rows for validation for the current validation step.
-The statements are executed for every row of the table in focus and are
-often referred as predicate statements (they either return \code{TRUE} or
-\code{FALSE} for every row evaluated, where rows evaluated as \code{TRUE} are the
-rows that are retained for the validation step). For example, if a table
-has columns \code{a}, \code{b}, and \code{c}, and, column \code{a} has numerical data, we can
-write a statement \code{a < 5} that filters all rows in the table where values
-in column a are less than five.}
+\item{preconditions}{expressions used for mutating the input table before
+proceeding with the validation. This is ideally as a one-sided R formula
+using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+input data table to be transformed (e.g.,
+\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
+used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
+object must be ultimately returned.}
 
 \item{brief}{An optional, text-based description for the validation step.}
 

--- a/man/col_vals_gte.Rd
+++ b/man/col_vals_gte.Rd
@@ -34,15 +34,13 @@ columns (e.g., \code{a + b} or \code{a + sum(a)}).}
 
 \item{value}{A numeric value used for this test. Any column values \verb{>= value} are considered passing.}
 
-\item{preconditions}{An optional statement of filtering conditions that may
-reduce the number of rows for validation for the current validation step.
-The statements are executed for every row of the table in focus and are
-often referred as predicate statements (they either return \code{TRUE} or
-\code{FALSE} for every row evaluated, where rows evaluated as \code{TRUE} are the
-rows that are retained for the validation step). For example, if a table
-has columns \code{a}, \code{b}, and \code{c}, and, column \code{a} has numerical data, we can
-write a statement \code{a < 5} that filters all rows in the table where values
-in column a are less than five.}
+\item{preconditions}{expressions used for mutating the input table before
+proceeding with the validation. This is ideally as a one-sided R formula
+using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+input data table to be transformed (e.g.,
+\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
+used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
+object must be ultimately returned.}
 
 \item{brief}{An optional, text-based description for the validation step.}
 

--- a/man/col_vals_in_set.Rd
+++ b/man/col_vals_in_set.Rd
@@ -35,15 +35,13 @@ columns (e.g., \code{a + b} or \code{a + sum(a)}).}
 \item{set}{A vector of numeric or string-based elements, where column values
 found within this \code{set} will be considered as passing.}
 
-\item{preconditions}{An optional statement of filtering conditions that may
-reduce the number of rows for validation for the current validation step.
-The statements are executed for every row of the table in focus and are
-often referred as predicate statements (they either return \code{TRUE} or
-\code{FALSE} for every row evaluated, where rows evaluated as \code{TRUE} are the
-rows that are retained for the validation step). For example, if a table
-has columns \code{a}, \code{b}, and \code{c}, and, column \code{a} has numerical data, we can
-write a statement \code{a < 5} that filters all rows in the table where values
-in column a are less than five.}
+\item{preconditions}{expressions used for mutating the input table before
+proceeding with the validation. This is ideally as a one-sided R formula
+using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+input data table to be transformed (e.g.,
+\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
+used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
+object must be ultimately returned.}
 
 \item{brief}{An optional, text-based description for the validation step.}
 

--- a/man/col_vals_lt.Rd
+++ b/man/col_vals_lt.Rd
@@ -35,15 +35,13 @@ columns (e.g., \code{a + b} or \code{a + sum(a)}).}
 \item{value}{A numeric value used for this test. Any column values \verb{< value}
 are considered passing.}
 
-\item{preconditions}{An optional statement of filtering conditions that may
-reduce the number of rows for validation for the current validation step.
-The statements are executed for every row of the table in focus and are
-often referred as predicate statements (they either return \code{TRUE} or
-\code{FALSE} for every row evaluated, where rows evaluated as \code{TRUE} are the
-rows that are retained for the validation step). For example, if a table
-has columns \code{a}, \code{b}, and \code{c}, and, column \code{a} has numerical data, we can
-write a statement \code{a < 5} that filters all rows in the table where values
-in column a are less than five.}
+\item{preconditions}{expressions used for mutating the input table before
+proceeding with the validation. This is ideally as a one-sided R formula
+using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+input data table to be transformed (e.g.,
+\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
+used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
+object must be ultimately returned.}
 
 \item{brief}{An optional, text-based description for the validation step.}
 

--- a/man/col_vals_lte.Rd
+++ b/man/col_vals_lte.Rd
@@ -35,15 +35,13 @@ columns (e.g., \code{a + b} or \code{a + sum(a)}).}
 \item{value}{A numeric value used for this test. Any column values \verb{<= value}
 are considered passing.}
 
-\item{preconditions}{An optional statement of filtering conditions that may
-reduce the number of rows for validation for the current validation step.
-The statements are executed for every row of the table in focus and are
-often referred as predicate statements (they either return \code{TRUE} or
-\code{FALSE} for every row evaluated, where rows evaluated as \code{TRUE} are the
-rows that are retained for the validation step). For example, if a table
-has columns \code{a}, \code{b}, and \code{c}, and, column \code{a} has numerical data, we can
-write a statement \code{a < 5} that filters all rows in the table where values
-in column a are less than five.}
+\item{preconditions}{expressions used for mutating the input table before
+proceeding with the validation. This is ideally as a one-sided R formula
+using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+input data table to be transformed (e.g.,
+\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
+used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
+object must be ultimately returned.}
 
 \item{brief}{An optional, text-based description for the validation step.}
 

--- a/man/col_vals_not_between.Rd
+++ b/man/col_vals_not_between.Rd
@@ -41,15 +41,13 @@ Any values \verb{>= left} and \verb{<= right} will be considered as failing.}
 \item{incl_na}{Should \code{NA} values be a part of the condition? This is by
 default \code{FALSE}.}
 
-\item{preconditions}{An optional statement of filtering conditions that may
-reduce the number of rows for validation for the current validation step.
-The statements are executed for every row of the table in focus and are
-often referred as predicate statements (they either return \code{TRUE} or
-\code{FALSE} for every row evaluated, where rows evaluated as \code{TRUE} are the
-rows that are retained for the validation step). For example, if a table
-has columns \code{a}, \code{b}, and \code{c}, and, column \code{a} has numerical data, we can
-write a statement \code{a < 5} that filters all rows in the table where values
-in column a are less than five.}
+\item{preconditions}{expressions used for mutating the input table before
+proceeding with the validation. This is ideally as a one-sided R formula
+using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+input data table to be transformed (e.g.,
+\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
+used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
+object must be ultimately returned.}
 
 \item{brief}{An optional, text-based description for the validation step.}
 

--- a/man/col_vals_not_equal.Rd
+++ b/man/col_vals_not_equal.Rd
@@ -107,6 +107,8 @@ Verification step where numeric values in a table column should not be equal
 to a specified value.
 }
 \examples{
+library(dplyr)
+
 # Create a simple data frame
 # with 2 columns of numerical values
 df <-
@@ -124,7 +126,7 @@ agent <-
   col_vals_not_equal(
     column = b,
     value = 5,
-    preconditions = a == 2
+    preconditions = ~ tbl \%>\% dplyr::filter(a == 2)
   ) \%>\%
   interrogate()
 

--- a/man/col_vals_not_equal.Rd
+++ b/man/col_vals_not_equal.Rd
@@ -34,15 +34,13 @@ columns (e.g., \code{a + b} or \code{a + sum(a)}).}
 
 \item{value}{a numeric value used to test for non-equality.}
 
-\item{preconditions}{An optional statement of filtering conditions that may
-reduce the number of rows for validation for the current validation step.
-The statements are executed for every row of the table in focus and are
-often referred as predicate statements (they either return \code{TRUE} or
-\code{FALSE} for every row evaluated, where rows evaluated as \code{TRUE} are the
-rows that are retained for the validation step). For example, if a table
-has columns \code{a}, \code{b}, and \code{c}, and, column \code{a} has numerical data, we can
-write a statement \code{a < 5} that filters all rows in the table where values
-in column a are less than five.}
+\item{preconditions}{expressions used for mutating the input table before
+proceeding with the validation. This is ideally as a one-sided R formula
+using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+input data table to be transformed (e.g.,
+\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
+used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
+object must be ultimately returned.}
 
 \item{brief}{An optional, text-based description for the validation step.}
 

--- a/man/col_vals_not_in_set.Rd
+++ b/man/col_vals_not_in_set.Rd
@@ -35,15 +35,13 @@ columns (e.g., \code{a + b} or \code{a + sum(a)}).}
 \item{set}{A vector of numeric or string-based elements, where column values
 found within this \code{set} will be considered as failing.}
 
-\item{preconditions}{An optional statement of filtering conditions that may
-reduce the number of rows for validation for the current validation step.
-The statements are executed for every row of the table in focus and are
-often referred as predicate statements (they either return \code{TRUE} or
-\code{FALSE} for every row evaluated, where rows evaluated as \code{TRUE} are the
-rows that are retained for the validation step). For example, if a table
-has columns \code{a}, \code{b}, and \code{c}, and, column \code{a} has numerical data, we can
-write a statement \code{a < 5} that filters all rows in the table where values
-in column a are less than five.}
+\item{preconditions}{expressions used for mutating the input table before
+proceeding with the validation. This is ideally as a one-sided R formula
+using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+input data table to be transformed (e.g.,
+\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
+used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
+object must be ultimately returned.}
 
 \item{brief}{An optional, text-based description for the validation step.}
 

--- a/man/col_vals_not_null.Rd
+++ b/man/col_vals_not_null.Rd
@@ -31,15 +31,13 @@ vector) to which this validation should be applied. Aside from a single
 column name, column operations can be used to create one or more computed
 columns (e.g., \code{a + b} or \code{a + sum(a)}).}
 
-\item{preconditions}{An optional statement of filtering conditions that may
-reduce the number of rows for validation for the current validation step.
-The statements are executed for every row of the table in focus and are
-often referred as predicate statements (they either return \code{TRUE} or
-\code{FALSE} for every row evaluated, where rows evaluated as \code{TRUE} are the
-rows that are retained for the validation step). For example, if a table
-has columns \code{a}, \code{b}, and \code{c}, and, column \code{a} has numerical data, we can
-write a statement \code{a < 5} that filters all rows in the table where values
-in column a are less than five.}
+\item{preconditions}{expressions used for mutating the input table before
+proceeding with the validation. This is ideally as a one-sided R formula
+using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+input data table to be transformed (e.g.,
+\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
+used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
+object must be ultimately returned.}
 
 \item{brief}{An optional, text-based description for the validation step.}
 

--- a/man/col_vals_not_null.Rd
+++ b/man/col_vals_not_null.Rd
@@ -104,6 +104,8 @@ Verification step where no values in a table column are expected to be
 \code{NULL}.
 }
 \examples{
+library(dplyr)
+
 # Create a simple data frame with
 # 2 columns of numerical values
 df <-
@@ -121,7 +123,8 @@ agent <-
   focus_on(tbl_name = "df") \%>\%
   col_vals_not_null(
     column = a,
-    preconditions = b == 2) \%>\%
+    preconditions = ~ tbl \%>\% dplyr::filter(b == 2)
+  ) \%>\%
   interrogate()
 
 # Determine if these column

--- a/man/col_vals_null.Rd
+++ b/man/col_vals_null.Rd
@@ -104,6 +104,8 @@ Verification step where all values in a table column are expected to be
 \code{NULL}.
 }
 \examples{
+library(dplyr)
+
 # Create a simple data frame with
 # 2 columns of numerical values
 df <-
@@ -121,7 +123,8 @@ agent <-
   focus_on(tbl_name = "df") \%>\%
   col_vals_null(
     column = a,
-    preconditions = b == 5) \%>\%
+    preconditions = ~ tbl \%>\% dplyr::filter(b >= 5)
+  ) \%>\%
   interrogate()
 
 # Determine if these column

--- a/man/col_vals_null.Rd
+++ b/man/col_vals_null.Rd
@@ -31,15 +31,13 @@ vector) to which this validation should be applied. Aside from a single
 column name, column operations can be used to create one or more computed
 columns (e.g., \code{a + b} or \code{a + sum(a)}).}
 
-\item{preconditions}{An optional statement of filtering conditions that may
-reduce the number of rows for validation for the current validation step.
-The statements are executed for every row of the table in focus and are
-often referred as predicate statements (they either return \code{TRUE} or
-\code{FALSE} for every row evaluated, where rows evaluated as \code{TRUE} are the
-rows that are retained for the validation step). For example, if a table
-has columns \code{a}, \code{b}, and \code{c}, and, column \code{a} has numerical data, we can
-write a statement \code{a < 5} that filters all rows in the table where values
-in column a are less than five.}
+\item{preconditions}{expressions used for mutating the input table before
+proceeding with the validation. This is ideally as a one-sided R formula
+using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+input data table to be transformed (e.g.,
+\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
+used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
+object must be ultimately returned.}
 
 \item{brief}{An optional, text-based description for the validation step.}
 

--- a/man/col_vals_regex.Rd
+++ b/man/col_vals_regex.Rd
@@ -34,15 +34,13 @@ columns (e.g., \code{a + b} or \code{a + sum(a)}).}
 
 \item{regex}{A regex pattern to test for matching strings.}
 
-\item{preconditions}{An optional statement of filtering conditions that may
-reduce the number of rows for validation for the current validation step.
-The statements are executed for every row of the table in focus and are
-often referred as predicate statements (they either return \code{TRUE} or
-\code{FALSE} for every row evaluated, where rows evaluated as \code{TRUE} are the
-rows that are retained for the validation step). For example, if a table
-has columns \code{a}, \code{b}, and \code{c}, and, column \code{a} has numerical data, we can
-write a statement \code{a < 5} that filters all rows in the table where values
-in column a are less than five.}
+\item{preconditions}{expressions used for mutating the input table before
+proceeding with the validation. This is ideally as a one-sided R formula
+using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+input data table to be transformed (e.g.,
+\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
+used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
+object must be ultimately returned.}
 
 \item{brief}{An optional, text-based description for the validation step.}
 

--- a/man/interrogate.Rd
+++ b/man/interrogate.Rd
@@ -48,6 +48,8 @@ The agent has all the information on what to do, so now all interrogations
 can proceed efficiently, and, according to plan.
 }
 \examples{
+library(dplyr)
+
 # Create 2 simple data frames
 # with 2 columns of numerical
 # values in each
@@ -76,7 +78,8 @@ agent <-
   col_vals_equal(
     column = c,
     value = 8,
-    preconditions = d >= 5) \%>\%
+    preconditions = ~ tbl \%>\% dplyr::filter(d >= 5)
+  ) \%>\%
   interrogate()
   
 # Get a basic summary with

--- a/man/rows_not_duplicated.Rd
+++ b/man/rows_not_duplicated.Rd
@@ -30,15 +30,13 @@ rows_not_duplicated(
 provided, the validation checks for duplicate records using data across all
 columns.}
 
-\item{preconditions}{An optional statement of filtering conditions that may
-reduce the number of rows for validation for the current validation step.
-The statements are executed for every row of the table in focus and are
-often referred as predicate statements (they either return \code{TRUE} or
-\code{FALSE} for every row evaluated, where rows evaluated as \code{TRUE} are the
-rows that are retained for the validation step). For example, if a table
-has columns \code{a}, \code{b}, and \code{c}, and, column \code{a} has numerical data, we can
-write a statement \code{a < 5} that filters all rows in the table where values
-in column a are less than five.}
+\item{preconditions}{expressions used for mutating the input table before
+proceeding with the validation. This is ideally as a one-sided R formula
+using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+input data table to be transformed (e.g.,
+\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
+used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
+object must be ultimately returned.}
 
 \item{brief}{An optional, text-based description for the validation step.}
 

--- a/tests/testthat/test-create_agent.R
+++ b/tests/testthat/test-create_agent.R
@@ -16,7 +16,7 @@ test_that("Creating a valid `agent` object is possible", {
           "focal_col_types", "focal_db_cred_file_path",
           "focal_db_env_vars", "focal_init_sql",
           "email", "slack", "logical_plan",
-          "validation_set", "preconditions")))
+          "validation_set")))
   
   # Expect an agent object of class `dgr_graph`
   expect_is(agent, "ptblank_agent")
@@ -28,9 +28,6 @@ test_that("Creating a valid `agent` object is possible", {
   # Expect that the `validation_set` component is
   # a `tbl_df`
   expect_is(agent$validation_set, "tbl_df")
-  
-  # Expect that the `preconditions` component is a list
-  expect_is(agent$preconditions, "list")
   
   # Expect certain classes for the different
   # `agent` components
@@ -52,6 +49,7 @@ test_that("Creating a valid `agent` object is possible", {
   expect_is(agent$validation_set$value, "numeric")
   expect_is(agent$validation_set$set, "list")
   expect_is(agent$validation_set$regex, "character")
+  expect_is(agent$validation_set$preconditions, "list")
   expect_is(agent$validation_set$n, "integer")
   expect_is(agent$validation_set$n_passed, "integer")
   expect_is(agent$validation_set$n_failed, "integer")

--- a/tests/testthat/test-get_summary.R
+++ b/tests/testthat/test-get_summary.R
@@ -18,8 +18,8 @@ test_that("Getting a validation summary is possible", {
   expect_equivalent(
     colnames(summary),
     c("tbl_name", "db_type", "assertion_type", "column", "value",
-      "set", "regex", "all_passed", "n", "n_passed",
-      "f_passed", "action", "brief"))
+      "set", "regex", "preconditions", "all_passed", "n", "f_passed", "n_passed",
+      "action", "brief"))
   
   # Expect a single row in this summary
   expect_equivalent(nrow(summary), 1)

--- a/tests/testthat/test-interrogate_simple.R
+++ b/tests/testthat/test-interrogate_simple.R
@@ -273,7 +273,7 @@ test_that("Interrogating simply returns the expected results", {
       column = d,
       left = 3000,
       right = 10000,
-      preconditions = date > "2016-01-20",
+      preconditions = ~ tbl %>% dplyr::filter(date > "2016-01-20"),
       warn_count = 1
     )
   
@@ -288,7 +288,7 @@ test_that("Interrogating simply returns the expected results", {
         column = d,
         left = 0,
         right = 3000,
-        preconditions = date > "2016-01-20",
+        preconditions = ~ tbl %>% dplyr::filter(date > "2016-01-20"),
         warn_count = 1
       )
   )
@@ -306,7 +306,7 @@ test_that("Interrogating simply returns the expected results", {
         column = d,
         left = 0,
         right = 3000,
-        preconditions = date > "2016-01-20",
+        preconditions = ~ tbl %>% dplyr::filter(date > "2016-01-20"),
         stop_count = 1
       )
   )
@@ -531,7 +531,7 @@ test_that("Interrogating simply returns the expected results", {
     tbl %>%
     col_vals_null(
       column = c,
-      preconditions = date == "2016-01-06"
+      preconditions = ~ tbl %>% dplyr::filter(date == "2016-01-06")
     )
   
   # Expect that `tbl_result` is equivalent to `tbl`
@@ -543,7 +543,7 @@ test_that("Interrogating simply returns the expected results", {
       tbl %>%
       col_vals_null(
         column = c,
-        preconditions = date != "2016-01-06",
+        preconditions = ~ tbl %>% dplyr::filter(date != "2016-01-06"),
         warn_count = 1
       )
   )
@@ -559,7 +559,7 @@ test_that("Interrogating simply returns the expected results", {
       tbl %>%
       col_vals_null(
         column = c,
-        preconditions = date != "2016-01-06",
+        preconditions = ~ tbl %>% dplyr::filter(date != "2016-01-06"),
         stop_count = 1
       )
   )

--- a/tests/testthat/test-interrogate_with_agent.R
+++ b/tests/testthat/test-interrogate_with_agent.R
@@ -270,7 +270,8 @@ test_that("Interrogating for valid row values", {
       column = d,
       left = 0,
       right = 5000,
-      preconditions = date > "2016-01-04") %>%
+      preconditions = ~ tbl %>% dplyr::filter(date > "2016-01-04")
+    )%>%
     interrogate()
   
   # Expect certain values in `validation$validation_set`
@@ -339,7 +340,8 @@ test_that("Interrogating for valid row values", {
       column = d,
       left = 500,
       right = 1000,
-      preconditions = date > "2016-01-04") %>%
+      preconditions = ~ tbl %>% dplyr::filter(date > "2016-01-04")
+    ) %>%
     interrogate()
   
   # Expect certain values in `validation$validation_set`
@@ -406,7 +408,8 @@ test_that("Interrogating for valid row values", {
     col_vals_equal(
       column = d,
       value = 283.94,
-      preconditions = date > "2016-01-04") %>%
+      preconditions = ~ tbl %>% dplyr::filter(date > "2016-01-04")
+    ) %>%
     interrogate()
   
   # Expect certain values in `validation$validation_set`
@@ -472,7 +475,8 @@ test_that("Interrogating for valid row values", {
     col_vals_not_equal(
       column = d,
       value = 283.94,
-      preconditions = date > "2016-01-04") %>%
+      preconditions = ~ tbl %>% dplyr::filter(date > "2016-01-04")
+    ) %>%
     interrogate()
   
   # Expect certain values in `validation$validation_set`
@@ -534,7 +538,8 @@ test_that("Interrogating for valid row values", {
                               package = "pointblank"),
       col_types = "TDicidlc") %>%
     rows_not_duplicated(
-      preconditions = date != "2016-01-20") %>%
+      preconditions = ~ tbl %>% dplyr::filter(date != "2016-01-20")
+    ) %>%
     interrogate()
   
   # Expect certain values in `validation$validation_set`
@@ -736,7 +741,9 @@ test_that("Interrogating for valid row values", {
       col_types = "TDicidlc") %>%
     col_vals_not_null(
       column = c,
-      preconditions = date > "2016-01-06" & date < "2016-01-30") %>%
+      preconditions = ~ tbl %>%
+        dplyr::filter(date > "2016-01-06" & date < "2016-01-30")
+    ) %>%
     interrogate()
   
   # Expect certain values in `validation$validation_set`
@@ -799,7 +806,9 @@ test_that("Interrogating for valid row values", {
       col_types = "TDicidlc") %>%
     col_vals_null(
       column = c,
-      preconditions = date == '2016-01-06' | date == '2016-01-30') %>%
+      preconditions = ~ tbl %>%
+        dplyr::filter(date == '2016-01-06' | date == '2016-01-30')
+    ) %>%
     interrogate()
   
   # Expect certain values in `validation$validation_set`
@@ -865,7 +874,8 @@ test_that("Interrogating for valid row values", {
     col_vals_regex(
       column = f,
       regex = "[a-z]{3}",
-      preconditions = f != "high") %>%
+      preconditions = ~ tbl %>% dplyr::filter(f != "high")
+    ) %>%
     interrogate()
   
   # Expect certain values in `validation$validation_set`


### PR DESCRIPTION
The big change here is that `preconditions` can be used to temporarily transform the table (i.e., transforming for a particular validation step). This is useful for joining in a table, filtering rows, etc. 

Fixes https://github.com/rich-iannone/pointblank/issues/27.