### PR TITLE
Improve the `col_schema_match()` & `expect_col_schema_match()` functions

### DIFF
--- a/man/col_schema_match.Rd
+++ b/man/col_schema_match.Rd
@@ -5,9 +5,23 @@
 \alias{expect_col_schema_match}
 \title{Do columns in the table (and their types) match a predefined schema?}
 \usage{
-col_schema_match(x, schema, actions = NULL, brief = NULL, active = TRUE)
+col_schema_match(
+  x,
+  schema,
+  complete = TRUE,
+  in_order = TRUE,
+  actions = NULL,
+  brief = NULL,
+  active = TRUE
+)
 
-expect_col_schema_match(object, schema, threshold = 1)
+expect_col_schema_match(
+  object,
+  schema,
+  complete = TRUE,
+  in_order = TRUE,
+  threshold = 1
+)
 }
 \arguments{
 \item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
@@ -15,6 +29,17 @@ class \code{ptblank_agent} that can be created with \code{\link[=create_agent]{c
 
 \item{schema}{A table schema of type \code{col_schema} which can be generated
 using the \code{\link[=col_schema]{col_schema()}} function.}
+
+\item{complete}{A requirement to account for all table columns in the
+\code{schema}. By default, this is \code{TRUE} and so that all column names in the
+target table must be present in the schema object. This restriction can be
+relaxed by using \code{FALSE}, where we can provide a subset of table columns in
+the schema.}
+
+\item{in_order}{A stringent requirement for enforcing the order of columns in
+the provided \code{schema}. By default, this is \code{TRUE} and the order of columns
+in both the schema and the target table must match. By setting to \code{FALSE},
+this strict order requirement is removed.}
 
 \item{actions}{A list containing threshold levels so that the validation step
 can react accordingly when exceeding the set levels. This is to be created
@@ -57,11 +82,12 @@ validation step function can be used directly on a data table or with an
 expectation function can only be used with a data table. The types of data
 tables that can be used include data frames, tibbles, and even database
 tables of \code{tbl_dbi} class. The validation step or expectation operates over a
-single test unit, which is whether the schema exactly matches that of the
-table. If the target table is a \code{tbl_dbi} object, we can choose to validate
-the column schema that is based on R column types (e.g., \code{"numeric"},
+single test unit, which is whether the schema matches that of the table
+(within the constraints enforced by the \code{complete} and \code{in_order} options).
+If the target table is a \code{tbl_dbi} object, we can choose to validate the
+column schema that is based on R column types (e.g., \code{"numeric"},
 \code{"character"}, etc.), or, SQL column types (e.g., \code{"double"}, \code{"varchar"},
-etc.). That option is defined in the \code{\link[=col_schema]{col_schema()}} function (with the
+etc.). That option is defined in the \code{\link[=col_schema]{col_schema()}} function (it is the
 \code{.db_col_types} argument).
 }
 \details{

--- a/tests/testthat/test-col_schema.R
+++ b/tests/testthat/test-col_schema.R
@@ -1,0 +1,238 @@
+tbl <- 
+  dplyr::tibble(
+    a = 1:5,
+    b = letters[1:5],
+    c = c(3.5, 8.3, 6.7, 9.1, NA_real_)
+  )
+
+test_that("`col_schema_match()` works properly", {
+  
+  # Incorrect schema (column `d` doesn't exist)
+  schema_obj_i_1 <- col_schema(a = "integer", b = "character", d = "numeric")
+  
+  # Incorrect schema (class in column `c` doesn't match)
+  schema_obj_i_2 <- col_schema(a = "integer", b = "character", c = "character")
+  
+  # Incorrect schema (too many columns in column `c` doesn't match)
+  schema_obj_i_3 <- col_schema(a = "integer", b = "character", c = "numeric", d = "numeric")
+  
+  # Schema with correct classes, complete columns, in order
+  schema_obj_1_1 <- col_schema(a = "integer", b = "character", c = "numeric")
+  
+  # Schema with incorrect classes, complete columns, in order
+  schema_obj_1_1_i <- col_schema(a = "integer_i", b = "character_i", c = "numeric_i")
+  
+  # Schemas with correct classes, complete columns, out of order
+  schema_obj_2_1 <- col_schema(b = "character", c = "numeric", a = "integer")
+  schema_obj_2_2 <- col_schema(c = "numeric", a = "integer", b = "character")
+  
+  # Schemas with incorrect classes, complete columns, out of order
+  schema_obj_2_1_i <- col_schema(b = "character_i", c = "numeric_i", a = "integer_i")
+  schema_obj_2_2_i <- col_schema(c = "numeric_i", a = "integer_i", b = "character_i")
+  
+  # Schemas with correct classes, incomplete columns, in order
+  schema_obj_3_1 <- col_schema(b = "character", c = "numeric")
+  schema_obj_3_2 <- col_schema(a = "integer", b = "character")
+  schema_obj_3_3 <- col_schema(a = "integer", c = "numeric")
+  schema_obj_3_4 <- col_schema(a = "integer")
+  schema_obj_3_5 <- col_schema(b = "character")
+  schema_obj_3_6 <- col_schema(c = "numeric")
+  
+  # Schemas with incorrect classes, incomplete columns, in order
+  schema_obj_3_1_i <- col_schema(b = "character_i", c = "numeric_i")
+  schema_obj_3_2_i <- col_schema(a = "integer_i", b = "character_i")
+  schema_obj_3_3_i <- col_schema(a = "integer_i", c = "numeric_i")
+  schema_obj_3_4_i <- col_schema(a = "integer_i")
+  schema_obj_3_5_i <- col_schema(b = "character_i")
+  schema_obj_3_6_i <- col_schema(c = "numeric_i")
+  
+  # Schemas with correct classes, incomplete columns, out of order
+  schema_obj_4_1 <- col_schema(b = "character", c = "numeric")
+  schema_obj_4_2 <- col_schema(c = "numeric", b = "character")
+  schema_obj_4_3 <- col_schema(a = "integer", b = "character")
+  schema_obj_4_4 <- col_schema(b = "character", a = "integer")
+  schema_obj_4_5 <- col_schema(a = "integer", c = "numeric")
+  schema_obj_4_6 <- col_schema(c = "numeric", a = "integer")
+  
+  # Schemas with incorrect classes, incomplete columns, out of order
+  schema_obj_4_1_i <- col_schema(b = "character_i", c = "numeric_i")
+  schema_obj_4_2_i <- col_schema(c = "numeric_i", b = "character_i")
+  schema_obj_4_3_i <- col_schema(a = "integer_i", b = "character_i")
+  schema_obj_4_4_i <- col_schema(b = "character_i", a = "integer_i")
+  schema_obj_4_5_i <- col_schema(a = "integer_i", c = "numeric_i")
+  schema_obj_4_6_i <- col_schema(c = "integer_i", a = "numeric_i")
+  
+  #
+  # Case I (Default) (`complete = TRUE`, `in_order = TRUE`)
+  #
+  
+  # No error
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_1_1, complete = TRUE, in_order = TRUE))
+  
+  # Error here but not necessarily in other cases
+  expect_error(tbl %>% col_schema_match(schema_obj_1_1_i, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_2_1, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_2_2, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_2_1_i, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_2_2_i, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_1, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_2, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_3, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_4, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_5, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_6, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_1_i, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_2_i, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_3_i, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_4_i, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_5_i, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_6_i, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_1, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_2, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_3, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_4, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_5, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_6, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_1_i, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_2_i, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_3_i, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_4_i, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_5_i, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_6_i, complete = TRUE, in_order = TRUE))
+  
+  # Certain error cases
+  expect_error(tbl %>% col_schema_match(schema_obj_cnc_1, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_cnc_2, complete = TRUE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_cnc_3, complete = TRUE, in_order = TRUE))
+  
+  #
+  # Case II (`complete = TRUE`, `in_order = FALSE`)
+  #
+  
+  # No error
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_2_1, complete = TRUE, in_order = FALSE))
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_2_2, complete = TRUE, in_order = FALSE))
+  
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_1_1, complete = TRUE, in_order = FALSE))
+  
+  
+  # Error here but not necessarily in other cases
+  expect_error(tbl %>% col_schema_match(schema_obj_2_1_i, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_2_2_i, complete = TRUE, in_order = FALSE))
+  
+  expect_error(tbl %>% col_schema_match(schema_obj_3_1, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_2, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_3, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_4, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_5, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_6, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_1_i, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_2_i, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_3_i, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_4_i, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_5_i, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_6_i, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_1, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_2, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_3, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_4, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_5, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_6, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_1_i, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_2_i, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_3_i, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_4_i, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_5_i, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_6_i, complete = TRUE, in_order = FALSE))
+  
+  # Certain error cases
+  expect_error(tbl %>% col_schema_match(schema_obj_cnc_1, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_cnc_2, complete = TRUE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_cnc_3, complete = TRUE, in_order = FALSE))
+  
+  #
+  # Case III (`complete = FALSE`, `in_order = TRUE`)
+  #
+  
+  # No error
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_3_1, complete = FALSE, in_order = TRUE))
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_3_2, complete = FALSE, in_order = TRUE))
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_3_3, complete = FALSE, in_order = TRUE))
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_3_4, complete = FALSE, in_order = TRUE))
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_3_5, complete = FALSE, in_order = TRUE))
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_3_6, complete = FALSE, in_order = TRUE))
+  
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_1_1, complete = FALSE, in_order = TRUE))
+  
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_4_1, complete = FALSE, in_order = TRUE))
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_4_3, complete = FALSE, in_order = TRUE))
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_4_5, complete = FALSE, in_order = TRUE))
+  
+  # Error here but not necessarily in other cases
+  expect_error(tbl %>% col_schema_match(schema_obj_3_1_i, complete = FALSE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_2_i, complete = FALSE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_3_i, complete = FALSE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_4_i, complete = FALSE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_5_i, complete = FALSE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_6_i, complete = FALSE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_2_1, complete = FALSE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_2_2, complete = FALSE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_2, complete = FALSE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_4, complete = FALSE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_6, complete = FALSE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_1_i, complete = FALSE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_2_i, complete = FALSE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_3_i, complete = FALSE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_4_i, complete = FALSE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_5_i, complete = FALSE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_6_i, complete = FALSE, in_order = TRUE))
+  
+  # Certain error cases
+  expect_error(tbl %>% col_schema_match(schema_obj_cnc_1, complete = FALSE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_cnc_2, complete = FALSE, in_order = TRUE))
+  expect_error(tbl %>% col_schema_match(schema_obj_cnc_3, complete = FALSE, in_order = TRUE))
+  
+  # Case IV (`complete = FALSE`, `in_order = FALSE`)
+  
+  # No error
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_4_1, complete = FALSE, in_order = FALSE))
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_4_2, complete = FALSE, in_order = FALSE))
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_4_3, complete = FALSE, in_order = FALSE))
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_4_4, complete = FALSE, in_order = FALSE))
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_4_5, complete = FALSE, in_order = FALSE))
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_4_6, complete = FALSE, in_order = FALSE))
+  
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_1_1, complete = FALSE, in_order = FALSE))
+  
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_2_1, complete = FALSE, in_order = FALSE))
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_2_2, complete = FALSE, in_order = FALSE))
+  
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_3_1, complete = FALSE, in_order = FALSE))
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_3_2, complete = FALSE, in_order = FALSE))
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_3_3, complete = FALSE, in_order = FALSE))
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_3_4, complete = FALSE, in_order = FALSE))
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_3_5, complete = FALSE, in_order = FALSE))
+  expect_error(regexp = NA, tbl %>% col_schema_match(schema_obj_3_6, complete = FALSE, in_order = FALSE))
+  
+  
+  # Error here but not necessarily in other cases
+  expect_error(tbl %>% col_schema_match(schema_obj_2_1_i, complete = FALSE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_2_2_i, complete = FALSE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_1_i, complete = FALSE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_2_i, complete = FALSE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_3_i, complete = FALSE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_4_i, complete = FALSE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_5_i, complete = FALSE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_3_6_i, complete = FALSE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_1_i, complete = FALSE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_2_i, complete = FALSE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_3_i, complete = FALSE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_4_i, complete = FALSE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_5_i, complete = FALSE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_4_6_i, complete = FALSE, in_order = FALSE))
+  
+  # Certain error cases
+  expect_error(tbl %>% col_schema_match(schema_obj_cnc_1, complete = FALSE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_cnc_2, complete = FALSE, in_order = FALSE))
+  expect_error(tbl %>% col_schema_match(schema_obj_cnc_3, complete = FALSE, in_order = FALSE))
+})

