### PR TITLE
Improvements to automatically creating explanations for validation steps

### DIFF
--- a/R/conjointly.R
+++ b/R/conjointly.R
@@ -127,6 +127,17 @@ conjointly <- function(x,
   
   agent <- x
   
+  if (is.null(brief)) {
+    
+    brief <-
+      create_autobrief(
+        agent = agent,
+        assertion_type = "conjointly",
+        preconditions = preconditions,
+        values = validation_formulas
+      )
+  }
+  
   agent <-
     create_validation_step(
       agent = agent,

--- a/R/steps_and_briefs.R
+++ b/R/steps_and_briefs.R
@@ -66,147 +66,105 @@ create_autobrief <- function(agent,
                              column = NULL,
                              values = NULL) {
   
+  precondition_text <- prep_precondition_text(preconditions)
+  column_computed_text <- prep_column_computed_text(agent, column)
+  column_text <- prep_column_text(column)
+  values_text <- prep_values_text(values)
+  
   if (assertion_type %in%
       c("col_vals_gt", "col_vals_gte",
         "col_vals_lt", "col_vals_lte",
         "col_vals_equal", "col_vals_not_equal")) {
     
-    is_column_computed <- ifelse(column %in% agent$col_names, FALSE, TRUE)
-    
-    if (assertion_type == "col_vals_gt") {
-      operator <- ">"
-    } else if (assertion_type == "col_vals_gte") {
-      operator <- ">="
-    } else if (assertion_type == "col_vals_lt") {
-      operator <- "<"
-    } else if (assertion_type == "col_vals_lte") {
-      operator <- "<="
-    } else if (assertion_type == "col_vals_equal") {
-      operator <- "=="
-    } else if (assertion_type == "col_vals_not_equal") {
-      operator <- "!="
-    } 
-    
-    autobrief <-
-      paste0(
-        "Expect that ",
-        ifelse(
-          !is.null(preconditions),
-          paste0(
-            "when the precondition ", "`",
-            preconditions %>% rlang::f_rhs() %>% rlang::as_label(),
-            "` is applied, "),
-          paste0("")),
-        "values in `",
-        column, "`",
-        ifelse(is_column_computed, " (computed column) ", " "),
-        "should be ", operator, " ", values
+    operator <- 
+      switch(
+        assertion_type,
+        "col_vals_gt" = ">",
+        "col_vals_gte" = ">=",
+        "col_vals_lt" = "<",
+        "col_vals_lte" = "<=",
+        "col_vals_equal" = "==",
+        "col_vals_not_equal" = "!="
       )
+    
+    expectation_str <- 
+      prep_compare_expectation_str(
+        column_text,
+        column_computed_text,
+        operator,
+        values_text
+      )
+    
+    autobrief <- finalize_autobrief(expectation_str, precondition_text)
   }
   
-  
   if (assertion_type == "col_exists") {
-    autobrief <- paste0("Expect that column `", column, "` exists")
+    
+    autobrief <- 
+      prep_col_exists_expectation_str(column_text) %>%
+      as.character() %>%
+      tidy_gsub("\\s{2,}", " ")
   }
   
   if (assertion_type %in% c("col_vals_in_set", "col_vals_not_in_set")) {
     
-    is_column_computed <- ifelse(column %in% agent$col_names, FALSE, TRUE)
-    
-    autobrief <-
-      paste0(
-        "Expect that ",
-        ifelse(
-          !is.null(preconditions),
-          paste0(
-            "when the precondition ", "`",
-            preconditions %>% rlang::f_rhs() %>% rlang::as_label(),
-            "` is applied, "),
-          paste0("")),
-        "values in `",
-        column, "`",
-        ifelse(is_column_computed, " (computed column) ", " "),
-        "should ",
-        ifelse(assertion_type == "col_vals_not_in_set", "not ", ""),
-        "be part of set `", paste(values, collapse = ", "), "`"
+    expectation_str <- 
+      prep_in_set_expectation_str(
+        column_text,
+        column_computed_text,
+        values_text,
+        not = grepl("not", assertion_type)
       )
-  }
-  
-  if (assertion_type %in% c("col_vals_between", "col_vals_not_between")) {
     
-    is_column_computed <- ifelse(column %in% agent$col_names, FALSE, TRUE)
-    
-    autobrief <-
-      paste0(
-        "Expect that ",
-        ifelse(
-          !is.null(preconditions),
-          paste0(
-            "when the precondition ", "`",
-            preconditions %>% rlang::f_rhs() %>% rlang::as_label(),
-            "` is applied, "),
-          paste0("")),
-        "values in `",
-        column, "`",
-        ifelse(is_column_computed, " (computed column) ", " "),
-        "should ",
-        ifelse(assertion_type == "col_vals_not_between", "not ", ""),
-        "be between `", values[1], "` and `", values[2], "`"
-      )
-  }
-  
-  if (assertion_type == "col_vals_regex") {
-    
-    is_column_computed <- ifelse(column %in% agent$col_names, FALSE, TRUE)
-    
-    autobrief <-
-      paste0(
-        "Expect that ",
-        ifelse(
-          !is.null(preconditions),
-          paste0(
-            "when the precondition ", "`",
-            preconditions %>% rlang::f_rhs() %>% rlang::as_label(),
-            "` is applied, "),
-          paste0("")),
-        "values in `",
-        column, "`",
-        ifelse(is_column_computed, " (computed column) ", " "),
-        "should match the regex expression `",
-        values, "`"
-      )
+    autobrief <- finalize_autobrief(expectation_str, precondition_text)
   }
   
   if (assertion_type %in% c("col_vals_null", "col_vals_not_null")) {
     
-    is_column_computed <- ifelse(column %in% agent$col_names, FALSE, TRUE)
-    
-    autobrief <-
-      paste0(
-        "Expect that ",
-        ifelse(
-          !is.null(preconditions),
-          paste0(
-            "when the precondition ", "`",
-            preconditions %>% rlang::f_rhs() %>% rlang::as_label(),
-            "` is applied, "),
-          paste0("")),
-        "values in `",
-        column, "`",
-        ifelse(is_column_computed, " (computed column) ", " "),
-        "should ",
-        ifelse(assertion_type == "col_vals_not_null", "not ", ""),
-        "be NULL"
+    expectation_str <- 
+      prep_null_expectation_str(
+        column_text,
+        column_computed_text,
+        not = grepl("not", assertion_type)
       )
+    
+    autobrief <- finalize_autobrief(expectation_str, precondition_text)
+  }
+  
+  if (assertion_type %in% c("col_vals_between", "col_vals_not_between")) {
+    
+    value_1 <- strsplit(values_text, ", ") %>% unlist() %>% .[1]
+    value_2 <- strsplit(values_text, ", ") %>% unlist() %>% .[2]
+    
+    expectation_str <- 
+      prep_between_expectation_str(
+        column_text,
+        column_computed_text,
+        value_1,
+        value_2,
+        not = grepl("not", assertion_type)
+      )
+    
+    autobrief <- finalize_autobrief(expectation_str, precondition_text)
+  }
+  
+  if (assertion_type == "col_vals_regex") {
+    
+    expectation_str <- 
+      prep_regex_expectation_str(
+        column_text,
+        column_computed_text,
+        values_text
+      )
+    
+    autobrief <- finalize_autobrief(expectation_str, precondition_text)
   }
   
   if (grepl("col_is_.*", assertion_type)) {
     
     if (assertion_type %in% 
-        c("col_is_numeric", "col_is_integer",
-          "col_is_character", "col_is_logical",
-          "col_is_factor")) {
-      
+        c("col_is_numeric", "col_is_integer", "col_is_character",
+          "col_is_logical", "col_is_factor")) {
       col_type <- gsub("col_is_", "", assertion_type)
     } else if (assertion_type == "col_is_posix") {
       col_type <- "POSIXct"
@@ -214,26 +172,157 @@ create_autobrief <- function(agent,
       col_type <- "Date"
     }
     
-    autobrief <- 
-      paste0("Expect that column `", column, "` is `", col_type, "`-based")
+    expectation_str <- prep_col_is_expectation_str(column_text, col_type)
+    autobrief <- finalize_autobrief(expectation_str, precondition_text)
   }
   
   if (assertion_type == "rows_distinct") {
-    
-    autobrief <-
-      paste0(
-        "Expect that ",
-        ifelse(
-          !is.null(preconditions),
-          paste0(
-            "when the precondition ", "`",
-            preconditions %>% rlang::f_rhs() %>% rlang::as_label(),
-            "` is applied, "),
-          paste0("")
-        ),
-        "rows from `", column, "` ", "have no duplicates"
-      )
+
+    expectation_str <- prep_row_distinct_expectation_str(column_text)
+    autobrief <- finalize_autobrief(expectation_str, precondition_text)
+  }
+  
+  if (assertion_type == "conjointly") {
+
+    values_text <- values_text %>% tidy_gsub("\"", "'")
+    expectation_str <- prep_conjointly_expectation_str(values_text)
+    autobrief <- finalize_autobrief(expectation_str, precondition_text)
   }
   
   autobrief
+}
+
+prep_precondition_text <- function(preconditions) {
+  
+  if (is.null(preconditions)) return("")
+  
+  precondition_label <- preconditions %>% rlang::f_rhs() %>% rlang::as_label()
+  
+  paste0("Precondition applied", ": `", precondition_label, "`.")
+}
+
+prep_column_computed_text <- function(agent, column) {
+  
+  if (is.null(column)) return("")
+  
+  column_is_computed <- ifelse(column %in% agent$col_names, FALSE, TRUE)
+  
+  if (!column_is_computed) return("")
+  
+  parens <- c("(", ")")
+  
+  paste0(parens[1], "computed column", parens[2])
+}
+
+prep_column_text <- function(column) {
+  paste0("`", column, "`")
+}
+
+prep_values_text <- function(values, limit = 3) {
+  
+  # Normalize the `columns` expression enclosed in `vars()`
+  if (inherits(values, "quosures")) {
+    
+    values <- 
+      vapply(
+        values,
+        FUN.VALUE = character(1),
+        USE.NAMES = FALSE,
+        FUN = function(x) as.character(rlang::get_expr(x))
+      )
+  }
+  
+  if (!is.null(limit) && length(values) > limit) {
+    num_omitted <- length(values) - limit
+    values_text <- paste0("`", values[seq_len(limit)], "`", collapse = ", ")
+    additional_text <- glue::glue("(", "and {num_omitted} more", ")")
+    values_text <- paste0(values_text, " ", additional_text)
+  } else {
+    values_text <- paste0("`", values, "`", collapse = ", ")
+  }
+
+  values_text
+}
+
+finalize_autobrief <- function(expectation_str, precondition_text) {
+  
+  glue::glue("{expectation_str} {precondition_text}") %>%
+    as.character() %>%
+    tidy_gsub("\\s{2,}", " ")
+}
+
+prep_compare_expectation_str <- function(column_text,
+                                         column_computed_text,
+                                         operator,
+                                         values_text) {
+  
+  glue::glue(
+    "Expect that values in {column_text} {column_computed_text} should be {operator} {values_text}."
+  )
+}
+
+prep_in_set_expectation_str <- function(column_text,
+                                        column_computed_text,
+                                        values_text,
+                                        not = FALSE) {
+  
+  if (!not) {
+    glue::glue("Expect that values in {column_text} {column_computed_text} should be in the set of {values_text}.")
+  } else {
+    glue::glue("Expect that values in {column_text} {column_computed_text} should not be in the set of {values_text}.")
+  }
+}
+
+prep_between_expectation_str <- function(column_text,
+                                         column_computed_text,
+                                         value_1,
+                                         value_2,
+                                         not = FALSE) {
+  
+  if (!not) {
+    glue::glue("Expect that values in {column_text} {column_computed_text} should be between {value_1} and {value_2}.")
+  } else {
+    glue::glue("Expect that values in {column_text} {column_computed_text} should not be between {value_1} and {value_2}.")
+  }
+}
+
+prep_null_expectation_str <- function(column_text,
+                                      column_computed_text,
+                                      not = FALSE) {
+  
+  if (!not) {
+    glue::glue("Expect that all values in {column_text} {column_computed_text} should be NULL.")
+  } else {
+    glue::glue("Expect that all values in {column_text} {column_computed_text} should not be NULL.")
+  }
+}
+
+prep_regex_expectation_str <- function(column_text,
+                                       column_computed_text,
+                                       values_text) {
+  
+  glue::glue(
+    "Expect that values in {column_text} {column_computed_text} should match the regular expression: {values_text}."
+  )
+}
+
+prep_col_exists_expectation_str <- function(column_text) {
+  glue::glue("Expect that column {column_text} exists.")
+}
+
+prep_col_is_expectation_str <- function(column_text, col_type) {
+  glue::glue("Expect that column {column_text} is of type: {col_type}.")
+}
+
+prep_row_distinct_expectation_str <- function(column_text) {
+
+  if (column_text == "``") {
+    glue::glue("Expect entirely distinct rows across all columns.")
+  } else {
+    glue::glue("Expect entirely distinct rows across {column_text}.")
+  }
+}
+
+prep_conjointly_expectation_str <- function(values_text) {
+  glue::glue("Expect conjoint 'pass' units across the following expressions: {values_text}.")
 }

--- a/tests/manual_tests/tests_preconditions.R
+++ b/tests/manual_tests/tests_preconditions.R
@@ -1,0 +1,43 @@
+library(pointblank)
+library(tidyverse)
+
+al <- action_levels(warn_at = 0.1, stop_at = 0.2)
+
+agent <-
+  create_agent(tbl = small_table, actions = al) %>%
+  col_vals_gt(vars(g), 100, preconditions = ~tbl %>% dplyr::mutate(g = a + 95)) %>%
+  col_vals_lt(vars(c), vars(d), preconditions = ~tbl %>% dplyr::mutate(d = d - 200)) %>%
+  col_vals_in_set(vars(f), c("low", "mid", "high", "higher")) %>%
+  col_vals_not_in_set(vars(f), LETTERS[1:8]) %>%
+  col_vals_between(vars(c), 0, 10) %>%
+  col_vals_not_between(vars(c), 100, 500) %>%
+  col_vals_regex(vars(b), ".-...-...") %>%
+  col_vals_not_null(vars(a)) %>%
+  col_is_date(vars(date)) %>%
+  rows_distinct(columns = vars(a, b, c, d, e, f)) %>%
+  rows_distinct() %>%
+  conjointly(
+    ~ col_vals_in_set(., vars(f), c("low", "mid", "high", "higher")),
+    ~ col_vals_not_in_set(., vars(f), LETTERS[1:8]),
+    ~ col_vals_between(., vars(c), 0, 10)
+  )
+
+agent <- agent %>% interrogate()
+agent
+
+report_all <- get_agent_report(agent)
+report_all
+
+report_severe <- get_agent_report(agent, arrange_by = "severity")
+report_severe
+
+report_severe_trunc <- get_agent_report(agent, arrange_by = "severity", keep = "fail_states")
+report_severe_trunc
+
+extracts <- agent %>% get_data_extracts()
+extracts
+
+x_list <- get_agent_x_list(agent)
+x_list
+
+email_blast_preview(agent)


### PR DESCRIPTION
This PR refactors code around the `create_autobrief()` utility function. This also improves the messages and adds one for the `conjointly()` validation step function.

Fixes: https://github.com/rich-iannone/pointblank/issues/68
Fixes: https://github.com/rich-iannone/pointblank/issues/70
