### PR TITLE
Add multilanguage support for reporting/briefs

### DIFF
--- a/R/create_agent.R
+++ b/R/create_agent.R
@@ -30,6 +30,10 @@
 #'   the `ptblank_agent` object. If `FALSE` (the default) then the table object
 #'   will be not generated and available with the agent upon returning from the
 #'   interrogation.
+#' @param reporting_lang The language to use for automatic creation of briefs
+#'   (short descriptions for each validation step). By default, `NULL` will
+#'   create English (`"en"`) text. Other options include French (`"fr"`),
+#'   German (`"de"`), Italian (`"it"`), and Spanish (`"es"`).
 #'   
 #' @return A `ptblank_agent` object.
 #'   
@@ -65,7 +69,8 @@ create_agent <- function(tbl,
                          name = NULL,
                          actions = NULL,
                          end_fns = NULL,
-                         embed_report = FALSE) {
+                         embed_report = FALSE,
+                         reporting_lang = NULL) {
 
   # Generate an agent name if none provided
   if (is.null(name)) {
@@ -74,6 +79,9 @@ create_agent <- function(tbl,
   } else {
     brief <- "Create agent with an assigned validation name"
   }
+  
+  # Normalize the reporting language identifer and stop if necessary
+  reporting_lang <- normalize_reporting_language(reporting_lang)
 
   tbl_name <- deparse(match.call()$tbl)
   
@@ -117,6 +125,7 @@ create_agent <- function(tbl,
       end_fns = list(end_fns),
       embed_report = embed_report,
       reporting = NULL,
+      reporting_lang = reporting_lang,
       validation_set =
         dplyr::tibble(
           i = integer(0),

--- a/R/get_agent_report.R
+++ b/R/get_agent_report.R
@@ -82,6 +82,8 @@ get_agent_report <- function(agent,
   agent_name <- agent$name
   agent_time <- agent$time
   
+  lang <- agent$reporting_lang
+  
   eval <- 
     validation_set %>%
     dplyr::select(eval_error, eval_warning) %>%
@@ -441,9 +443,9 @@ get_agent_report <- function(agent,
       ) %>%
       gt::cols_label(
         i = "",
-        type = "STEP FN",
-        columns = "COLUMNS",
-        values = "VALUES",
+        type = report_col_step[lang],
+        columns = report_col_columns[lang],
+        values = report_col_values[lang],
         precon = "TBL",
         eval_sym = "EVAL",
         units = "UNITS",
@@ -452,7 +454,7 @@ get_agent_report <- function(agent,
         extract = "EXTRACT"
       ) %>%
       gt::tab_header(
-        title = "Pointblank Validation",
+        title = pointblank_validation_title_text[lang],
         subtitle = gt::md(paste0("`", agent_name, " (", agent_time, ")`<br><br>"))
       ) %>%
       gt::tab_options(
@@ -594,11 +596,11 @@ get_agent_report <- function(agent,
           title = gt::md(
             paste0(
               "<div>",
-              "<span style=\"float: left;\">Pointblank Validation Plan</span>",
+              "<span style=\"float: left;\">", pointblank_validation_plan_text[lang], "</span>",
               "<span style=\"float: right; text-decoration-line: underline; ",
               "font-size: 16px; text-decoration-color: #008B8B;",
               "padding-top: 0.1em; padding-right: 0.4em;\">",
-              "No Interrogation Performed</span>",
+              no_interrogation_performed_text[lang], "</span>",
               "</div>"
             )
           ),

--- a/R/utils_text.R
+++ b/R/utils_text.R
@@ -1,0 +1,216 @@
+# Text for autobriefs
+
+precondition_text <- 
+  c(
+    "en" = "Precondition applied",
+    "fr" = "Condition pr\u00E9alable",
+    "de" = "Voraussetzung angewendet",
+    "it" = "Prerequisito applicato",
+    "es" = "Condici\u00F3n previa aplicada"
+  )
+
+column_computed_text <-
+  c(
+    "en" = "computed column",
+    "fr" = "colonne calcul\u00E9e",
+    "de" = "berechnete Spalte",
+    "it" = "colonna calcolata",
+    "es" = "columna calculada"
+  )
+
+values_text <- 
+  c(
+    "en" = "and {num_omitted} more",
+    "fr" = "et {num_omitted} de plus",
+    "de" = "und {num_omitted} mehr",
+    "it" = "e altri {num_omitted}",
+    "es" = "y {num_omitted} m\u00E1s"
+  )
+
+compare_expectation_text <- 
+  c(
+    "en" = "Expect that values in {column_text} {column_computed_text} should be {operator} {values_text}.",
+    "fr" = "Attendez-vous \u00E0 ce que les valeurs de {column_text} {column_computed_text} soient {operator} {values_text}.",
+    "de" = "Erwarten Sie, dass die Werte in {column_text} {column_computed_text} {operator} {values_text} sein sollten.",
+    "it" = "Aspettatevi che i valori in {column_text} {column_computed_text} dovrebbero essere {operator} {values_text}.",
+    "es" = "Espere que los valores en {column_text} {column_computed_text} sean {operator} {values_text}."
+  )
+
+in_set_expectation_text <-
+  c(
+    "en" = "Expect that values in {column_text} {column_computed_text} should be in the set of {values_text}.",
+    "fr" = "Attendez-vous \u00E0 ce que les valeurs de {column_text} {column_computed_text} soient dans l'ensemble de {values_text}.",
+    "de" = "Erwarten Sie, dass die Werte in {column_text} {column_computed_text} in der Menge von {values_text} enthalten sein sollten.",
+    "it" = "Aspettatevi che i valori in {column_text} {column_computed_text} siano nell'insieme di {values_text}.",
+    "es" = "Espere que los valores en {column_text} {column_computed_text} est\u00E9n en el conjunto de {values_text}."
+  )
+
+not_in_set_expectation_text <-
+  c(
+    "en" = "Expect that values in {column_text} {column_computed_text} should not be in the set of {values_text}.",
+    "fr" = "Attendez-vous \u00E0 ce que les valeurs de {column_text} {column_computed_text} ne soient pas dans l'ensemble de {values_text}.",
+    "de" = "Erwarten Sie, dass die Werte in {column_text} {column_computed_text} nicht in der Menge von {values_text} enthalten sein sollten.",
+    "it" = "Aspettatevi che i valori in {column_text} {column_computed_text} non debbano essere nel set di {values_text}.",
+    "es" = "Espere que los valores en {column_text} {column_computed_text} no est\u00E9n en el conjunto de {values_text}."
+  )
+
+between_expectation_text <- 
+  c(
+    "en" = "Expect that values in {column_text} {column_computed_text} should be between {value_1} and {value_2}.",
+    "fr" = "Attendez-vous \u00E0 ce que les valeurs de {column_text} {column_computed_text} soient comprises entre {value_1} et {value_2}.",
+    "de" = "Erwarten Sie, dass die Werte in {column_text} {column_computed_text} zwischen {value_1} und {value_2} liegen sollten.",
+    "it" = "Aspettati che i valori in {column_text} {column_computed_text} siano compresi tra {value_1} e {value_2}.",
+    "es" = "Espere que los valores en {column_text} {column_computed_text} est\u00E9n entre {value_1} y {value_2}."
+  )
+
+not_between_expectation_text <- 
+  c(
+    "en" = "Expect that values in {column_text} {column_computed_text} should not be between {value_1} and {value_2}.",
+    "fr" = "Attendez-vous \u00E0 ce que les valeurs de {column_text} {column_computed_text} ne soient pas comprises entre {value_1} et {value_2}.",
+    "de" = "Erwarten Sie, dass die Werte in {column_text} {column_computed_text} nicht zwischen {value_1} und {value_2} liegen sollten.",
+    "it" = "Aspettatevi che i valori in {column_text} {column_computed_text} non debbano essere compresi tra {value_1} e {value_2}.",
+    "es" = "Espere que los valores en {column_text} {column_computed_text} no est\u00E9n entre {value_1} y {value_2}."
+  )
+
+null_expectation_text <- 
+  c(
+    "en" = "Expect that all values in {column_text} {column_computed_text} should be NULL.",
+    "fr" = "Attendez-vous \u00E0 ce que toutes les valeurs de {column_text} {column_computed_text} soient NULL.",
+    "de" = "Erwarten Sie, dass alle Werte in {column_text} {column_computed_text} NULL sein sollten.",
+    "it" = "Aspettatevi che tutti i valori in {column_text} {column_computed_text} siano NULL.",
+    "es" = "Espere que todos los valores en {column_text} {column_computed_text} sean NULL."
+  )
+
+not_null_expectation_text <- 
+  c(
+    "en" = "Expect that all values in {column_text} {column_computed_text} should not be NULL.",
+    "fr" = "Attendez-vous \u00E0 ce que toutes les valeurs de {column_text} {column_computed_text} ne soient pas NULL.",
+    "de" = "Erwarten Sie, dass alle Werte in {column_text} {column_computed_text} nicht NULL sein sollten.",
+    "it" = "Aspettatevi che tutti i valori in {column_text} {column_computed_text} non debbano essere NULL.",
+    "es" = "Espere que todos los valores en {column_text} {column_computed_text} no sean NULL."
+  )
+
+regex_expectation_text <- 
+  c(
+    "en" = "Expect that values in {column_text} {column_computed_text} should match the regular expression: {values_text}.",
+    "fr" = "Attendez-vous \u00E0 ce que les valeurs de {column_text} {column_computed_text} correspondent \u00E0 l'expression r\u00E9guli\u00E8re: {values_text}.",
+    "de" = "Erwarten Sie, dass die Werte in {column_text} {column_computed_text} mit dem regul\u00E4ren Ausdruck {values_text} \u00FCbereinstimmen.",
+    "it" = "Aspettati che i valori in {column_text} {column_computed_text} debbano corrispondere all'espressione regolare: {values_text}.",
+    "es" = "Espere que los valores en {column_text} {column_computed_text} coincidan con la expresi\u00F3n regular: {values_text}."
+  )
+
+conjointly_expectation_text <-
+  c(
+    "en" = "Expect conjoint 'pass' units across the following expressions: {values_text}.",
+    "fr" = "Attendez-vous \u00E0 des unit\u00E9s de \u00ABpass\u00BB conjointes dans les expressions suivantes: {values_text}.",
+    "de" = "Erwarten Sie gemeinsame 'Pass'-Einheiten f\u00FCr die folgenden Ausdr\u00FCcke: {values_text}.",
+    "it" = "Aspettatevi unit\u00E1 'pass' congiunte tra le seguenti espressioni: {values_text}.",
+    "es" = "Espere unidades conjuntas de 'pass' en las siguientes expresiones: {values_text}."
+  )
+
+col_exists_expectation_text <-
+  c(
+    "en" = "Expect that column {column_text} exists.",
+    "fr" = "Attendez-vous \u00E0 ce que la colonne {column_text} existe.",
+    "de" = "Erwarten Sie, dass die Spalte {column_text} vorhanden ist.",
+    "it" = "Aspettati che la colonna {column_text} esista.",
+    "es" = "Espere que exista la columna {column_text}."
+  )
+
+col_is_expectation_text <-
+  c(
+    "en" = "Expect that column {column_text} is of type: {col_type}.",
+    "fr" = "Attendez-vous \u00E0 ce que la colonne {column_text} soit de type: {col_type}.",
+    "de" = "Erwarten Sie, dass die Spalte {column_text} vom Typ {col_type} ist.",
+    "it" = "Aspettati che la colonna {column_text} sia di tipo: {col_type}.",
+    "es" = "Espere que la columna {column_text} sea del tipo: {col_type}."
+  )
+
+all_row_distinct_expectation_text <-
+  c(
+    "en" = "Expect entirely distinct rows across all columns.",
+    "fr" = "Attendez-vous \u00E0 des lignes enti\u00E8rement distinctes dans toutes les colonnes.",
+    "de" = "Erwarten Sie in allen Spalten v\u00F6llig unterschiedliche Zeilen.",
+    "it" = "Aspettati righe completamente distinte su tutte le colonne.",
+    "es" = "Espere filas completamente distintas en todas las columnas."
+  )
+
+across_row_distinct_expectation_text <-
+  c(
+    "en" = "Expect entirely distinct rows across {column_text}.",
+    "fr" = "Attendez-vous \u00E0 des lignes enti\u00E8rement distinctes sur {column_text}.",
+    "de" = "Erwarten Sie v\u00F6llig unterschiedliche Zeilen in {column_text}.",
+    "it" = "Aspettati righe completamente distinte su {column_text}.",
+    "es" = "Espere filas completamente distintas en {column_text}."
+  )
+
+
+# Text for agent report
+
+pointblank_validation_title_text <-
+  c(
+    "en" = "Pointblank Validation",
+    "fr" = "Validation Pointblank",
+    "de" = "Pointblank-Validierung",
+    "it" = "Convalida Pointblank",
+    "es" = "Validaci\u00F3n de Pointblank"
+  )
+
+pointblank_validation_plan_text <- 
+  c(
+    "en" = "Pointblank Validation Plan",
+    "fr" = "Plan de validation de Pointblank",
+    "de" = "Pointblank-Validierungsplan",
+    "it" = "Piano di convalida Pointblank",
+    "es" = "Plan de validaci\u00F3n de Pointblank"
+  )
+
+no_interrogation_performed_text <- 
+  c(
+    "en" = "No Interrogation Performed",
+    "fr" = "Aucune interrogation effectu\u00E9e",
+    "de" = "Keine Abfrage durchgef\u00FChrt",
+    "it" = "Nessuna interrogazione eseguita",
+    "es" = "No se realizan interrogatorios"
+  )
+
+report_col_step <-
+  c(
+    "en" = "STEP",
+    "fr" = "\u00C9TAPE",
+    "de" = "SCHRITT",
+    "it" = "PASSAGGIO",
+    "es" = "PASO"
+  )
+
+report_col_columns <-
+  c(
+    "en" = "COLUMNS",
+    "fr" = "COLONNES",
+    "de" = "SPALTEN",
+    "it" = "COLONNE",
+    "es" = "COLUMNAS"
+  )
+
+report_col_values <-
+  c(
+    "en" = "VALUES",
+    "fr" = "VALEURS",
+    "de" = "WERTE",
+    "it" = "VALORI",
+    "es" = "VALORES"
+  )
+
+reporting_languages <- c("en", "fr", "de", "it", "es")
+
+normalize_reporting_language <- function(reporting_lang) {
+  
+  if (is.null(reporting_lang)) return("en")
+  
+  if (!(tolower(reporting_lang) %in%  reporting_languages)) {
+    stop("The text ", reporting_lang, " doesn't correspond to a pointblank reporting language",
+         call. = FALSE)
+  }
+  
+  tolower(reporting_lang)
+}

--- a/man/create_agent.Rd
+++ b/man/create_agent.Rd
@@ -9,7 +9,8 @@ create_agent(
   name = NULL,
   actions = NULL,
   end_fns = NULL,
-  embed_report = FALSE
+  embed_report = FALSE,
+  reporting_lang = NULL
 )
 }
 \arguments{
@@ -33,6 +34,11 @@ interrogation.}
 the \code{ptblank_agent} object. If \code{FALSE} (the default) then the table object
 will be not generated and available with the agent upon returning from the
 interrogation.}
+
+\item{reporting_lang}{The language to use for automatic creation of briefs
+(short descriptions for each validation step). By default, \code{NULL} will
+create English (\code{"en"}) text. Other options include French (\code{"fr"}),
+German (\code{"de"}), Italian (\code{"it"}), and Spanish (\code{"es"}).}
 }
 \value{
 A \code{ptblank_agent} object.

--- a/tests/manual_tests/tests_preconditions.R
+++ b/tests/manual_tests/tests_preconditions.R
@@ -4,7 +4,7 @@ library(tidyverse)
 al <- action_levels(warn_at = 0.1, stop_at = 0.2)
 
 agent <-
-  create_agent(tbl = small_table, actions = al) %>%
+  create_agent(tbl = small_table, actions = al, reporting_lang = "it") %>%
   col_vals_gt(vars(g), 100, preconditions = ~tbl %>% dplyr::mutate(g = a + 95)) %>%
   col_vals_lt(vars(c), vars(d), preconditions = ~tbl %>% dplyr::mutate(d = d - 200)) %>%
   col_vals_in_set(vars(f), c("low", "mid", "high", "higher")) %>%

--- a/tests/testthat/test-create_agent.R
+++ b/tests/testthat/test-create_agent.R
@@ -18,7 +18,7 @@ test_that("Creating a valid `agent` object is possible", {
       names(agent) ==
         c("name", "time", "tbl", "tbl_name",
           "tbl_src", "tbl_src_details", "col_names", "col_types",
-          "actions", "end_fns", "embed_report", "reporting",
+          "actions", "end_fns", "embed_report", "reporting", "reporting_lang",
           "validation_set", "extracts"
         )
     )
@@ -42,6 +42,7 @@ test_that("Creating a valid `agent` object is possible", {
   expect_is(agent$actions, "list")
   expect_is(agent$end_fns, "list")
   expect_is(agent$embed_report, "logical")
+  expect_is(agent$reporting_lang, "character")
   expect_is(agent$validation_set$i, "integer")
   expect_is(agent$validation_set$assertion_type, "character")
   expect_is(agent$validation_set$column, "list")


### PR DESCRIPTION
This adds a `reporting_lang` option to `create_agent()` and allows for automatic briefs and agent reports to be in five different languages.