### PR TITLE
Transform SQL column types to lowercase

### DIFF
--- a/R/col_schema_match.R
+++ b/R/col_schema_match.R
@@ -363,6 +363,13 @@ col_schema <- function(...,
 
   x <- list(...)
   
+  # Transform SQL column types to lowercase to allow
+  # both uppercase and lowercase conventions while
+  # standardizing the input
+  if (db_col_types == "sql") {
+    x <- lapply(x, tolower)
+  }
+  
   # Apply the `col_schema` and the `r_type`/`sql_type` classes
   class(x) <- c(paste0(db_col_types, "_type"), "col_schema")
   

--- a/tests/manual_tests/tests_mysql.R
+++ b/tests/manual_tests/tests_mysql.R
@@ -45,13 +45,13 @@ agent <-
   ) %>%
   col_schema_match(
     schema = col_schema(
-      asm_seq_region_id = "int",
-      cmp_seq_region_id = "int",
-      asm_start = "int",
-      asm_end = "int",
-      cmp_start = "int",
-      cmp_end = "int",
-      ori = "tinyint",
+      asm_seq_region_id = "INT",
+      cmp_seq_region_id = "INT",
+      asm_start = "INT",
+      asm_end = "INT",
+      cmp_start = "INT",
+      cmp_end = "INT",
+      ori = "TINYINT",
       .db_col_types = "sql"
     )
   ) %>%


### PR DESCRIPTION
The `col_schema()` function allows you to specifying SQL column types (using `.db_col_types = "sql"`) but it's common to write these types as uppercase (e.g., "INT", "TINYINT", etc.). This will always fail validation because we  lowercase the SQL column types of the target table during the `create_agent()` call. To fix, this PR lowercases the user-submitted column types in `col_schema()` when the `.db_col_types = "sql"` option is present.

Fixes: https://github.com/rich-iannone/pointblank/issues/107