### PR TITLE
Allow use of formula and function values for `preconditions`

### DIFF
--- a/R/col_vals_between.R
+++ b/R/col_vals_between.R
@@ -33,15 +33,15 @@
 #' test units. 
 #' 
 #' Having table `preconditions` means **pointblank** will mutate the table just
-#' before interrogation. It's isolated to the validation steps produced by this
-#' validation step function. Using **dplyr** code is suggested here since the
-#' statements can be translated to SQL if necessary. The code is to be supplied
-#' as a one-sided **R** formula (using a leading `~`). In the formula
-#' representation, the obligatory `tbl` variable will serve as the input
-#' data table to be transformed (e.g.,
-#' `~ tbl %>% dplyr::mutate(col_a = col_b + 10)`. A series of expressions can be
-#' used by enclosing the set of statements with `{ }` but note that the `tbl`
-#' variable must be ultimately returned.
+#' before interrogation. Such a table mutation is isolated in scope to the
+#' validation step(s) produced by the validation step function call. Using
+#' **dplyr** code is suggested here since the statements can be translated to
+#' SQL if necessary. The code is most easily supplied as a one-sided **R**
+#' formula (using a leading `~`). In the formula representation, the `.` serves
+#' as the input data table to be transformed (e.g., 
+#' `~ . %>% dplyr::mutate(col_a = col_b + 10)`). Alternatively, a function could
+#' instead be supplied (e.g., 
+#' `function(x) dplyr::mutate(x, col_a = col_b + 10)`).
 #' 
 #' Often, we will want to specify `actions` for the validation. This argument,
 #' present in every validation step function, takes a specially-crafted list
@@ -126,7 +126,7 @@ col_vals_between <- function(x,
   
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
-  
+
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions)
   

--- a/R/col_vals_equal.R
+++ b/R/col_vals_equal.R
@@ -26,15 +26,15 @@
 #' test units. 
 #' 
 #' Having table `preconditions` means **pointblank** will mutate the table just
-#' before interrogation. It's isolated to the validation steps produced by this
-#' validation step function. Using **dplyr** code is suggested here since the
-#' statements can be translated to SQL if necessary. The code is to be supplied
-#' as a one-sided **R** formula (using a leading `~`). In the formula
-#' representation, the obligatory `tbl` variable will serve as the input
-#' data table to be transformed (e.g.,
-#' `~ tbl %>% dplyr::mutate(col_a = col_b + 10)`. A series of expressions can be
-#' used by enclosing the set of statements with `{ }` but note that the `tbl`
-#' variable must be ultimately returned.
+#' before interrogation. Such a table mutation is isolated in scope to the
+#' validation step(s) produced by the validation step function call. Using
+#' **dplyr** code is suggested here since the statements can be translated to
+#' SQL if necessary. The code is most easily supplied as a one-sided **R**
+#' formula (using a leading `~`). In the formula representation, the `.` serves
+#' as the input data table to be transformed (e.g., 
+#' `~ . %>% dplyr::mutate(col_a = col_b + 10)`). Alternatively, a function could
+#' instead be supplied (e.g., 
+#' `function(x) dplyr::mutate(x, col_a = col_b + 10)`).
 #' 
 #' Often, we will want to specify `actions` for the validation. This argument,
 #' present in every validation step function, takes a specially-crafted list
@@ -81,7 +81,7 @@
 #'   create_agent(tbl = tbl) %>%
 #'   col_vals_equal(vars(b), 5,
 #'     preconditions = 
-#'       ~ tbl %>% dplyr::filter(a == 1)
+#'       ~ . %>% dplyr::filter(a == 1)
 #'   ) %>%
 #'   interrogate()
 #' 

--- a/R/col_vals_gt.R
+++ b/R/col_vals_gt.R
@@ -27,15 +27,15 @@
 #' test units. 
 #' 
 #' Having table `preconditions` means **pointblank** will mutate the table just
-#' before interrogation. It's isolated to the validation steps produced by this
-#' validation step function. Using **dplyr** code is suggested here since the
-#' statements can be translated to SQL if necessary. The code is to be supplied
-#' as a one-sided **R** formula (using a leading `~`). In the formula
-#' representation, the obligatory `tbl` variable will serve as the input
-#' data table to be transformed (e.g.,
-#' `~ tbl %>% dplyr::mutate(col_a = col_b + 10)`. A series of expressions can be
-#' used by enclosing the set of statements with `{ }` but note that the `tbl`
-#' variable must be ultimately returned.
+#' before interrogation. Such a table mutation is isolated in scope to the
+#' validation step(s) produced by the validation step function call. Using
+#' **dplyr** code is suggested here since the statements can be translated to
+#' SQL if necessary. The code is most easily supplied as a one-sided **R**
+#' formula (using a leading `~`). In the formula representation, the `.` serves
+#' as the input data table to be transformed (e.g., 
+#' `~ . %>% dplyr::mutate(col_a = col_b + 10)`). Alternatively, a function could
+#' instead be supplied (e.g., 
+#' `function(x) dplyr::mutate(x, col_a = col_b + 10)`).
 #' 
 #' Often, we will want to specify `actions` for the validation. This argument,
 #' present in every validation step function, takes a specially-crafted list
@@ -70,11 +70,9 @@
 #'   a pass.
 #' @param preconditions expressions used for mutating the input table before
 #'   proceeding with the validation. This is ideally as a one-sided R formula
-#'   using a leading `~`. In the formula representation, the `tbl` serves as the
+#'   using a leading `~`. In the formula representation, the `.` serves as the
 #'   input data table to be transformed (e.g.,
-#'   `~ tbl %>% dplyr::mutate(col = col + 10)`. A series of expressions can be
-#'   used by enclosing the set of statements with `{ }` but note that the `tbl`
-#'   object must be ultimately returned.
+#'   `~ . %>% dplyr::mutate(col = col + 10)`.
 #' @param actions A list containing threshold levels so that the validation step
 #'   can react accordingly when exceeding the set levels. This is to be created
 #'   with the [action_levels()] helper function.

--- a/R/col_vals_gte.R
+++ b/R/col_vals_gte.R
@@ -27,15 +27,15 @@
 #' test units. 
 #' 
 #' Having table `preconditions` means **pointblank** will mutate the table just
-#' before interrogation. It's isolated to the validation steps produced by this
-#' validation step function. Using **dplyr** code is suggested here since the
-#' statements can be translated to SQL if necessary. The code is to be supplied
-#' as a one-sided **R** formula (using a leading `~`). In the formula
-#' representation, the obligatory `tbl` variable will serve as the input
-#' data table to be transformed (e.g.,
-#' `~ tbl %>% dplyr::mutate(col_a = col_b + 10)`. A series of expressions can be
-#' used by enclosing the set of statements with `{ }` but note that the `tbl`
-#' variable must be ultimately returned.
+#' before interrogation. Such a table mutation is isolated in scope to the
+#' validation step(s) produced by the validation step function call. Using
+#' **dplyr** code is suggested here since the statements can be translated to
+#' SQL if necessary. The code is most easily supplied as a one-sided **R**
+#' formula (using a leading `~`). In the formula representation, the `.` serves
+#' as the input data table to be transformed (e.g., 
+#' `~ . %>% dplyr::mutate(col_a = col_b + 10)`). Alternatively, a function could
+#' instead be supplied (e.g., 
+#' `function(x) dplyr::mutate(x, col_a = col_b + 10)`).
 #' 
 #' Often, we will want to specify `actions` for the validation. This argument,
 #' present in every validation step function, takes a specially-crafted list

--- a/R/col_vals_in_set.R
+++ b/R/col_vals_in_set.R
@@ -19,15 +19,15 @@
 #' `matches()`, and `everything()`.
 #' 
 #' Having table `preconditions` means **pointblank** will mutate the table just
-#' before interrogation. It's isolated to the validation steps produced by this
-#' validation step function. Using **dplyr** code is suggested here since the
-#' statements can be translated to SQL if necessary. The code is to be supplied
-#' as a one-sided **R** formula (using a leading `~`). In the formula
-#' representation, the obligatory `tbl` variable will serve as the input
-#' data table to be transformed (e.g.,
-#' `~ tbl %>% dplyr::mutate(col_a = col_b + 10)`. A series of expressions can be
-#' used by enclosing the set of statements with `{ }` but note that the `tbl`
-#' variable must be ultimately returned.
+#' before interrogation. Such a table mutation is isolated in scope to the
+#' validation step(s) produced by the validation step function call. Using
+#' **dplyr** code is suggested here since the statements can be translated to
+#' SQL if necessary. The code is most easily supplied as a one-sided **R**
+#' formula (using a leading `~`). In the formula representation, the `.` serves
+#' as the input data table to be transformed (e.g., 
+#' `~ . %>% dplyr::mutate(col_a = col_b + 10)`). Alternatively, a function could
+#' instead be supplied (e.g., 
+#' `function(x) dplyr::mutate(x, col_a = col_b + 10)`).
 #' 
 #' Often, we will want to specify `actions` for the validation. This argument,
 #' present in every validation step function, takes a specially-crafted list

--- a/R/col_vals_lt.R
+++ b/R/col_vals_lt.R
@@ -27,15 +27,15 @@
 #' test units. 
 #' 
 #' Having table `preconditions` means **pointblank** will mutate the table just
