### PR TITLE
Add a way to specify default `action levels`

### DIFF
--- a/R/create_agent.R
+++ b/R/create_agent.R
@@ -19,6 +19,11 @@
 #' @param name An optional name for the validation plan that the agent will
 #'   eventually carry out during the interrogation process. If no value is
 #'   provided, a name will be generated based on the current system time.
+#' @param actions A list containing threshold levels so that all validation
+#'   steps can react accordingly when exceeding the set levels. This is to be
+#'   created with the [action_levels()] helper function. Should an action levels
+#'   list be used for specific validation step, any default set here will be
+#'   overridden.
 #'   
 #' @return A `ptblank_agent` object.
 #'   
@@ -57,7 +62,8 @@
 #' @export
 
 create_agent <- function(tbl,
-                         name = NULL) {
+                         name = NULL,
+                         actions = NULL) {
 
   # Generate an agent name if none provided
   if (is.null(name)) {
@@ -109,6 +115,7 @@ create_agent <- function(tbl,
       tbl_src_details = tbl_src_details,
       col_names = column_names,
       col_types = column_types,
+      actions = list(actions),
       validation_set =
         dplyr::tibble(
           i = integer(0),

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -79,6 +79,12 @@ interrogate <- function(agent,
     
     # Get the table object for interrogation 
     table <- get_tbl_object(agent)
+
+    # Use the default `action_levels` list if it exists and
+    # only if it isn't set for this validation step
+    if (!is.null(agent$actions) & is.null(agent$validation_set[i, ]["actions"])) {
+      agent$validation_set[[i, "actions"]] <- agent$actions %>% unlist(recursive = FALSE)
+    }
     
     # Use preconditions to modify the table
     table <- apply_preconditions_to_tbl(agent, idx = i, tbl = table)

--- a/man/create_agent.Rd
+++ b/man/create_agent.Rd
@@ -4,7 +4,7 @@
 \alias{create_agent}
 \title{Create a pointblank agent object}
 \usage{
-create_agent(tbl, name = NULL)
+create_agent(tbl, name = NULL, actions = NULL)
 }
 \arguments{
 \item{tbl}{The input table. This can be a data frame, a tibble, or a
@@ -13,6 +13,12 @@ create_agent(tbl, name = NULL)
 \item{name}{An optional name for the validation plan that the agent will
 eventually carry out during the interrogation process. If no value is
 provided, a name will be generated based on the current system time.}
+
+\item{actions}{A list containing threshold levels so that all validation
+steps can react accordingly when exceeding the set levels. This is to be
+created with the \code{\link[=action_levels]{action_levels()}} helper function. Should an action levels
+list be used for specific validation step, any default set here will be
+overridden.}
 }
 \value{
 A \code{ptblank_agent} object.

--- a/tests/testthat/test-create_agent.R
+++ b/tests/testthat/test-create_agent.R
@@ -17,7 +17,7 @@ test_that("Creating a valid `agent` object is possible", {
     all(
       names(agent) ==
         c("name", "time", "tbl", "tbl_name", "tbl_src", "tbl_src_details",
-          "col_names", "col_types", "validation_set", "extracts")
+          "col_names", "col_types", "actions", "validation_set", "extracts")
     )
   )
   
@@ -36,6 +36,7 @@ test_that("Creating a valid `agent` object is possible", {
   expect_is(agent$tbl_src_details, "character")
   expect_is(agent$col_names, "character")
   expect_is(agent$col_types, "character")
+  expect_is(agent$actions, "list")
   expect_is(agent$validation_set$i, "integer")
   expect_is(agent$validation_set$assertion_type, "character")
   expect_is(agent$validation_set$column, "list")


### PR DESCRIPTION
This adds the `actions` arg to `create_agent()` (and it knows how to use it).