--- a/tests/testthat/test-interrogate_with_agent.R
+++ b/tests/testthat/test-interrogate_with_agent.R
@@ -32,8 +32,8 @@ test_that("Interrogating with an agent yields the correct results", {
   schema <- 
     col_schema(
       date_time = c("POSIXct", "POSIXt"), date = "Date", 
-      a = "integer", b = "character", c = "numeric", d = "numeric", 
-      e = "logical", f = "character"
+      a = "integer", b = "character", c = "numeric",
+      d = "numeric", e = "logical", f = "character"
     )
   
   validation <-
@@ -56,6 +56,18 @@ test_that("Interrogating with an agent yields the correct results", {
   
   # Expect a single row in `validation$validation_set`
   expect_equivalent(nrow(validation$validation_set), 1)
+  
+  # Expect an error if a `col_schema` object isn't provided to `schema`
+  expect_error(
+    create_agent(tbl = small_table) %>%
+      col_schema_match(
+        schema = list(
+          date_time = c("POSIXct", "POSIXt"), date = "Date", 
+          a = "integer", b = "character", c = "numeric",
+          d = "numeric",  e = "logical", f = "character"
+        )
+      )
+  )
   
   # Use the `col_exists()` function to create
   # a validation step, then, `interrogate()`

--- a/tests/testthat/test-util_functions.R
+++ b/tests/testthat/test-util_functions.R
@@ -78,4 +78,16 @@ test_that("Utility functions won't fail us", {
   agent %>% get_column_na_pass_at_idx(idx = 1) %>% expect_equal(TRUE)
   agent %>% get_column_na_pass_at_idx(idx = 2) %>% expect_is("logical")
   agent %>% get_column_na_pass_at_idx(idx = 2) %>% expect_equal(FALSE)
+  
+  # Expect that the `create_col_schema_from_names_types()` function generates
+  # named list object from a character vector and an unnamed list
+  col_names <- names(small_table)
+  col_types <- unname(lapply(small_table, class))
+  
+  cs <- create_col_schema_from_names_types(names = col_names, types = col_types)
+  
+  expect_is(cs, "list")
+  expect_equal(names(cs), col_names)
+  expect_equal(unname(cs), col_types)
+  expect_equal(length(cs), length(col_names), length(col_types))
 })


### PR DESCRIPTION
Add the `complete` and `in_order` arguments to the `col_schema_match()` and `expect_col_schema_match()` functions to relax constraints on completeness and ordering of columns defined in a `col_schema` object.

Fixes: #85 