-#' before interrogation. It's isolated to the validation steps produced by this
-#' validation step function. Using **dplyr** code is suggested here since the
-#' statements can be translated to SQL if necessary. The code is to be supplied
-#' as a one-sided **R** formula (using a leading `~`). In the formula
-#' representation, the obligatory `tbl` variable will serve as the input
-#' data table to be transformed (e.g.,
-#' `~ tbl %>% dplyr::mutate(col_a = col_b + 10)`. A series of expressions can be
-#' used by enclosing the set of statements with `{ }` but note that the `tbl`
-#' variable must be ultimately returned.
+#' before interrogation. Such a table mutation is isolated in scope to the
+#' validation step(s) produced by the validation step function call. Using
+#' **dplyr** code is suggested here since the statements can be translated to
+#' SQL if necessary. The code is most easily supplied as a one-sided **R**
+#' formula (using a leading `~`). In the formula representation, the `.` serves
+#' as the input data table to be transformed (e.g., 
+#' `~ . %>% dplyr::mutate(col_a = col_b + 10)`). Alternatively, a function could
+#' instead be supplied (e.g., 
+#' `function(x) dplyr::mutate(x, col_a = col_b + 10)`).
 #' 
 #' Often, we will want to specify `actions` for the validation. This argument,
 #' present in every validation step function, takes a specially-crafted list

--- a/R/col_vals_lte.R
+++ b/R/col_vals_lte.R
@@ -27,15 +27,15 @@
 #' test units.
 #' 
 #' Having table `preconditions` means **pointblank** will mutate the table just
-#' before interrogation. It's isolated to the validation steps produced by this
-#' validation step function. Using **dplyr** code is suggested here since the
-#' statements can be translated to SQL if necessary. The code is to be supplied
-#' as a one-sided **R** formula (using a leading `~`). In the formula
-#' representation, the obligatory `tbl` variable will serve as the input
-#' data table to be transformed (e.g.,
-#' `~ tbl %>% dplyr::mutate(col_a = col_b + 10)`. A series of expressions can be
-#' used by enclosing the set of statements with `{ }` but note that the `tbl`
-#' variable must be ultimately returned.
+#' before interrogation. Such a table mutation is isolated in scope to the
+#' validation step(s) produced by the validation step function call. Using
+#' **dplyr** code is suggested here since the statements can be translated to
+#' SQL if necessary. The code is most easily supplied as a one-sided **R**
+#' formula (using a leading `~`). In the formula representation, the `.` serves
+#' as the input data table to be transformed (e.g., 
+#' `~ . %>% dplyr::mutate(col_a = col_b + 10)`). Alternatively, a function could
+#' instead be supplied (e.g., 
+#' `function(x) dplyr::mutate(x, col_a = col_b + 10)`).
 #' 
 #' Often, we will want to specify `actions` for the validation. This argument,
 #' present in every validation step function, takes a specially-crafted list
@@ -83,9 +83,8 @@
 #' agent <-
 #'   create_agent(tbl = tbl) %>%
 #'   col_vals_lte(vars(a_b), 10,
-#'     preconditions = ~ {
-#'       tbl %>% dplyr::mutate(a_b = a + b)
-#'     }
+#'     preconditions = ~
+#'       . %>% dplyr::mutate(a_b = a + b)
 #'   ) %>%
 #'   interrogate()
 #' 

--- a/R/col_vals_not_between.R
+++ b/R/col_vals_not_between.R
@@ -33,15 +33,15 @@
 #' test units. 
 #' 
 #' Having table `preconditions` means **pointblank** will mutate the table just
-#' before interrogation. It's isolated to the validation steps produced by this
-#' validation step function. Using **dplyr** code is suggested here since the
-#' statements can be translated to SQL if necessary. The code is to be supplied
-#' as a one-sided **R** formula (using a leading `~`). In the formula
-#' representation, the obligatory `tbl` variable will serve as the input
-#' data table to be transformed (e.g.,
-#' `~ tbl %>% dplyr::mutate(col_a = col_b + 10)`. A series of expressions can be
-#' used by enclosing the set of statements with `{ }` but note that the `tbl`
-#' variable must be ultimately returned.
+#' before interrogation. Such a table mutation is isolated in scope to the
+#' validation step(s) produced by the validation step function call. Using
+#' **dplyr** code is suggested here since the statements can be translated to
+#' SQL if necessary. The code is most easily supplied as a one-sided **R**
+#' formula (using a leading `~`). In the formula representation, the `.` serves
+#' as the input data table to be transformed (e.g., 
+#' `~ . %>% dplyr::mutate(col_a = col_b + 10)`). Alternatively, a function could
+#' instead be supplied (e.g., 
+#' `function(x) dplyr::mutate(x, col_a = col_b + 10)`).
 #' 
 #' Often, we will want to specify `actions` for the validation. This argument,
 #' present in every validation step function, takes a specially-crafted list

--- a/R/col_vals_not_equal.R
+++ b/R/col_vals_not_equal.R
@@ -25,15 +25,15 @@
 #' test units.
 #' 
 #' Having table `preconditions` means **pointblank** will mutate the table just
-#' before interrogation. It's isolated to the validation steps produced by this
-#' validation step function. Using **dplyr** code is suggested here since the
-#' statements can be translated to SQL if necessary. The code is to be supplied
-#' as a one-sided **R** formula (using a leading `~`). In the formula
-#' representation, the obligatory `tbl` variable will serve as the input
-#' data table to be transformed (e.g.,
-#' `~ tbl %>% dplyr::mutate(col_a = col_b + 10)`. A series of expressions can be
-#' used by enclosing the set of statements with `{ }` but note that the `tbl`
-#' variable must be ultimately returned.
+#' before interrogation. Such a table mutation is isolated in scope to the
+#' validation step(s) produced by the validation step function call. Using
+#' **dplyr** code is suggested here since the statements can be translated to
+#' SQL if necessary. The code is most easily supplied as a one-sided **R**
+#' formula (using a leading `~`). In the formula representation, the `.` serves
+#' as the input data table to be transformed (e.g., 
+#' `~ . %>% dplyr::mutate(col_a = col_b + 10)`). Alternatively, a function could
+#' instead be supplied (e.g., 
+#' `function(x) dplyr::mutate(x, col_a = col_b + 10)`).
 #' 
 #' Often, we will want to specify `actions` for the validation. This argument,
 #' present in every validation step function, takes a specially-crafted list
@@ -81,7 +81,7 @@
 #'   create_agent(tbl = tbl) %>%
 #'   col_vals_not_equal(vars(b), 5,
 #'     preconditions = 
-#'       ~ tbl %>% dplyr::filter(a == 2)
+#'       ~ . %>% dplyr::filter(a == 2)
 #'   ) %>%
 #'   interrogate()
 #' 

--- a/R/col_vals_not_in_set.R
+++ b/R/col_vals_not_in_set.R
@@ -19,15 +19,15 @@
 #' `matches()`, and `everything()`.
 #' 
 #' Having table `preconditions` means **pointblank** will mutate the table just
-#' before interrogation. It's isolated to the validation steps produced by this
-#' validation step function. Using **dplyr** code is suggested here since the
-#' statements can be translated to SQL if necessary. The code is to be supplied
-#' as a one-sided **R** formula (using a leading `~`). In the formula
-#' representation, the obligatory `tbl` variable will serve as the input
-#' data table to be transformed (e.g.,
-#' `~ tbl %>% dplyr::mutate(col_a = col_b + 10)`. A series of expressions can be
-#' used by enclosing the set of statements with `{ }` but note that the `tbl`
-#' variable must be ultimately returned.
+#' before interrogation. Such a table mutation is isolated in scope to the
+#' validation step(s) produced by the validation step function call. Using
+#' **dplyr** code is suggested here since the statements can be translated to
+#' SQL if necessary. The code is most easily supplied as a one-sided **R**
+#' formula (using a leading `~`). In the formula representation, the `.` serves
+#' as the input data table to be transformed (e.g., 
+#' `~ . %>% dplyr::mutate(col_a = col_b + 10)`). Alternatively, a function could
+#' instead be supplied (e.g., 
+#' `function(x) dplyr::mutate(x, col_a = col_b + 10)`).
 #' 
 #' Often, we will want to specify `actions` for the validation. This argument,
 #' present in every validation step function, takes a specially-crafted list

--- a/R/col_vals_not_null.R
+++ b/R/col_vals_not_null.R
@@ -19,15 +19,15 @@
 #' `matches()`, and `everything()`.
 #' 
 #' Having table `preconditions` means **pointblank** will mutate the table just
-#' before interrogation. It's isolated to the validation steps produced by this
-#' validation step function. Using **dplyr** code is suggested here since the
-#' statements can be translated to SQL if necessary. The code is to be supplied
-#' as a one-sided **R** formula (using a leading `~`). In the formula
-#' representation, the obligatory `tbl` variable will serve as the input
-#' data table to be transformed (e.g.,
-#' `~ tbl %>% dplyr::mutate(col_a = col_b + 10)`. A series of expressions can be
-#' used by enclosing the set of statements with `{ }` but note that the `tbl`
-#' variable must be ultimately returned.
+#' before interrogation. Such a table mutation is isolated in scope to the
+#' validation step(s) produced by the validation step function call. Using
+#' **dplyr** code is suggested here since the statements can be translated to
+#' SQL if necessary. The code is most easily supplied as a one-sided **R**
+#' formula (using a leading `~`). In the formula representation, the `.` serves
+#' as the input data table to be transformed (e.g., 
+#' `~ . %>% dplyr::mutate(col_a = col_b + 10)`). Alternatively, a function could
+#' instead be supplied (e.g., 
+#' `function(x) dplyr::mutate(x, col_a = col_b + 10)`).
 #' 
 #' Often, we will want to specify `actions` for the validation. This argument,
 #' present in every validation step function, takes a specially-crafted list
