### PR TITLE
Use `covert_actions()` for every validation fcn

### DIFF
--- a/R/action_levels.R
+++ b/R/action_levels.R
@@ -206,6 +206,15 @@ prime_actions <- function(actions) {
   actions
 }
 
+covert_actions <- function(actions, agent) {
+  
+  if (is.null(actions)) {
+    actions <- agent$actions
+  } 
+  
+  actions
+}
+
 stock_stoppage <- function(x) {
 
   fn_name <- x$type

--- a/R/col_exists.R
+++ b/R/col_exists.R
@@ -166,7 +166,7 @@ col_exists <- function(x,
         assertion_type = "col_exists",
         column = columns[i],
         preconditions = NULL,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/col_is_character.R
+++ b/R/col_is_character.R
@@ -155,7 +155,7 @@ col_is_character <- function(x,
         assertion_type = "col_is_character",
         column = columns[i],
         preconditions = NULL,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/col_is_date.R
+++ b/R/col_is_date.R
@@ -158,7 +158,7 @@ col_is_date <- function(x,
         assertion_type = "col_is_date",
         column = columns[i],
         preconditions = NULL,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/col_is_factor.R
+++ b/R/col_is_factor.R
@@ -160,7 +160,7 @@ col_is_factor <- function(x,
         assertion_type = "col_is_factor",
         column = columns[i],
         preconditions = NULL,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/col_is_integer.R
+++ b/R/col_is_integer.R
@@ -157,7 +157,7 @@ col_is_integer <- function(x,
         assertion_type = "col_is_integer",
         column = columns[i],
         preconditions = NULL,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/col_is_logical.R
+++ b/R/col_is_logical.R
@@ -159,7 +159,7 @@ col_is_logical <- function(x,
         assertion_type = "col_is_logical",
         column = columns[i],
         preconditions = NULL,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/col_is_numeric.R
+++ b/R/col_is_numeric.R
@@ -159,7 +159,7 @@ col_is_numeric <- function(x,
         assertion_type = "col_is_numeric",
         column = columns[i],
         preconditions = NULL,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/col_is_posix.R
+++ b/R/col_is_posix.R
@@ -161,7 +161,7 @@ col_is_posix <- function(x,
         assertion_type = "col_is_posix",
         column = columns[i],
         preconditions = NULL,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/col_schema_match.R
+++ b/R/col_schema_match.R
@@ -196,7 +196,7 @@ col_schema_match <- function(x,
       column = NA_character_,
       values = schema,
       preconditions = NULL,
-      actions = actions,
+      actions = covert_actions(actions, agent),
       brief = brief,
       active = active
     )

--- a/R/col_vals_between.R
+++ b/R/col_vals_between.R
@@ -239,7 +239,7 @@ col_vals_between <- function(x,
         values = c(left, right),
         na_pass = na_pass,
         preconditions = preconditions,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/col_vals_equal.R
+++ b/R/col_vals_equal.R
@@ -191,7 +191,7 @@ col_vals_equal <- function(x,
         values = value,
         na_pass = na_pass,
         preconditions = preconditions,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/col_vals_expr.R
+++ b/R/col_vals_expr.R
@@ -200,7 +200,7 @@ col_vals_expr <- function(x,
       column = NA_character_,
       values = expr,
       preconditions = preconditions,
-      actions = actions,
+      actions = covert_actions(actions, agent),
       brief = brief,
       active = active
     )

--- a/R/col_vals_gt.R
+++ b/R/col_vals_gt.R
@@ -223,7 +223,7 @@ col_vals_gt <- function(x,
         values = value,
         na_pass = na_pass,
         preconditions = preconditions,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/col_vals_gte.R
+++ b/R/col_vals_gte.R
@@ -183,7 +183,7 @@ col_vals_gte <- function(x,
   }
   
   # Add one or more validation steps based on the
-  # length of the `column` variable
+  # length of the `columns` variable
   for (i in seq(columns)) {
     
     agent <-
@@ -194,7 +194,7 @@ col_vals_gte <- function(x,
         values = value,
         na_pass = na_pass,
         preconditions = preconditions,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/col_vals_in_set.R
+++ b/R/col_vals_in_set.R
@@ -183,7 +183,7 @@ col_vals_in_set <- function(x,
         column = columns[i],
         values = set,
         preconditions = preconditions,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/col_vals_lt.R
+++ b/R/col_vals_lt.R
@@ -182,7 +182,7 @@ col_vals_lt <- function(x,
   }
   
   # Add one or more validation steps based on the
-  # length of the `column` variable
+  # length of the `columns` variable
   for (i in seq(columns)) {
     
     agent <-
@@ -193,7 +193,7 @@ col_vals_lt <- function(x,
         values = value,
         na_pass = na_pass,
         preconditions = preconditions,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/col_vals_lte.R
+++ b/R/col_vals_lte.R
@@ -183,7 +183,7 @@ col_vals_lte <- function(x,
   }
   
   # Add one or more validation steps based on the
-  # length of the `column` variable
+  # length of the `columns` variable
   for (i in seq(columns)) {
     
     agent <-
@@ -194,7 +194,7 @@ col_vals_lte <- function(x,
         values = value,
         na_pass = na_pass,
         preconditions = preconditions,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/col_vals_not_between.R
+++ b/R/col_vals_not_between.R
@@ -234,7 +234,7 @@ col_vals_not_between <- function(x,
         values = c(left, right),
         na_pass = na_pass,
         preconditions = preconditions,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/col_vals_not_equal.R
+++ b/R/col_vals_not_equal.R
@@ -192,7 +192,7 @@ col_vals_not_equal <- function(x,
         values = value,
         na_pass = na_pass,
         preconditions = preconditions,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/col_vals_not_in_set.R
+++ b/R/col_vals_not_in_set.R
@@ -184,7 +184,7 @@ col_vals_not_in_set <- function(x,
         column = columns[i],
         values = set,
         preconditions = preconditions,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/col_vals_not_null.R
+++ b/R/col_vals_not_null.R
@@ -180,7 +180,7 @@ col_vals_not_null <- function(x,
         assertion_type = "col_vals_not_null",
         column = columns[i],
         preconditions = preconditions,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/col_vals_null.R
+++ b/R/col_vals_null.R
@@ -179,7 +179,7 @@ col_vals_null <- function(x,
         assertion_type = "col_vals_null",
         column = columns[i],
         preconditions = preconditions,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/col_vals_regex.R
+++ b/R/col_vals_regex.R
@@ -191,7 +191,7 @@ col_vals_regex <- function(x,
         values = regex,
         na_pass = na_pass,
         preconditions = preconditions,
-        actions = actions,
+        actions = covert_actions(actions, agent),
         brief = brief[i],
         active = active
       )

--- a/R/conjointly.R
+++ b/R/conjointly.R
@@ -224,6 +224,7 @@ conjointly <- function(x,
       )
   }
 
+  # Add a validation step
   agent <-
     create_validation_step(
       agent = agent,
@@ -232,7 +233,7 @@ conjointly <- function(x,
       values = validation_formulas,
       na_pass = NULL,
       preconditions = preconditions,
-      actions = actions,
+      actions = covert_actions(actions, agent),
       brief = brief,
       active = active
     )

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -89,12 +89,6 @@ interrogate <- function(agent,
     # Get the table object for interrogation 
     table <- get_tbl_object(agent)
     
-    # Use the default `action_levels` list if it exists and
-    # only if it isn't set for this validation step
-    if (!is.null(agent$actions) && is.null(agent$validation_set$actions[i][[1]])) {
-      agent$validation_set[[i, "actions"]] <- list(agent$actions)
-    }
-    
     # Use preconditions to modify the table
     table <- apply_preconditions_to_tbl(agent, idx = i, tbl = table)
 

--- a/R/rows_distinct.R
+++ b/R/rows_distinct.R
@@ -152,7 +152,7 @@ rows_distinct <- function(x,
       )
   }
 
-  # Add one or more validation steps
+  # Add a validation step
   agent <-
     create_validation_step(
       agent = agent,
@@ -160,7 +160,7 @@ rows_distinct <- function(x,
       column = list(ifelse(is.null(columns), NA_character_, columns)),
       values = NULL,
       preconditions = preconditions,
-      actions = actions,
+      actions = covert_actions(actions, agent),
       brief = brief,
       active = active
     )


### PR DESCRIPTION
This PR simply adds the default `actions` list to each validation step, if necessary, at the moment of creation (rather than doing so in the interrogation pipeline).

This change will make it easier to describe thresholds and actions in the tabular reporting done in the `get_agent_report()` (at all stages of validation).