### PR TITLE
Quiet the interrogation if non-interactive; add `knit_print` method

### DIFF
--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -63,7 +63,7 @@ interrogate <- function(agent,
   # Add the starting time to the `agent` object
   agent$time <- Sys.time()
   
-  if (agent$name == "::QUIET::") {
+  if (agent$name == "::QUIET::" || !interactive()) {
     quiet <- TRUE
   } else {
     quiet <- FALSE

--- a/R/print.R
+++ b/R/print.R
@@ -3,15 +3,35 @@
 #' This function will allow the agent to print a useful report.
 #' 
 #' @param x An agent object of class `ptblank_agent`.
+#' @param view The value for `print()`s `browse` argument.
 #' @param ... Any additional parameters.
 #' 
 #' @keywords internal
 #' @export
-print.ptblank_agent <- function(x, ...) {
+print.ptblank_agent <- function(x, view = interactive(), ...) {
   
   # nocov start 
   
-  print(get_agent_report(x))
+  print(get_agent_report(x), view = view, ...)
+  
+  # nocov end 
+}
+
+#' Knit print the agent information table
+#'
+#' This facilitates printing of the agent report table within a knitr code chunk.
+#'
+#' @param x An object of class `ptblank_agent`.
+#' @param ... Any additional parameters.
+#'
+#' @keywords internal
+#' @noRd
+knit_print.ptblank_agent <- function(x, ...) {
+  
+  # nocov start 
+
+  # Use `knit_print()` to print in a code chunk
+  knitr::knit_print(get_agent_report(x), ...)
   
   # nocov end 
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,30 @@
+#nocov start
+
+register_s3_method <- function(pkg, generic, class, fun = NULL) {
+  stopifnot(is.character(pkg), length(pkg) == 1)
+  stopifnot(is.character(generic), length(generic) == 1)
+  stopifnot(is.character(class), length(class) == 1)
+  
+  if (is.null(fun)) {
+    fun <- get(paste0(generic, ".", class), envir = parent.frame())
+  } else {
+    stopifnot(is.function(fun))
+  }
+  
+  if (pkg %in% loadedNamespaces()) {
+    registerS3method(generic, class, fun, envir = asNamespace(pkg))
+  }
+  
+  # Always register hook in case package is later unloaded & reloaded
+  setHook(
+    packageEvent(pkg, "onLoad"),
+    function(...) {
+      registerS3method(generic, class, fun, envir = asNamespace(pkg))
+    }
+  )
+}
+
+
 utils::globalVariables(
   c(
     ".",
@@ -62,3 +89,12 @@ utils::globalVariables(
     "x"
   )
 )
+
+.onLoad <- function(libname, pkgname, ...) {
+  
+  register_s3_method("knitr", "knit_print", "ptblank_agent")
+  
+  invisible()
+}
+
+#nocov end

--- a/README.Rmd
+++ b/README.Rmd
@@ -101,7 +101,7 @@ Error: The validation (`col_vals_lt()`) meets or exceeds the stop threshold
  * VIOLATION: Expect that values in `c` (computed column) should be < `12`. Precondition applied: `. %>% dplyr::mutate(c = a + b)`.
 ```
 
-We can downgrade this to a warning with the `warn_on_fail()` helper function (and assigning to `actions`). In this way, the data will be returned, but warnings will appear.
+We can downgrade this to a warning with the `warn_on_fail()` helper function (assigning to `actions`). In this way, the data will be returned, but warnings will appear.
 
 ```{r example_workflow_two_warning, eval=FALSE}
 # This `warn_on_fail()` is a nice wrapper for

--- a/README.md
+++ b/README.md
@@ -80,13 +80,6 @@ agent <-
   interrogate()
 ```
 
-    #> 
-    #> ── Interrogation Started - there are 2 steps ───────────────────────
-    #> ✓ Step 1: OK.
-    #> ! Step 2: WARNING condition met.
-    #> 
-    #> ── Interrogation Completed ─────────────────────────────────────────
-
 Because an *agent* was used, we can get a report from it.
 
 ``` r
@@ -114,7 +107,7 @@ dplyr::tibble(
      * VIOLATION: Expect that values in `c` (computed column) should be < `12`. Precondition applied: `. %>% dplyr::mutate(c = a + b)`.
 
 We can downgrade this to a warning with the `warn_on_fail()` helper
-function (and assigning to `actions`). In this way, the data will be
+function (assigning to `actions`). In this way, the data will be
 returned, but warnings will appear.
 
 ``` r

--- a/man/print.ptblank_agent.Rd
+++ b/man/print.ptblank_agent.Rd
@@ -4,10 +4,12 @@
 \alias{print.ptblank_agent}
 \title{Print the agent information to the console}
 \usage{
-\method{print}{ptblank_agent}(x, ...)
+\method{print}{ptblank_agent}(x, view = interactive(), ...)
 }
 \arguments{
 \item{x}{An agent object of class \code{ptblank_agent}.}
+
+\item{view}{The value for \code{print()}s \code{browse} argument.}
 
 \item{...}{Any additional parameters.}
 }


### PR DESCRIPTION
The changes in this PR make it possible to add agent-based data validations inside of an R Markdown document. The status messages are automatically quieted and the resulting agent report table is now nicely printed in the chunk output.