@@ -74,7 +74,7 @@
 #'   create_agent(tbl = tbl) %>%
 #'   col_vals_not_null(vars(a),
 #'     preconditions = 
-#'       ~ tbl %>% dplyr::filter(b == 2)
+#'       ~ . %>% dplyr::filter(b == 2)
 #'   ) %>%
 #'   interrogate()
 #' 

--- a/R/col_vals_null.R
+++ b/R/col_vals_null.R
@@ -19,15 +19,15 @@
 #' `matches()`, and `everything()`.
 #' 
 #' Having table `preconditions` means **pointblank** will mutate the table just
-#' before interrogation. It's isolated to the validation steps produced by this
-#' validation step function. Using **dplyr** code is suggested here since the
-#' statements can be translated to SQL if necessary. The code is to be supplied
-#' as a one-sided **R** formula (using a leading `~`). In the formula
-#' representation, the obligatory `tbl` variable will serve as the input
-#' data table to be transformed (e.g.,
-#' `~ tbl %>% dplyr::mutate(col_a = col_b + 10)`. A series of expressions can be
-#' used by enclosing the set of statements with `{ }` but note that the `tbl`
-#' variable must be ultimately returned.
+#' before interrogation. Such a table mutation is isolated in scope to the
+#' validation step(s) produced by the validation step function call. Using
+#' **dplyr** code is suggested here since the statements can be translated to
+#' SQL if necessary. The code is most easily supplied as a one-sided **R**
+#' formula (using a leading `~`). In the formula representation, the `.` serves
+#' as the input data table to be transformed (e.g., 
+#' `~ . %>% dplyr::mutate(col_a = col_b + 10)`). Alternatively, a function could
+#' instead be supplied (e.g., 
+#' `function(x) dplyr::mutate(x, col_a = col_b + 10)`).
 #' 
 #' Often, we will want to specify `actions` for the validation. This argument,
 #' present in every validation step function, takes a specially-crafted list
@@ -74,7 +74,7 @@
 #'   create_agent(tbl = tbl) %>%
 #'   col_vals_null(vars(a),
 #'     preconditions = 
-#'       ~ tbl %>% dplyr::filter(b >= 5)
+#'       ~ . %>% dplyr::filter(b >= 5)
 #'   ) %>%
 #'   interrogate()
 #' 

--- a/R/col_vals_regex.R
+++ b/R/col_vals_regex.R
@@ -24,15 +24,15 @@
 #' test units. 
 #' 
 #' Having table `preconditions` means **pointblank** will mutate the table just
-#' before interrogation. It's isolated to the validation steps produced by this
-#' validation step function. Using **dplyr** code is suggested here since the
-#' statements can be translated to SQL if necessary. The code is to be supplied
-#' as a one-sided **R** formula (using a leading `~`). In the formula
-#' representation, the obligatory `tbl` variable will serve as the input
-#' data table to be transformed (e.g.,
-#' `~ tbl %>% dplyr::mutate(col_a = col_b + 10)`. A series of expressions can be
-#' used by enclosing the set of statements with `{ }` but note that the `tbl`
-#' variable must be ultimately returned.
+#' before interrogation. Such a table mutation is isolated in scope to the
+#' validation step(s) produced by the validation step function call. Using
+#' **dplyr** code is suggested here since the statements can be translated to
+#' SQL if necessary. The code is most easily supplied as a one-sided **R**
+#' formula (using a leading `~`). In the formula representation, the `.` serves
+#' as the input data table to be transformed (e.g., 
+#' `~ . %>% dplyr::mutate(col_a = col_b + 10)`). Alternatively, a function could
+#' instead be supplied (e.g., 
+#' `function(x) dplyr::mutate(x, col_a = col_b + 10)`).
 #' 
 #' Often, we will want to specify `actions` for the validation. This argument,
 #' present in every validation step function, takes a specially-crafted list

--- a/R/conjointly.R
+++ b/R/conjointly.R
@@ -24,15 +24,15 @@
 #' `everything()`.
 #' 
 #' Having table `preconditions` means **pointblank** will mutate the table just
-#' before interrogation. It's isolated to the validation steps produced by this
-#' validation step function. Using **dplyr** code is suggested here since the
-#' statements can be translated to SQL if necessary. The code is to be supplied
-#' as a one-sided **R** formula (using a leading `~`). In the formula
-#' representation, the obligatory `tbl` variable will serve as the input
-#' data table to be transformed (e.g.,
-#' `~ tbl %>% dplyr::mutate(col_a = col_b + 10)`. A series of expressions can be
-#' used by enclosing the set of statements with `{ }` but note that the `tbl`
-#' variable must be ultimately returned.
+#' before interrogation. Such a table mutation is isolated in scope to the
+#' validation step(s) produced by the validation step function call. Using
+#' **dplyr** code is suggested here since the statements can be translated to
+#' SQL if necessary. The code is most easily supplied as a one-sided **R**
+#' formula (using a leading `~`). In the formula representation, the `.` serves
+#' as the input data table to be transformed (e.g., 
+#' `~ . %>% dplyr::mutate(col_a = col_b + 10)`). Alternatively, a function could
+#' instead be supplied (e.g., 
+#' `function(x) dplyr::mutate(x, col_a = col_b + 10)`).
 #' 
 #' Often, we will want to specify `actions` for the validation. This argument,
 #' present in every validation step function, takes a specially-crafted list

--- a/R/get_agent_report.R
+++ b/R/get_agent_report.R
@@ -340,7 +340,7 @@ get_agent_report <- function(agent,
           x
         } 
       )
-    
+
     # Reformat `precon`
     precon_upd <- 
       validation_set$preconditions %>%
