### PR TITLE
Enable the use of `col_vals_regex()` with DB tables. 

### DIFF
--- a/R/col_vals_regex.R
+++ b/R/col_vals_regex.R
@@ -6,10 +6,10 @@
 #' The validation step function can be used directly on a data table or with an
 #' *agent* object (technically, a `ptblank_agent` object) whereas the
 #' expectation and test functions can only be used with a data table. The types
-#' of data tables that can be used include data frames and tibbles. Each
-#' validation step or expectation will operate over the number of test units
-#' that is equal to the number of rows in the table (after any `preconditions`
-#' have been applied).
+#' of data tables that can be used include data frames, tibbles, and even
+#' database tables of `tbl_dbi` class. Each validation step or expectation will
+#' operate over the number of test units that is equal to the number of rows in
+#' the table (after any `preconditions` have been applied).
 #'
 #' If providing multiple column names, the result will be an expansion of
 #' validation steps to that number of column names (e.g., `vars(col_a, col_b)`

--- a/R/col_vals_regex.R
+++ b/R/col_vals_regex.R
@@ -151,14 +151,6 @@ col_vals_regex <- function(x,
                            brief = NULL,
                            active = TRUE) {
   
-  # Stop function if `col_vals_regex()` is to be used with a database table
-  if (is_ptblank_agent(x)) {
-    if (inherits(x$tbl, "tbl_dbi")) {
-      stop("The `col_vals_regex()` step function cannot be used with `tbl_dbi` objects.",
-           call. = FALSE)
-    }
-  }
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
   
@@ -218,12 +210,6 @@ expect_col_vals_regex <- function(object,
                                   preconditions = NULL,
                                   threshold = 1) {
   
-  # Stop function if `expect_col_vals_regex()` is used with a database table
-  if (inherits(object, "tbl_dbi")) {
-    stop("The `expect_col_vals_regex()` expectation function cannot be used with `tbl_dbi` objects.",
-         call. = FALSE)
-  }
-  
   fn_name <- "expect_col_vals_regex"
   
   vs <- 
@@ -278,12 +264,6 @@ test_col_vals_regex <- function(object,
                                 na_pass = FALSE,
                                 preconditions = NULL,
                                 threshold = 1) {
-  
-  # Stop function if `expect_col_vals_regex()` is used with a database table
-  if (inherits(object, "tbl_dbi")) {
-    stop("The `expect_col_vals_regex()` expectation function cannot be used with `tbl_dbi` objects.",
-         call. = FALSE)
-  }
   
   vs <- 
     create_agent(tbl = object, name = "::QUIET::") %>%

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -700,9 +700,9 @@ interrogate_regex <- function(agent, idx, table) {
     }
     
     if (tbl_type == "mysql") {
-      
+
       tbl <- 
-        table %>% 
+        table %>%
         dplyr::mutate(pb_is_good_ = ifelse(!is.na({{ column }}), {{ column }} %REGEXP% regex, NA)) %>%
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           is.na(pb_is_good_) ~ na_pass,

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -24,7 +24,6 @@ register_s3_method <- function(pkg, generic, class, fun = NULL) {
   )
 }
 
-
 utils::globalVariables(
   c(
     ".",
@@ -42,6 +41,7 @@ utils::globalVariables(
     "count",
     "Count",
     "::cut_group::",
+    "data_type",
     "DATA_TYPE",
     "desc",
     "duplicates",
@@ -71,6 +71,7 @@ utils::globalVariables(
     "pb_is_good_",
     "precon",
     "preconditions",
+    "%REGEXP%",
     "S",
     "schema",
     "sd",

--- a/man/col_vals_regex.Rd
+++ b/man/col_vals_regex.Rd
@@ -93,10 +93,10 @@ whether column values in a table correspond to a \code{regex} matching expressio
 The validation step function can be used directly on a data table or with an
 \emph{agent} object (technically, a \code{ptblank_agent} object) whereas the
 expectation and test functions can only be used with a data table. The types
-of data tables that can be used include data frames and tibbles. Each
-validation step or expectation will operate over the number of test units
-that is equal to the number of rows in the table (after any \code{preconditions}
-have been applied).
+of data tables that can be used include data frames, tibbles, and even
+database tables of \code{tbl_dbi} class. Each validation step or expectation will
+operate over the number of test units that is equal to the number of rows in
+the table (after any \code{preconditions} have been applied).
 }
 \details{
 If providing multiple column names, the result will be an expansion of

--- a/tests/manual_tests/tests_local_tbl.R
+++ b/tests/manual_tests/tests_local_tbl.R
@@ -4,9 +4,11 @@ library(tidyverse)
 al <- action_levels(warn_at = 0.1, stop_at = 0.2)
 
 agent <-
-  create_agent(tbl = small_table, actions = al) %>%
+  small_table %>%
+  create_agent(actions = al) %>%
   col_vals_gt(vars(date_time), vars(date), na_pass = TRUE) %>%
   col_vals_gt(vars(b), vars(g), na_pass = TRUE) %>%
+  col_vals_regex(vars(b), "[1-9]-[a-z]{3}-[0-9]{3}") %>%
   rows_distinct() %>%
   col_vals_gt(vars(d), 100) %>%
   col_vals_equal(vars(d), vars(d), na_pass = TRUE) %>%

--- a/tests/manual_tests/tests_mysql.R
+++ b/tests/manual_tests/tests_mysql.R
@@ -61,4 +61,3 @@ DBI::dbDisconnect(con)
 
 # Get a report from the `agent`
 agent
-  

--- a/tests/manual_tests/tests_postgres.R
+++ b/tests/manual_tests/tests_postgres.R
@@ -1,0 +1,66 @@
+library(tidyverse)
+library(pointblank)
+library(DBI)
+library(RPostgres)
+
+# Create a connection to the `pfmegrnargs`
+# database hosted publicly at "hh-pgsql-public.ebi.ac.uk"
+con <- 
+  DBI::dbConnect(
+    drv = RPostgres::Postgres(),
+    dbname = "pfmegrnargs",
+    user = "reader",
+    password = "NWDMCE5xdipIjRrp",
+    host = "hh-pgsql-public.ebi.ac.uk",
+    port = 5432
+  )
+
+# Set failure thresholds and functions that are
+# actioned from exceeding certain error levels
+al <- action_levels(warn_at = 0.02, stop_at = 0.05, notify_at = 0.10)
+
+# Validate the `rna` table in the `pfmegrnargs` DB (contains 27M rows)
+agent <- 
+  dplyr::tbl(con, "rna") %>%
+  create_agent(
+    name = "pfmegrnargs: 'rna' table",
+    actions = al
+  ) %>%
+  # col_vals_lt(vars(timestamp), value = as.Date("2020-05-05")) %>%
+  col_vals_regex(vars(seq_short), "[GTCA]*", na_pass = TRUE) %>%
+  col_is_character(vars(upi, userstamp, crc64, seq_short, seq_long, md5)) %>%
+  col_vals_gte(vars(len), 1) %>%
+  col_schema_match(
+    schema = col_schema(
+      id = "integer64",
+      upi = "character",
+      timestamp = "POSIXct",
+      userstamp = "character",
+      crc64 = "character",
+      len = "integer",
+      seq_short = "character",
+      seq_long = "character",
+      md5 = "character"
+    )
+  ) %>%
+  col_schema_match(
+    schema = col_schema(
+      id = "bigint",
+      upi = "character varying",
+      timestamp = "timestamp without time zone",
+      userstamp = "character varying",
+      crc64 = "character",
+      len = "integer",
+      seq_short = "character varying",
+      seq_long = "text",
+      md5 = "character varying",
+      .db_col_types = "sql"
+    )
+  ) %>%
+  interrogate()
+
+DBI::dbDisconnect(con)
+
+# Get a report from the `agent`
+agent
+    

--- a/tests/testthat/test-interrogate_with_agent_db.R
+++ b/tests/testthat/test-interrogate_with_agent_db.R
@@ -617,16 +617,6 @@ test_that("Interrogating for valid row values", {
   expect_equivalent(validation$validation_set$n_failed, 0)
   expect_equivalent(validation$validation_set$f_passed, 1)
   expect_equivalent(validation$validation_set$f_failed, 0)
-  
-  # Expect an error when using the `col_vals_regex()` function
-  # to create with a `tbl_dbi` table object
-  expect_error(
-    create_agent(tbl = small_table) %>%
-      col_vals_regex(
-        columns = vars(b),
-        regex = "[0-9]-[a-z]{3}-[0-9]{3}"
-      )
-  )
 })
 
 test_that("Interrogating with an agent incorporates the `na_pass` option", {


### PR DESCRIPTION
This PR makes it possible to use the `col_vals_regex()` validation function (plus the expectation and test functions) on some DB types (tested on MySQL and PostgreSQL). Some manual testing files have been updated/added. 

Fixes: #108 