@@ -348,6 +348,7 @@ get_agent_report <- function(agent,
         FUN.VALUE = character(1),
         USE.NAMES = FALSE,
         FUN = function(x) {
+
           if (is.null(x)) {
             x <- 
               make_button(
@@ -357,9 +358,8 @@ get_agent_report <- function(agent,
                 background = "#FFFFFF"
               )
             
-          } else {
-            x <- x %>% as.character() %>% base::setdiff("~")
-            
+          } else if (rlang::is_formula(x) || rlang::is_function(x)) {
+
             x <- 
               make_button(
                 x = "&#10174;",

--- a/R/rows_distinct.R
+++ b/R/rows_distinct.R
@@ -17,15 +17,15 @@
 #' `ends_with()`, `contains()`, `matches()`, and `everything()`.
 #' 
 #' Having table `preconditions` means **pointblank** will mutate the table just
-#' before interrogation. It's isolated to the validation steps produced by this
-#' validation step function. Using **dplyr** code is suggested here since the
-#' statements can be translated to SQL if necessary. The code is to be supplied
-#' as a one-sided **R** formula (using a leading `~`). In the formula
-#' representation, the obligatory `tbl` variable will serve as the input
-#' data table to be transformed (e.g.,
-#' `~ tbl %>% dplyr::mutate(col_a = col_b + 10)`. A series of expressions can be
-#' used by enclosing the set of statements with `{ }` but note that the `tbl`
-#' variable must be ultimately returned.
+#' before interrogation. Such a table mutation is isolated in scope to the
+#' validation step(s) produced by the validation step function call. Using
+#' **dplyr** code is suggested here since the statements can be translated to
+#' SQL if necessary. The code is most easily supplied as a one-sided **R**
+#' formula (using a leading `~`). In the formula representation, the `.` serves
+#' as the input data table to be transformed (e.g., 
+#' `~ . %>% dplyr::mutate(col_a = col_b + 10)`). Alternatively, a function could
+#' instead be supplied (e.g., 
+#' `function(x) dplyr::mutate(x, col_a = col_b + 10)`).
 #' 
 #' Often, we will want to specify `actions` for the validation. This argument,
 #' present in every validation step function, takes a specially-crafted list

--- a/R/utils.R
+++ b/R/utils.R
@@ -66,10 +66,10 @@ resolve_columns <- function(x, var_expr, preconditions) {
   if (inherits(var_expr, "quosure") && var_expr %>% rlang::as_label() == "NULL") {
     return(character(0))
   } 
-  
+
   # Get the column names
   if (is.null(preconditions)) {
-    
+
     if (inherits(x, c("data.frame", "tbl_df", "tbl_dbi"))) {
       
       column <- resolve_expr_to_cols(tbl = x, var_expr = !!var_expr)
@@ -81,26 +81,18 @@ resolve_columns <- function(x, var_expr, preconditions) {
     }
     
   } else {
-    
+
     if (inherits(x, c("data.frame", "tbl_df", "tbl_dbi"))) {
-      
-      tbl <- x
-      
-      tbl <- 
-        preconditions %>%
-        rlang::f_rhs() %>%
-        rlang::eval_tidy()
+  
+      tbl <- apply_preconditions(tbl = x, preconditions = preconditions)
       
       column <- resolve_expr_to_cols(tbl = tbl, var_expr = !!var_expr)
       
     } else if (inherits(x, ("ptblank_agent"))) {
-      
+
       tbl <- get_tbl_object(agent = x)
       
-      tbl <- 
-        preconditions %>%
-        rlang::f_rhs() %>%
-        rlang::eval_tidy()
+      tbl <- apply_preconditions(tbl = tbl, preconditions = preconditions)
       
       column <- resolve_expr_to_cols(tbl = tbl, var_expr = !!var_expr)
     }

--- a/man/col_vals_between.Rd
+++ b/man/col_vals_between.Rd
@@ -56,11 +56,9 @@ a pass.}
 
 \item{preconditions}{expressions used for mutating the input table before
 proceeding with the validation. This is ideally as a one-sided R formula
-using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+using a leading \code{~}. In the formula representation, the \code{.} serves as the
 input data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-object must be ultimately returned.}
+\code{~ . \%>\% dplyr::mutate(col = col + 10)}.}
 
 \item{actions}{A list containing threshold levels so that the validation step
 can react accordingly when exceeding the set levels. This is to be created
@@ -127,15 +125,15 @@ unit should be counted as a \emph{pass} or a \emph{fail}. The default of
 test units.
 
 Having table \code{preconditions} means \strong{pointblank} will mutate the table just
-before interrogation. It's isolated to the validation steps produced by this
-validation step function. Using \strong{dplyr} code is suggested here since the
-statements can be translated to SQL if necessary. The code is to be supplied
-as a one-sided \strong{R} formula (using a leading \code{~}). In the formula
-representation, the obligatory \code{tbl} variable will serve as the input
-data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col_a = col_b + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-variable must be ultimately returned.
+before interrogation. Such a table mutation is isolated in scope to the
+validation step(s) produced by the validation step function call. Using
+\strong{dplyr} code is suggested here since the statements can be translated to
+SQL if necessary. The code is most easily supplied as a one-sided \strong{R}
+formula (using a leading \code{~}). In the formula representation, the \code{.} serves
+as the input data table to be transformed (e.g.,
+\code{~ . \%>\% dplyr::mutate(col_a = col_b + 10)}). Alternatively, a function could
+instead be supplied (e.g.,
+\code{function(x) dplyr::mutate(x, col_a = col_b + 10)}).
 
 Often, we will want to specify \code{actions} for the validation. This argument,
 present in every validation step function, takes a specially-crafted list

--- a/man/col_vals_equal.Rd
+++ b/man/col_vals_equal.Rd
@@ -40,11 +40,9 @@ a pass.}
 
 \item{preconditions}{expressions used for mutating the input table before
 proceeding with the validation. This is ideally as a one-sided R formula
-using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+using a leading \code{~}. In the formula representation, the \code{.} serves as the
 input data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-object must be ultimately returned.}
+\code{~ . \%>\% dplyr::mutate(col = col + 10)}.}
 
 \item{actions}{A list containing threshold levels so that the validation step
 can react accordingly when exceeding the set levels. This is to be created
@@ -105,15 +103,15 @@ unit should be counted as a \emph{pass} or a \emph{fail}. The default of
 test units.
 
 Having table \code{preconditions} means \strong{pointblank} will mutate the table just
-before interrogation. It's isolated to the validation steps produced by this
-validation step function. Using \strong{dplyr} code is suggested here since the
-statements can be translated to SQL if necessary. The code is to be supplied
-as a one-sided \strong{R} formula (using a leading \code{~}). In the formula
-representation, the obligatory \code{tbl} variable will serve as the input
-data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col_a = col_b + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-variable must be ultimately returned.
+before interrogation. Such a table mutation is isolated in scope to the
+validation step(s) produced by the validation step function call. Using
+\strong{dplyr} code is suggested here since the statements can be translated to
+SQL if necessary. The code is most easily supplied as a one-sided \strong{R}
+formula (using a leading \code{~}). In the formula representation, the \code{.} serves
+as the input data table to be transformed (e.g.,
+\code{~ . \%>\% dplyr::mutate(col_a = col_b + 10)}). Alternatively, a function could
+instead be supplied (e.g.,
+\code{function(x) dplyr::mutate(x, col_a = col_b + 10)}).
 
 Often, we will want to specify \code{actions} for the validation. This argument,
 present in every validation step function, takes a specially-crafted list
@@ -156,7 +154,7 @@ agent <-
   create_agent(tbl = tbl) \%>\%
   col_vals_equal(vars(b), 5,
     preconditions = 
-      ~ tbl \%>\% dplyr::filter(a == 1)
+      ~ . \%>\% dplyr::filter(a == 1)
   ) \%>\%
   interrogate()
 

--- a/man/col_vals_gt.Rd
+++ b/man/col_vals_gt.Rd
@@ -41,11 +41,9 @@ a pass.}
 
 \item{preconditions}{expressions used for mutating the input table before
 proceeding with the validation. This is ideally as a one-sided R formula
-using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+using a leading \code{~}. In the formula representation, the \code{.} serves as the
 input data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-object must be ultimately returned.}
+\code{~ . \%>\% dplyr::mutate(col = col + 10)}.}
 
 \item{actions}{A list containing threshold levels so that the validation step
 can react accordingly when exceeding the set levels. This is to be created
@@ -107,15 +105,15 @@ unit should be counted as a \emph{pass} or a \emph{fail}. The default of
 test units.
 
 Having table \code{preconditions} means \strong{pointblank} will mutate the table just
-before interrogation. It's isolated to the validation steps produced by this
-validation step function. Using \strong{dplyr} code is suggested here since the
-statements can be translated to SQL if necessary. The code is to be supplied
-as a one-sided \strong{R} formula (using a leading \code{~}). In the formula
-representation, the obligatory \code{tbl} variable will serve as the input
-data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col_a = col_b + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-variable must be ultimately returned.
+before interrogation. Such a table mutation is isolated in scope to the
+validation step(s) produced by the validation step function call. Using
+\strong{dplyr} code is suggested here since the statements can be translated to
+SQL if necessary. The code is most easily supplied as a one-sided \strong{R}
+formula (using a leading \code{~}). In the formula representation, the \code{.} serves
+as the input data table to be transformed (e.g.,
+\code{~ . \%>\% dplyr::mutate(col_a = col_b + 10)}). Alternatively, a function could
+instead be supplied (e.g.,
+\code{function(x) dplyr::mutate(x, col_a = col_b + 10)}).
 
 Often, we will want to specify \code{actions} for the validation. This argument,
 present in every validation step function, takes a specially-crafted list

--- a/man/col_vals_gte.Rd
+++ b/man/col_vals_gte.Rd
@@ -40,11 +40,9 @@ a pass.}
 
 \item{preconditions}{expressions used for mutating the input table before
 proceeding with the validation. This is ideally as a one-sided R formula
-using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+using a leading \code{~}. In the formula representation, the \code{.} serves as the
 input data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-object must be ultimately returned.}
+\code{~ . \%>\% dplyr::mutate(col = col + 10)}.}
 
 \item{actions}{A list containing threshold levels so that the validation step
 can react accordingly when exceeding the set levels. This is to be created
@@ -106,15 +104,15 @@ unit should be counted as a \emph{pass} or a \emph{fail}. The default of
 test units.
 
 Having table \code{preconditions} means \strong{pointblank} will mutate the table just
-before interrogation. It's isolated to the validation steps produced by this
-validation step function. Using \strong{dplyr} code is suggested here since the
-statements can be translated to SQL if necessary. The code is to be supplied
-as a one-sided \strong{R} formula (using a leading \code{~}). In the formula
-representation, the obligatory \code{tbl} variable will serve as the input
-data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col_a = col_b + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-variable must be ultimately returned.
+before interrogation. Such a table mutation is isolated in scope to the
+validation step(s) produced by the validation step function call. Using
+\strong{dplyr} code is suggested here since the statements can be translated to
+SQL if necessary. The code is most easily supplied as a one-sided \strong{R}
+formula (using a leading \code{~}). In the formula representation, the \code{.} serves
+as the input data table to be transformed (e.g.,
+\code{~ . \%>\% dplyr::mutate(col_a = col_b + 10)}). Alternatively, a function could
+instead be supplied (e.g.,
+\code{function(x) dplyr::mutate(x, col_a = col_b + 10)}).
 
 Often, we will want to specify \code{actions} for the validation. This argument,
 present in every validation step function, takes a specially-crafted list

--- a/man/col_vals_in_set.Rd
+++ b/man/col_vals_in_set.Rd
@@ -35,11 +35,9 @@ found within this \code{set} will be considered as passing.}
 
 \item{preconditions}{expressions used for mutating the input table before
 proceeding with the validation. This is ideally as a one-sided R formula
-using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+using a leading \code{~}. In the formula representation, the \code{.} serves as the
 input data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-object must be ultimately returned.}
+\code{~ . \%>\% dplyr::mutate(col = col + 10)}.}
 
 \item{actions}{A list containing threshold levels so that the validation step
 can react accordingly when exceeding the set levels. This is to be created
@@ -93,15 +91,15 @@ specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{co
 \code{matches()}, and \code{everything()}.
 
 Having table \code{preconditions} means \strong{pointblank} will mutate the table just
-before interrogation. It's isolated to the validation steps produced by this
-validation step function. Using \strong{dplyr} code is suggested here since the
-statements can be translated to SQL if necessary. The code is to be supplied
-as a one-sided \strong{R} formula (using a leading \code{~}). In the formula
-representation, the obligatory \code{tbl} variable will serve as the input
-data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col_a = col_b + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-variable must be ultimately returned.
+before interrogation. Such a table mutation is isolated in scope to the
+validation step(s) produced by the validation step function call. Using
+\strong{dplyr} code is suggested here since the statements can be translated to
+SQL if necessary. The code is most easily supplied as a one-sided \strong{R}
+formula (using a leading \code{~}). In the formula representation, the \code{.} serves
+as the input data table to be transformed (e.g.,
+\code{~ . \%>\% dplyr::mutate(col_a = col_b + 10)}). Alternatively, a function could
+instead be supplied (e.g.,
+\code{function(x) dplyr::mutate(x, col_a = col_b + 10)}).
 
 Often, we will want to specify \code{actions} for the validation. This argument,
 present in every validation step function, takes a specially-crafted list

--- a/man/col_vals_lt.Rd
+++ b/man/col_vals_lt.Rd
@@ -41,11 +41,9 @@ a pass.}
 
 \item{preconditions}{expressions used for mutating the input table before
 proceeding with the validation. This is ideally as a one-sided R formula
-using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+using a leading \code{~}. In the formula representation, the \code{.} serves as the
 input data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-object must be ultimately returned.}
+\code{~ . \%>\% dplyr::mutate(col = col + 10)}.}
 
 \item{actions}{A list containing threshold levels so that the validation step
 can react accordingly when exceeding the set levels. This is to be created
@@ -107,15 +105,15 @@ unit should be counted as a \emph{pass} or a \emph{fail}. The default of
 test units.
 
 Having table \code{preconditions} means \strong{pointblank} will mutate the table just
-before interrogation. It's isolated to the validation steps produced by this
-validation step function. Using \strong{dplyr} code is suggested here since the
-statements can be translated to SQL if necessary. The code is to be supplied
-as a one-sided \strong{R} formula (using a leading \code{~}). In the formula
-representation, the obligatory \code{tbl} variable will serve as the input
-data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col_a = col_b + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-variable must be ultimately returned.
+before interrogation. Such a table mutation is isolated in scope to the
+validation step(s) produced by the validation step function call. Using
+\strong{dplyr} code is suggested here since the statements can be translated to
+SQL if necessary. The code is most easily supplied as a one-sided \strong{R}
+formula (using a leading \code{~}). In the formula representation, the \code{.} serves
+as the input data table to be transformed (e.g.,
+\code{~ . \%>\% dplyr::mutate(col_a = col_b + 10)}). Alternatively, a function could
+instead be supplied (e.g.,
+\code{function(x) dplyr::mutate(x, col_a = col_b + 10)}).
 
 Often, we will want to specify \code{actions} for the validation. This argument,
 present in every validation step function, takes a specially-crafted list

--- a/man/col_vals_lte.Rd
+++ b/man/col_vals_lte.Rd
@@ -41,11 +41,9 @@ a pass.}
 
 \item{preconditions}{expressions used for mutating the input table before
 proceeding with the validation. This is ideally as a one-sided R formula
-using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+using a leading \code{~}. In the formula representation, the \code{.} serves as the
 input data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-object must be ultimately returned.}
+\code{~ . \%>\% dplyr::mutate(col = col + 10)}.}
 
 \item{actions}{A list containing threshold levels so that the validation step
 can react accordingly when exceeding the set levels. This is to be created
@@ -107,15 +105,15 @@ unit should be counted as a \emph{pass} or a \emph{fail}. The default of
 test units.
 
 Having table \code{preconditions} means \strong{pointblank} will mutate the table just
-before interrogation. It's isolated to the validation steps produced by this
-validation step function. Using \strong{dplyr} code is suggested here since the
-statements can be translated to SQL if necessary. The code is to be supplied
-as a one-sided \strong{R} formula (using a leading \code{~}). In the formula
-representation, the obligatory \code{tbl} variable will serve as the input
-data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col_a = col_b + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-variable must be ultimately returned.
+before interrogation. Such a table mutation is isolated in scope to the
+validation step(s) produced by the validation step function call. Using
+\strong{dplyr} code is suggested here since the statements can be translated to
+SQL if necessary. The code is most easily supplied as a one-sided \strong{R}
+formula (using a leading \code{~}). In the formula representation, the \code{.} serves
+as the input data table to be transformed (e.g.,
+\code{~ . \%>\% dplyr::mutate(col_a = col_b + 10)}). Alternatively, a function could
+instead be supplied (e.g.,
+\code{function(x) dplyr::mutate(x, col_a = col_b + 10)}).
 
 Often, we will want to specify \code{actions} for the validation. This argument,
 present in every validation step function, takes a specially-crafted list
@@ -158,9 +156,8 @@ tbl <-
 agent <-
   create_agent(tbl = tbl) \%>\%
   col_vals_lte(vars(a_b), 10,
-    preconditions = ~ {
-      tbl \%>\% dplyr::mutate(a_b = a + b)
-    }
+    preconditions = ~
+      . \%>\% dplyr::mutate(a_b = a + b)
   ) \%>\%
   interrogate()
 

--- a/man/col_vals_not_between.Rd
+++ b/man/col_vals_not_between.Rd
@@ -49,11 +49,9 @@ a pass.}
 
 \item{preconditions}{expressions used for mutating the input table before
 proceeding with the validation. This is ideally as a one-sided R formula
-using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+using a leading \code{~}. In the formula representation, the \code{.} serves as the
 input data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-object must be ultimately returned.}
+\code{~ . \%>\% dplyr::mutate(col = col + 10)}.}
 
 \item{actions}{A list containing threshold levels so that the validation step
 can react accordingly when exceeding the set levels. This is to be created
@@ -121,15 +119,15 @@ unit should be counted as a \emph{pass} or a \emph{fail}. The default of
 test units.
 
 Having table \code{preconditions} means \strong{pointblank} will mutate the table just
-before interrogation. It's isolated to the validation steps produced by this
-validation step function. Using \strong{dplyr} code is suggested here since the
-statements can be translated to SQL if necessary. The code is to be supplied
-as a one-sided \strong{R} formula (using a leading \code{~}). In the formula
-representation, the obligatory \code{tbl} variable will serve as the input
-data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col_a = col_b + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-variable must be ultimately returned.
+before interrogation. Such a table mutation is isolated in scope to the
+validation step(s) produced by the validation step function call. Using
+\strong{dplyr} code is suggested here since the statements can be translated to
+SQL if necessary. The code is most easily supplied as a one-sided \strong{R}
+formula (using a leading \code{~}). In the formula representation, the \code{.} serves
+as the input data table to be transformed (e.g.,
+\code{~ . \%>\% dplyr::mutate(col_a = col_b + 10)}). Alternatively, a function could
+instead be supplied (e.g.,
+\code{function(x) dplyr::mutate(x, col_a = col_b + 10)}).
 
 Often, we will want to specify \code{actions} for the validation. This argument,
 present in every validation step function, takes a specially-crafted list

--- a/man/col_vals_not_equal.Rd
+++ b/man/col_vals_not_equal.Rd
@@ -40,11 +40,9 @@ a pass.}
 
 \item{preconditions}{expressions used for mutating the input table before
 proceeding with the validation. This is ideally as a one-sided R formula
-using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+using a leading \code{~}. In the formula representation, the \code{.} serves as the
 input data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-object must be ultimately returned.}
+\code{~ . \%>\% dplyr::mutate(col = col + 10)}.}
 
 \item{actions}{A list containing threshold levels so that the validation step
 can react accordingly when exceeding the set levels. This is to be created
@@ -104,15 +102,15 @@ unit should be counted as a \emph{pass} or a \emph{fail}. The default of
 test units.
 
 Having table \code{preconditions} means \strong{pointblank} will mutate the table just
-before interrogation. It's isolated to the validation steps produced by this
-validation step function. Using \strong{dplyr} code is suggested here since the
-statements can be translated to SQL if necessary. The code is to be supplied
-as a one-sided \strong{R} formula (using a leading \code{~}). In the formula
-representation, the obligatory \code{tbl} variable will serve as the input
-data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col_a = col_b + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-variable must be ultimately returned.
+before interrogation. Such a table mutation is isolated in scope to the
+validation step(s) produced by the validation step function call. Using
+\strong{dplyr} code is suggested here since the statements can be translated to
+SQL if necessary. The code is most easily supplied as a one-sided \strong{R}
+formula (using a leading \code{~}). In the formula representation, the \code{.} serves
+as the input data table to be transformed (e.g.,
+\code{~ . \%>\% dplyr::mutate(col_a = col_b + 10)}). Alternatively, a function could
+instead be supplied (e.g.,
+\code{function(x) dplyr::mutate(x, col_a = col_b + 10)}).
 
 Often, we will want to specify \code{actions} for the validation. This argument,
 present in every validation step function, takes a specially-crafted list
@@ -156,7 +154,7 @@ agent <-
   create_agent(tbl = tbl) \%>\%
   col_vals_not_equal(vars(b), 5,
     preconditions = 
-      ~ tbl \%>\% dplyr::filter(a == 2)
+      ~ . \%>\% dplyr::filter(a == 2)
   ) \%>\%
   interrogate()
 

--- a/man/col_vals_not_in_set.Rd
+++ b/man/col_vals_not_in_set.Rd
@@ -35,11 +35,9 @@ found within this \code{set} will be considered as failing.}
 
 \item{preconditions}{expressions used for mutating the input table before
 proceeding with the validation. This is ideally as a one-sided R formula
-using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+using a leading \code{~}. In the formula representation, the \code{.} serves as the
 input data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-object must be ultimately returned.}
+\code{~ . \%>\% dplyr::mutate(col = col + 10)}.}
 
 \item{actions}{A list containing threshold levels so that the validation step
 can react accordingly when exceeding the set levels. This is to be created
@@ -93,15 +91,15 @@ specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{co
 \code{matches()}, and \code{everything()}.
 
 Having table \code{preconditions} means \strong{pointblank} will mutate the table just
-before interrogation. It's isolated to the validation steps produced by this
-validation step function. Using \strong{dplyr} code is suggested here since the
-statements can be translated to SQL if necessary. The code is to be supplied
-as a one-sided \strong{R} formula (using a leading \code{~}). In the formula
-representation, the obligatory \code{tbl} variable will serve as the input
-data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col_a = col_b + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-variable must be ultimately returned.
+before interrogation. Such a table mutation is isolated in scope to the
+validation step(s) produced by the validation step function call. Using
+\strong{dplyr} code is suggested here since the statements can be translated to
+SQL if necessary. The code is most easily supplied as a one-sided \strong{R}
+formula (using a leading \code{~}). In the formula representation, the \code{.} serves
+as the input data table to be transformed (e.g.,
+\code{~ . \%>\% dplyr::mutate(col_a = col_b + 10)}). Alternatively, a function could
+instead be supplied (e.g.,
+\code{function(x) dplyr::mutate(x, col_a = col_b + 10)}).
 
 Often, we will want to specify \code{actions} for the validation. This argument,
 present in every validation step function, takes a specially-crafted list

--- a/man/col_vals_not_null.Rd
+++ b/man/col_vals_not_null.Rd
@@ -25,11 +25,9 @@ vector) to which this validation should be applied.}
 
 \item{preconditions}{expressions used for mutating the input table before
 proceeding with the validation. This is ideally as a one-sided R formula
-using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+using a leading \code{~}. In the formula representation, the \code{.} serves as the
 input data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-object must be ultimately returned.}
+\code{~ . \%>\% dplyr::mutate(col = col + 10)}.}
 
 \item{actions}{A list containing threshold levels so that the validation step
 can react accordingly when exceeding the set levels. This is to be created
@@ -83,15 +81,15 @@ specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{co
 \code{matches()}, and \code{everything()}.
 
 Having table \code{preconditions} means \strong{pointblank} will mutate the table just
-before interrogation. It's isolated to the validation steps produced by this
-validation step function. Using \strong{dplyr} code is suggested here since the
-statements can be translated to SQL if necessary. The code is to be supplied
-as a one-sided \strong{R} formula (using a leading \code{~}). In the formula
-representation, the obligatory \code{tbl} variable will serve as the input
-data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col_a = col_b + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-variable must be ultimately returned.
+before interrogation. Such a table mutation is isolated in scope to the
+validation step(s) produced by the validation step function call. Using
+\strong{dplyr} code is suggested here since the statements can be translated to
+SQL if necessary. The code is most easily supplied as a one-sided \strong{R}
+formula (using a leading \code{~}). In the formula representation, the \code{.} serves
+as the input data table to be transformed (e.g.,
+\code{~ . \%>\% dplyr::mutate(col_a = col_b + 10)}). Alternatively, a function could
+instead be supplied (e.g.,
+\code{function(x) dplyr::mutate(x, col_a = col_b + 10)}).
 
 Often, we will want to specify \code{actions} for the validation. This argument,
 present in every validation step function, takes a specially-crafted list
@@ -135,7 +133,7 @@ agent <-
   create_agent(tbl = tbl) \%>\%
   col_vals_not_null(vars(a),
     preconditions = 
-      ~ tbl \%>\% dplyr::filter(b == 2)
+      ~ . \%>\% dplyr::filter(b == 2)
   ) \%>\%
   interrogate()
 

--- a/man/col_vals_null.Rd
+++ b/man/col_vals_null.Rd
@@ -25,11 +25,9 @@ vector) to which this validation should be applied.}
 
 \item{preconditions}{expressions used for mutating the input table before
 proceeding with the validation. This is ideally as a one-sided R formula
-using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+using a leading \code{~}. In the formula representation, the \code{.} serves as the
 input data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-object must be ultimately returned.}
+\code{~ . \%>\% dplyr::mutate(col = col + 10)}.}
 
 \item{actions}{A list containing threshold levels so that the validation step
 can react accordingly when exceeding the set levels. This is to be created
@@ -83,15 +81,15 @@ specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{co
 \code{matches()}, and \code{everything()}.
 
 Having table \code{preconditions} means \strong{pointblank} will mutate the table just
-before interrogation. It's isolated to the validation steps produced by this
-validation step function. Using \strong{dplyr} code is suggested here since the
-statements can be translated to SQL if necessary. The code is to be supplied
-as a one-sided \strong{R} formula (using a leading \code{~}). In the formula
-representation, the obligatory \code{tbl} variable will serve as the input
-data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col_a = col_b + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-variable must be ultimately returned.
+before interrogation. Such a table mutation is isolated in scope to the
+validation step(s) produced by the validation step function call. Using
+\strong{dplyr} code is suggested here since the statements can be translated to
+SQL if necessary. The code is most easily supplied as a one-sided \strong{R}
+formula (using a leading \code{~}). In the formula representation, the \code{.} serves
+as the input data table to be transformed (e.g.,
+\code{~ . \%>\% dplyr::mutate(col_a = col_b + 10)}). Alternatively, a function could
+instead be supplied (e.g.,
+\code{function(x) dplyr::mutate(x, col_a = col_b + 10)}).
 
 Often, we will want to specify \code{actions} for the validation. This argument,
 present in every validation step function, takes a specially-crafted list
@@ -135,7 +133,7 @@ agent <-
   create_agent(tbl = tbl) \%>\%
   col_vals_null(vars(a),
     preconditions = 
-      ~ tbl \%>\% dplyr::filter(b >= 5)
+      ~ . \%>\% dplyr::filter(b >= 5)
   ) \%>\%
   interrogate()
 

--- a/man/col_vals_regex.Rd
+++ b/man/col_vals_regex.Rd
@@ -40,11 +40,9 @@ a pass.}
 
 \item{preconditions}{expressions used for mutating the input table before
 proceeding with the validation. This is ideally as a one-sided R formula
-using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+using a leading \code{~}. In the formula representation, the \code{.} serves as the
 input data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-object must be ultimately returned.}
+\code{~ . \%>\% dplyr::mutate(col = col + 10)}.}
 
 \item{actions}{A list containing threshold levels so that the validation step
 can react accordingly when exceeding the set levels. This is to be created
@@ -103,15 +101,15 @@ unit should be counted as a \emph{pass} or a \emph{fail}. The default of
 test units.
 
 Having table \code{preconditions} means \strong{pointblank} will mutate the table just
-before interrogation. It's isolated to the validation steps produced by this
-validation step function. Using \strong{dplyr} code is suggested here since the
-statements can be translated to SQL if necessary. The code is to be supplied
-as a one-sided \strong{R} formula (using a leading \code{~}). In the formula
-representation, the obligatory \code{tbl} variable will serve as the input
-data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col_a = col_b + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-variable must be ultimately returned.
+before interrogation. Such a table mutation is isolated in scope to the
+validation step(s) produced by the validation step function call. Using
+\strong{dplyr} code is suggested here since the statements can be translated to
+SQL if necessary. The code is most easily supplied as a one-sided \strong{R}
+formula (using a leading \code{~}). In the formula representation, the \code{.} serves
+as the input data table to be transformed (e.g.,
+\code{~ . \%>\% dplyr::mutate(col_a = col_b + 10)}). Alternatively, a function could
+instead be supplied (e.g.,
+\code{function(x) dplyr::mutate(x, col_a = col_b + 10)}).
 
 Often, we will want to specify \code{actions} for the validation. This argument,
 present in every validation step function, takes a specially-crafted list

--- a/man/conjointly.Rd
+++ b/man/conjointly.Rd
@@ -36,11 +36,9 @@ those with the naming pattern \verb{col_vals_*()}. An example of this is
 
 \item{preconditions}{expressions used for mutating the input table before
 proceeding with the validation. This is ideally as a one-sided R formula
-using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+using a leading \code{~}. In the formula representation, the \code{.} serves as the
 input data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-object must be ultimately returned.}
+\code{~ . \%>\% dplyr::mutate(col = col + 10)}.}
 
 \item{actions}{A list containing threshold levels so that the validation step
 can react accordingly when exceeding the set levels. This is to be created
@@ -99,15 +97,15 @@ are: \code{starts_with()}, \code{ends_with()}, \code{contains()}, \code{matches(
 \code{everything()}.
 
 Having table \code{preconditions} means \strong{pointblank} will mutate the table just
-before interrogation. It's isolated to the validation steps produced by this
-validation step function. Using \strong{dplyr} code is suggested here since the
-statements can be translated to SQL if necessary. The code is to be supplied
-as a one-sided \strong{R} formula (using a leading \code{~}). In the formula
-representation, the obligatory \code{tbl} variable will serve as the input
-data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col_a = col_b + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-variable must be ultimately returned.
+before interrogation. Such a table mutation is isolated in scope to the
+validation step(s) produced by the validation step function call. Using
+\strong{dplyr} code is suggested here since the statements can be translated to
+SQL if necessary. The code is most easily supplied as a one-sided \strong{R}
+formula (using a leading \code{~}). In the formula representation, the \code{.} serves
+as the input data table to be transformed (e.g.,
+\code{~ . \%>\% dplyr::mutate(col_a = col_b + 10)}). Alternatively, a function could
+instead be supplied (e.g.,
+\code{function(x) dplyr::mutate(x, col_a = col_b + 10)}).
 
 Often, we will want to specify \code{actions} for the validation. This argument,
 present in every validation step function, takes a specially-crafted list

--- a/man/rows_distinct.Rd
+++ b/man/rows_distinct.Rd
@@ -30,11 +30,9 @@ vector) to which this validation should be applied.}
 
 \item{preconditions}{expressions used for mutating the input table before
 proceeding with the validation. This is ideally as a one-sided R formula
-using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+using a leading \code{~}. In the formula representation, the \code{.} serves as the
 input data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-object must be ultimately returned.}
+\code{~ . \%>\% dplyr::mutate(col = col + 10)}.}
 
 \item{actions}{A list containing threshold levels so that the validation step
 can react accordingly when exceeding the set levels. This is to be created
@@ -86,15 +84,15 @@ the following \strong{tidyselect} helper functions: \code{starts_with()},
 \code{ends_with()}, \code{contains()}, \code{matches()}, and \code{everything()}.
 
 Having table \code{preconditions} means \strong{pointblank} will mutate the table just
-before interrogation. It's isolated to the validation steps produced by this
-validation step function. Using \strong{dplyr} code is suggested here since the
-statements can be translated to SQL if necessary. The code is to be supplied
-as a one-sided \strong{R} formula (using a leading \code{~}). In the formula
-representation, the obligatory \code{tbl} variable will serve as the input
-data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col_a = col_b + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-variable must be ultimately returned.
+before interrogation. Such a table mutation is isolated in scope to the
+validation step(s) produced by the validation step function call. Using
+\strong{dplyr} code is suggested here since the statements can be translated to
+SQL if necessary. The code is most easily supplied as a one-sided \strong{R}
+formula (using a leading \code{~}). In the formula representation, the \code{.} serves
+as the input data table to be transformed (e.g.,
+\code{~ . \%>\% dplyr::mutate(col_a = col_b + 10)}). Alternatively, a function could
+instead be supplied (e.g.,
+\code{function(x) dplyr::mutate(x, col_a = col_b + 10)}).
 
 Often, we will want to specify \code{actions} for the validation. This argument,
 present in every validation step function, takes a specially-crafted list

--- a/man/rows_not_duplicated.Rd
+++ b/man/rows_not_duplicated.Rd
@@ -21,11 +21,9 @@ vector) to which this validation should be applied.}
 
 \item{preconditions}{expressions used for mutating the input table before
 proceeding with the validation. This is ideally as a one-sided R formula
-using a leading \code{~}. In the formula representation, the \code{tbl} serves as the
+using a leading \code{~}. In the formula representation, the \code{.} serves as the
 input data table to be transformed (e.g.,
-\code{~ tbl \%>\% dplyr::mutate(col = col + 10)}. A series of expressions can be
-used by enclosing the set of statements with \code{{ }} but note that the \code{tbl}
-object must be ultimately returned.}
+\code{~ . \%>\% dplyr::mutate(col = col + 10)}.}
 
 \item{brief}{An optional, text-based description for the validation step.}
 

--- a/tests/manual_tests/tests_preconditions.R
+++ b/tests/manual_tests/tests_preconditions.R
@@ -5,8 +5,8 @@ al <- action_levels(warn_at = 0.1, stop_at = 0.2)
 
 agent <-
   create_agent(tbl = small_table, actions = al, reporting_lang = "it") %>%
-  col_vals_gt(vars(g), 100, preconditions = ~tbl %>% dplyr::mutate(g = a + 95)) %>%
-  col_vals_lt(vars(c), vars(d), preconditions = ~tbl %>% dplyr::mutate(d = d - 200)) %>%
+  col_vals_gt(vars(g), 100, preconditions = ~ . %>% dplyr::mutate(g = a + 95)) %>%
+  col_vals_lt(vars(c), vars(d), preconditions = ~ . %>% dplyr::mutate(d = d - 200)) %>%
   col_vals_in_set(vars(f), c("low", "mid", "high", "higher")) %>%
   col_vals_not_in_set(vars(f), LETTERS[1:8]) %>%
   col_vals_between(vars(c), 0, 10) %>%

--- a/tests/manual_tests/tests_sqlite.R
+++ b/tests/manual_tests/tests_sqlite.R
@@ -20,14 +20,14 @@ agent <-
   create_agent(tbl = tbl_sqlite) %>%
   col_vals_gt(vars(d), 100) %>%
   col_vals_gte(vars(c), 2, na_pass = TRUE) %>%
-  col_vals_equal(vars(e), 1, preconditions = ~tbl %>% dplyr::filter(e == 1)) %>%
+  col_vals_equal(vars(e), 1, preconditions = ~ . %>% dplyr::filter(e == 1)) %>%
   col_vals_not_equal(vars(e), 0) %>%
-  col_vals_lt(vars(e), 10, preconditions = ~tbl %>% dplyr::mutate(e = e + 9)) %>%
+  col_vals_lt(vars(e), 10, preconditions = ~ . %>% dplyr::mutate(e = e + 9)) %>%
   col_vals_in_set(vars(f), c("low", "medium", "high")) %>%
   col_vals_not_in_set(vars(e), 3:5) %>%
   col_vals_between(vars(d), 0, 10000) %>%
   col_vals_not_between(vars(d), 15000, 20000) %>%
-  col_vals_null(vars(c), preconditions = ~tbl %>% dplyr::filter(b == "5-jdo-903")) %>%
+  col_vals_null(vars(c), preconditions = ~ . %>% dplyr::filter(b == "5-jdo-903")) %>%
   col_is_character(vars(b)) %>%
   col_is_numeric(vars(d, e)) %>%
   col_is_integer(vars(e)) %>%

--- a/tests/testthat/test-interrogate_conjointly.R
+++ b/tests/testthat/test-interrogate_conjointly.R
@@ -66,7 +66,7 @@ test_that("Interrogating conjointly with an agent yields the correct results", {
       ~ col_vals_gt(., columns = vars(a), value = 4),
       ~ col_vals_lt(., columns = vars(b), value = 10),
       ~ col_vals_not_null(., columns = vars(c)),
-      preconditions = ~ tbl %>% head(2)
+      preconditions = ~ . %>% head(2)
     ) %>%
     interrogate()
   
@@ -107,7 +107,7 @@ test_that("Interrogating conjointly with an agent yields the correct results", {
     expect_equal(c("~", "col_vals_not_null(., columns = vars(c))"))
   
   validation$validation_set[["preconditions"]] %>% unlist() %>% .[[1]] %>% as.character() %>%
-    expect_equal(c("~", "tbl %>% head(2)"))
+    expect_equal(c("~", ". %>% head(2)"))
   
   # Use a single validation step function in a single
   # `conjointly()` validation step, then, `interrogate()`

--- a/tests/testthat/test-interrogate_simple.R
+++ b/tests/testthat/test-interrogate_simple.R
@@ -373,7 +373,7 @@ test_that("Interrogating simply returns the expected results", {
     col_vals_not_between(
       columns = vars(d),
       left = 3000, right = 10000,
-      preconditions = ~ tbl %>% dplyr::filter(date > "2016-01-20"),
+      preconditions = ~ . %>% dplyr::filter(date > "2016-01-20"),
       actions = action_levels(warn_at = 1)
     )
   
@@ -387,7 +387,7 @@ test_that("Interrogating simply returns the expected results", {
       col_vals_not_between(
         columns = vars(d),
         left = 0, right = 3000,
-        preconditions = ~ tbl %>% dplyr::filter(date > "2016-01-20"),
+        preconditions = ~ . %>% dplyr::filter(date > "2016-01-20"),
         actions = action_levels(warn_at = 1)
       )
   )
@@ -404,7 +404,7 @@ test_that("Interrogating simply returns the expected results", {
       col_vals_not_between(
         columns = vars(d),
         left = 0, right = 3000,
-        preconditions = ~ tbl %>% dplyr::filter(date > "2016-01-20"),
+        preconditions = ~ . %>% dplyr::filter(date > "2016-01-20"),
         actions = action_levels(stop_at = 1)
       )
   )
@@ -605,7 +605,7 @@ test_that("Interrogating simply returns the expected results", {
     tbl %>%
     col_vals_null(
       columns = vars(c),
-      preconditions = ~ tbl %>% dplyr::filter(date == "2016-01-06")
+      preconditions = ~ . %>% dplyr::filter(date == "2016-01-06")
     )
   
   # Expect that `tbl_result` is equivalent to `tbl`
@@ -617,7 +617,7 @@ test_that("Interrogating simply returns the expected results", {
       tbl %>%
       col_vals_null(
         columns = vars(c),
-        preconditions = ~ tbl %>% dplyr::filter(date != "2016-01-06"),
+        preconditions = ~ . %>% dplyr::filter(date != "2016-01-06"),
         actions = action_levels(warn_at = 1)
       )
   )
@@ -633,7 +633,7 @@ test_that("Interrogating simply returns the expected results", {
       tbl %>%
       col_vals_null(
         columns = vars(c),
-        preconditions = ~ tbl %>% dplyr::filter(date != "2016-01-06"),
+        preconditions = ~ . %>% dplyr::filter(date != "2016-01-06"),
         actions = action_levels(stop_at = 1)
       )
   )

--- a/tests/testthat/test-interrogate_with_agent.R
+++ b/tests/testthat/test-interrogate_with_agent.R
@@ -248,7 +248,7 @@ test_that("Interrogating for valid row values", {
     col_vals_between(
       columns = vars(d),
       left = 0, right = 5000,
-      preconditions = ~ tbl %>% dplyr::filter(date > "2016-01-04")
+      preconditions = ~ . %>% dplyr::filter(date > "2016-01-04")
     ) %>%
     interrogate()
   
@@ -349,7 +349,7 @@ test_that("Interrogating for valid row values", {
     col_vals_not_between(
       columns = vars(d),
       left = 500, right = 1000,
-      preconditions = ~ tbl %>% dplyr::filter(date > "2016-01-04")
+      preconditions = ~ . %>% dplyr::filter(date > "2016-01-04")
     ) %>%
     interrogate()
   
@@ -395,7 +395,7 @@ test_that("Interrogating for valid row values", {
     col_vals_equal(
       columns = vars(d),
       value = 283.94,
-      preconditions = ~ tbl %>% dplyr::filter(date > "2016-01-04")
+      preconditions = ~ . %>% dplyr::filter(date > "2016-01-04")
     ) %>%
     interrogate()
   
@@ -464,7 +464,7 @@ test_that("Interrogating for valid row values", {
     col_vals_not_equal(
       columns = vars(d),
       value = 283.94,
-      preconditions = ~ tbl %>% dplyr::filter(date > "2016-01-04")
+      preconditions = ~ . %>% dplyr::filter(date > "2016-01-04")
     ) %>%
     interrogate()
   
@@ -511,7 +511,7 @@ test_that("Interrogating for valid row values", {
       create_agent(tbl = small_table) %>%
       col_vals_gt(
         columns = vars(date_time), value = vars(date),
-        preconditions = ~ tbl %>% dplyr::mutate(date = lubridate::as_datetime(date))) %>%
+        preconditions = ~ . %>% dplyr::mutate(date = lubridate::as_datetime(date))) %>%
       interrogate()
   )
   
@@ -558,7 +558,7 @@ test_that("Interrogating for valid row values", {
   validation <-
     create_agent(tbl = small_table) %>%
     rows_distinct(
-      preconditions = ~ tbl %>% dplyr::filter(date != "2016-01-20")
+      preconditions = ~ . %>% dplyr::filter(date != "2016-01-20")
     ) %>%
     interrogate()
   
@@ -690,7 +690,7 @@ test_that("Interrogating for valid row values", {
     create_agent(tbl = small_table) %>%
     col_vals_not_null(
       columns = vars(c),
-      preconditions = ~ tbl %>%
+      preconditions = ~ . %>%
         dplyr::filter(date > "2016-01-06" & date < "2016-01-30")
     ) %>%
     interrogate()
@@ -736,7 +736,7 @@ test_that("Interrogating for valid row values", {
     create_agent(tbl = small_table) %>%
     col_vals_null(
       columns = vars(c),
-      preconditions = ~ tbl %>%
+      preconditions = ~ . %>%
         dplyr::filter(date == '2016-01-06' | date == '2016-01-30')
     ) %>%
     interrogate()
@@ -786,7 +786,7 @@ test_that("Interrogating for valid row values", {
     col_vals_regex(
       columns = vars(f),
       regex = "[a-z]{3}",
-      preconditions = ~ tbl %>% dplyr::filter(f != "high")
+      preconditions = ~ . %>% dplyr::filter(f != "high")
     ) %>%
     interrogate()
   

--- a/tests/testthat/test-interrogate_with_agent_db.R
+++ b/tests/testthat/test-interrogate_with_agent_db.R
@@ -186,7 +186,7 @@ test_that("Interrogating for valid row values", {
   #   col_vals_between(
   #     columns = vars(d),
   #     left = 0, right = 5000,
-  #     preconditions = ~ tbl %>% dplyr::filter(date > 16805)
+  #     preconditions = ~ . %>% dplyr::filter(date > 16805)
   #   ) %>%
   #   interrogate()
   # 
@@ -287,7 +287,7 @@ test_that("Interrogating for valid row values", {
   #   col_vals_not_between(
   #     columns = vars(d),
   #     left = 500, right = 1000,
-  #     preconditions = ~ tbl %>% dplyr::filter(date > 16805)
+  #     preconditions = ~ . %>% dplyr::filter(date > 16805)
   #   ) %>%
   #   interrogate()
   # 
@@ -333,7 +333,7 @@ test_that("Interrogating for valid row values", {
     col_vals_equal(
       columns = vars(d),
       value = 283.94,
-      preconditions = ~ tbl %>% dplyr::filter(date > 16805)
+      preconditions = ~ . %>% dplyr::filter(date > 16805)
     ) %>%
     interrogate()
   
@@ -379,7 +379,7 @@ test_that("Interrogating for valid row values", {
     col_vals_not_equal(
       columns = vars(d),
       value = 283.94,
-      preconditions = ~ tbl %>% dplyr::filter(date > 16805)
+      preconditions = ~ . %>% dplyr::filter(date > 16805)
     ) %>%
     interrogate()
   
@@ -423,7 +423,7 @@ test_that("Interrogating for valid row values", {
   validation <-
     create_agent(tbl = small_table) %>%
     rows_distinct(
-      preconditions = ~ tbl %>% dplyr::filter(date != 16820)
+      preconditions = ~ . %>% dplyr::filter(date != 16820)
     ) %>%
     interrogate()
   
@@ -555,7 +555,7 @@ test_that("Interrogating for valid row values", {
     create_agent(tbl = small_table) %>%
     col_vals_not_null(
       columns = vars(c),
-      preconditions = ~ tbl %>%
+      preconditions = ~ . %>%
         dplyr::filter(date > 16809 & date < 16820)
     ) %>%
     interrogate()
@@ -601,7 +601,7 @@ test_that("Interrogating for valid row values", {
     create_agent(tbl = small_table) %>%
     col_vals_null(
       columns = vars(c),
-      preconditions = ~ tbl %>%
+      preconditions = ~ . %>%
         dplyr::filter(date == 16806 | date == 16830)
     ) %>%
     interrogate()

--- a/tests/testthat/test-x_list.R
+++ b/tests/testthat/test-x_list.R
@@ -4,8 +4,8 @@ al <- action_levels(warn_at = 0.1, stop_at = 0.2)
 
 agent <-
   create_agent(tbl = small_table, actions = al) %>%
-  col_vals_gt(vars(g), 100, preconditions = ~tbl %>% dplyr::mutate(g = a + 95)) %>%
-  col_vals_lt(vars(c), vars(d), preconditions = ~tbl %>% dplyr::mutate(d = d - 200)) %>%
+  col_vals_gt(vars(g), 100, preconditions = ~ . %>% dplyr::mutate(g = a + 95)) %>%
+  col_vals_lt(vars(c), vars(d), preconditions = ~ . %>% dplyr::mutate(d = d - 200)) %>%
   col_vals_in_set(vars(f), c("low", "mid", "high", "higher"))
 
 test_that("An x-list for a step is structurally correct", {
@@ -56,7 +56,7 @@ test_that("An x-list for a step is structurally correct", {
     x_list_before$briefs,
     paste0(
       "Expect that values in `g` (computed column) should be > `100`. ",
-      "Precondition applied: `tbl %>% dplyr::mutate(g = a + 95)`."
+      "Precondition applied: `. %>% dplyr::mutate(g = a + 95)`."
       )
   )
   expect_is(x_list_before$eval_error, "logical")
@@ -130,7 +130,7 @@ test_that("An x-list for a step is structurally correct", {
     x_list_after$briefs, 
     paste0(
       "Expect that values in `g` (computed column) should be > `100`. ",
-      "Precondition applied: `tbl %>% dplyr::mutate(g = a + 95)`."
+      "Precondition applied: `. %>% dplyr::mutate(g = a + 95)`."
     )
   )
   expect_is(x_list_after$eval_error, "logical")
@@ -213,11 +213,11 @@ test_that("A complete x-list is structurally correct", {
     c(
       paste0(
         "Expect that values in `g` (computed column) should be > `100`. ",
-        "Precondition applied: `tbl %>% dplyr::mutate(g = a + 95)`."
+        "Precondition applied: `. %>% dplyr::mutate(g = a + 95)`."
       ),
       paste0(
         "Expect that values in `c` should be < `d`. Precondition applied: ",
-        "`tbl %>% dplyr::mutate(d = d - 200)`."
+        "`. %>% dplyr::mutate(d = d - 200)`."
       ),
       paste0(
         "Expect that values in `f` should be in the set of `low`, `mid`, ",
@@ -307,11 +307,11 @@ test_that("A complete x-list is structurally correct", {
     c(
       paste0(
         "Expect that values in `g` (computed column) should be > `100`. ",
-        "Precondition applied: `tbl %>% dplyr::mutate(g = a + 95)`."
+        "Precondition applied: `. %>% dplyr::mutate(g = a + 95)`."
       ),
       paste0(
         "Expect that values in `c` should be < `d`. Precondition applied: ",
-        "`tbl %>% dplyr::mutate(d = d - 200)`."
+        "`. %>% dplyr::mutate(d = d - 200)`."
       ),
       paste0(
         "Expect that values in `f` should be in the set of `low`, `mid`, ",


### PR DESCRIPTION
This change allows for both formula and function values for `preconditions`. Internal utility functions were generated for evaluating both inputs on target tables. Documentation was modified and testthat tests were revised.