### PR TITLE
Add support for `tbl_spark` data tables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,5 +49,6 @@ Suggests:
     RMariaDB,
     RPostgres,
     readr,
-    rmarkdown
+    rmarkdown,
+    sparklyr
 Roxygen: list(markdown = TRUE)

--- a/R/agent_ops.R
+++ b/R/agent_ops.R
@@ -5,7 +5,7 @@
 #' [agent_read()]). By default, any data table that the *agent* may have before
 #' being committed to disk will be expunged. This behavior can be changed by
 #' setting `keep_tbl` to `TRUE` but this only works in the case where the table
-#' is not of the `tbl_dbi` class.
+#' is not of the `tbl_dbi` or the `tbl_spark` class.
 #'
 #' It can be helpful to set a table-reading function to later reuse the *agent*
 #' when read from disk through [agent_read()]. This can be done with the
@@ -22,8 +22,8 @@
 #'   *agent* (which is the case when the *agent* is created using 
 #'   `create_agent(tbl = <data table, ...)`). The default is `FALSE` where the
 #'   data table is removed before writing to disk. For database tables of the
-#'   class `tbl_dbi`, the table is always removed (even if `keep_tbl` is set to
-#'   `TRUE`).
+#'   class `tbl_dbi` and for Spark DataFrames (`tbl_spark`) the table is always
+#'   removed (even if `keep_tbl` is set to `TRUE`).
 #' 
 #' @export
 agent_write <- function(agent,
@@ -33,10 +33,10 @@ agent_write <- function(agent,
   
   if (keep_tbl) {
     
-    if (inherits(agent$tbl, "tbl_dbi")) {
+    if (inherits(agent$tbl, "tbl_dbi") || inherits(agent$tbl, "tbl_spark")) {
       
       warning(
-        "A table of class `tbl_dbi` cannot be kept with the agent.",
+        "A table of class `tbl_dbi` or `tbl_spark` cannot be kept with the agent.",
         call. = FALSE
       )
       
@@ -88,17 +88,17 @@ agent_read <- function(path) {
 
 #' Set a data table to an agent
 #' 
-#' Setting a data table to *agent* with `set_tbl()` replaces any table (data
-#' frame, a tibble, or a `tbl_dbi` object) associated with the *agent*. If no
-#' data table is associated with an *agent*, setting one will mean the data
-#' table takes precedence over table-reading function (settable in
+#' Setting a data table to *agent* with `set_tbl()` replaces any table (a data
+#' frame, a tibble, objects of class `tbl_dbi` or `tbl_spark`) associated with
+#' the *agent*. If no data table is associated with an *agent*, setting one will
+#' mean the data table takes precedence over table-reading function (settable in
 #' [create_agent()]'s `read_fn` argument or with [set_read_fn()]).
 #' 
 #' @param agent An *agent* object of class `ptblank_agent` that is created with
 #'   [create_agent()].
 #' @param tbl The input table for the `agent`. This can be a data frame, a
-#'   tibble, or a `tbl_dbi` object. Any table already associated with the
-#'   *agent* will be overwritten.
+#'   tibble, a `tbl_dbi` object, or a `tbl_spark` object. Any table already
+#'   associated with the *agent* will be overwritten.
 #' 
 #' @export
 set_tbl <- function(agent,

--- a/R/col_exists.R
+++ b/R/col_exists.R
@@ -7,9 +7,9 @@
 #' table or with an *agent* object (technically, a `ptblank_agent` object)
 #' whereas the expectation and test functions can only be used with a data
 #' table. The types of data tables that can be used include data frames,
-#' tibbles, and even database tables of the `tbl_dbi` class. Each validation
-#' step or expectation will operate over a single test unit, which is whether
-#' the column exists or not.
+#' tibbles, database tables (`tbl_dbi`), and Spark DataFrames (`tbl_spark`).
+#' Each validation step or expectation will operate over a single test unit,
+#' which is whether the column exists or not.
 #'
 #' If providing multiple column names, the result will be an expansion of
 #' validation steps to that number of column names (e.g., `vars(col_a, col_b)`

--- a/R/col_is_character.R
+++ b/R/col_is_character.R
@@ -8,9 +8,9 @@
 #' can be used directly on a data table or with an *agent* object (technically,
 #' a `ptblank_agent` object) whereas the expectation and test functions can only
 #' be used with a data table. The types of data tables that can be used include
-#' data frames, tibbles, and even database tables of the `tbl_dbi` class. Each
-#' validation step or expectation will operate over a single test unit, which is
-#' whether the column is a character-type column or not.
+#' data frames, tibbles, database tables (`tbl_dbi`), and Spark DataFrames
+#' (`tbl_spark`). Each validation step or expectation will operate over a single
+#' test unit, which is whether the column is a character-type column or not.
 #'
 #' If providing multiple column names, the result will be an expansion of
 #' validation steps to that number of column names (e.g., `vars(col_a, col_b)`

--- a/R/col_is_date.R
+++ b/R/col_is_date.R
@@ -8,9 +8,9 @@
 #' directly on a data table or with an *agent* object (technically, a
 #' `ptblank_agent` object) whereas the expectation and test functions can only
 #' be used with a data table. The types of data tables that can be used include
-#' data frames, tibbles, and even database tables of the `tbl_dbi` class. Each
-#' validation step or expectation will operate over a single test unit, which is
-#' whether the column is a `Date`-type column or not.
+#' data frames, tibbles, database tables (`tbl_dbi`), and Spark DataFrames
+#' (`tbl_spark`). Each validation step or expectation will operate over a single
+#' test unit, which is whether the column is a `Date`-type column or not.
 #' 
 #' If providing multiple column names, the result will be an expansion of
 #' validation steps to that number of column names (e.g., `vars(col_a, col_b)`

--- a/R/col_is_factor.R
+++ b/R/col_is_factor.R
@@ -8,9 +8,9 @@
 #' directly on a data table or with an *agent* object (technically, a
 #' `ptblank_agent` object) whereas the expectation and test functions can only
 #' be used with a data table. The types of data tables that can be used include
-#' data frames, tibbles, and even database tables of the `tbl_dbi` class. Each
-#' validation step or expectation will operate over a single test unit, which is
-#' whether the column is a factor-type column or not.
+#' data frames, tibbles, database tables (`tbl_dbi`), and Spark DataFrames
+#' (`tbl_spark`). Each validation step or expectation will operate over a single
+#' test unit, which is whether the column is a factor-type column or not.
 #' 
 #' If providing multiple column names, the result will be an expansion of
 #' validation steps to that number of column names (e.g., `vars(col_a, col_b)`

--- a/R/col_is_integer.R
+++ b/R/col_is_integer.R
@@ -8,9 +8,9 @@
 #' directly on a data table or with an *agent* object (technically, a
 #' `ptblank_agent` object) whereas the expectation and test functions can only
 #' be used with a data table. The types of data tables that can be used include
-#' data frames, tibbles, and even database tables of the `tbl_dbi` class. Each
-#' validation step or expectation will operate over a single test unit, which is
-#' whether the column is an integer-type column or not.
+#' data frames, tibbles, database tables (`tbl_dbi`), and Spark DataFrames
+#' (`tbl_spark`). Each validation step or expectation will operate over a single
+#' test unit, which is whether the column is an integer-type column or not.
 #'
 #' If providing multiple column names, the result will be an expansion of
 #' validation steps to that number of column names (e.g., `vars(col_a, col_b)`

--- a/R/col_is_logical.R
+++ b/R/col_is_logical.R
@@ -8,10 +8,10 @@
 #' function can be used directly on a data table or with an *agent* object
 #' (technically, a `ptblank_agent` object) whereas the expectation and test
 #' functions can only be used with a data table. The types of data tables that
-#' can be used include data frames, tibbles, and even database tables of the
-#' `tbl_dbi` class. Each validation step or expectation will operate over a
-#' single test unit, which is whether the column is an logical-type column or
-#' not.
+#' can be used include data frames, tibbles, database tables (`tbl_dbi`), and
+#' Spark DataFrames (`tbl_spark`). Each validation step or expectation will
+#' operate over a single test unit, which is whether the column is an
+#' logical-type column or not.
 #'
 #' If providing multiple column names, the result will be an expansion of
 #' validation steps to that number of column names (e.g., `vars(col_a, col_b)`

--- a/R/col_is_numeric.R
+++ b/R/col_is_numeric.R
@@ -8,9 +8,9 @@
 #' directly on a data table or with an *agent* object (technically, a
 #' `ptblank_agent` object) whereas the expectation and test functions can only
 #' be used with a data table. The types of data tables that can be used include
-#' data frames, tibbles, and even database tables of `tbl_dbi` class. Each
-#' validation step or expectation will operate over a single test unit, which is
-#' whether the column is a numeric-type column or not.
+#' data frames, tibbles, database tables (`tbl_dbi`), and Spark DataFrames
+#' (`tbl_spark`). Each validation step or expectation will operate over a single
+#' test unit, which is whether the column is a numeric-type column or not.
 #'
 #' If providing multiple column names, the result will be an expansion of
 #' validation steps to that number of column names (e.g., `vars(col_a, col_b)`

--- a/R/col_is_posix.R
+++ b/R/col_is_posix.R
@@ -8,9 +8,9 @@
 #' can be used directly on a data table or with an *agent* object (technically,
 #' a `ptblank_agent` object) whereas the expectation and test functions can only
 #' be used with a data table. The types of data tables that can be used include
-#' data frames, tibbles, and even database tables of `tbl_dbi` class. Each
-#' validation step or expectation will operate over a single test unit, which is
-#' whether the column is a `POSIXct`-type column or not.
+#' data frames, tibbles, database tables (`tbl_dbi`), and Spark DataFrames
+#' (`tbl_spark`). Each validation step or expectation will operate over a single
+#' test unit, which is whether the column is a `POSIXct`-type column or not.
 #'
 #' If providing multiple column names, the result will be an expansion of
 #' validation steps to that number of column names (e.g., `vars(col_a, col_b)`

--- a/R/col_schema_match.R
+++ b/R/col_schema_match.R
@@ -8,14 +8,17 @@
 #' data table or with an *agent* object (technically, a `ptblank_agent` object)
 #' whereas the expectation and test functions can only be used with a data
 #' table. The types of data tables that can be used include data frames,
-#' tibbles, and even database tables of `tbl_dbi` class. The validation step or
-#' expectation operates over a single test unit, which is whether the schema
-#' matches that of the table (within the constraints enforced by the `complete`
-#' and `in_order` options). If the target table is a `tbl_dbi` object, we can
-#' choose to validate the column schema that is based on R column types (e.g.,
-#' `"numeric"`, `"character"`, etc.), or, SQL column types (e.g., `"double"`,
-#' `"varchar"`, etc.). That option is defined in the [col_schema()] function (it
-#' is the `.db_col_types` argument).
+#' tibbles, database tables (`tbl_dbi`), and Spark DataFrames (`tbl_spark`).
+#' Each validation step or expectation will operate over a single test unit,
+#' which is whether the column is an integer-type column or not. The validation
+#' step or expectation operates over a single test unit, which is whether the
+#' schema matches that of the table (within the constraints enforced by the
+#' `complete` and `in_order` options). If the target table is a `tbl_dbi` or a
+#' `tbl_spark` object, we can choose to validate the column schema that is based
+#' on R column types (e.g., `"numeric"`, `"character"`, etc.), SQL column types
+#' (e.g., `"double"`, `"varchar"`, etc.), or Spark SQL types (e.g,.
+#' `"DoubleType"`, `"StringType"`, etc.). That option is defined in the
+#' [col_schema()] function (it is the `.db_col_types` argument).
 #'
 #' Often, we will want to specify `actions` for the validation. This argument,
 #' present in every validation function, takes a specially-crafted list object
@@ -293,12 +296,14 @@ test_col_schema_match <- function(object,
 #' checks whether the table object under study matches a known column schema).
 #' The `col_schema` object can be made by carefully supplying the column names
 #' and their types as a set of named arguments, or, we could provide a table
-#' object, which could by of the `data.frame`, `tbl_df`, or `tbl_dbi` varieties.
-#' There's an additional option, which is just for validating the schema of a
-#' `tbl_dbi` object: we can validate the schema based on R column types (e.g.,
-#' `"numeric"`, `"character"`, etc.), or, SQL column types (e.g., `"double"`,
-#' `"varchar"`, etc.). This is great if we want to validate table column schemas
-#' both on the server side and when tabular data is collected and loaded into R.
+#' object, which could by of the `data.frame`, `tbl_df`, `tbl_dbi`, or
+#' `tbl_spark` varieties. There's an additional option, which is just for
+#' validating the schema of a `tbl_dbi` or `tbl_spark` object: we can validate
+#' the schema based on R column types (e.g., `"numeric"`, `"character"`, etc.),
+#' SQL column types (e.g., `"double"`, `"varchar"`, etc.), or Spark SQL column
+#' types (`"DoubleType"`, `"StringType"`, etc.). This is great if we want to
+#' validate table column schemas both on the server side and when tabular data
+#' is collected and loaded into R.
 #' 
 #' @param ... A set of named arguments where the names refer to column names and
 #'   the values are one or more column types.
@@ -328,9 +333,9 @@ test_col_schema_match <- function(object,
 #'   )
 #' 
 #' # Validate that the schema object
-#' # `col_schema_x` exactly defines
+#' # `schema_obj` exactly defines
 #' # the column names and column types
-#' # of the `tbl_x` table
+#' # of the `tbl` table
 #' agent <-
 #'   create_agent(tbl = tbl) %>%
 #'   col_schema_match(schema_obj) %>%
@@ -395,7 +400,7 @@ col_schema <- function(...,
       class(x) <- c("r_type", "col_schema")
     }
     
-    if (inherits(.tbl, "tbl_dbi")) {
+    if (inherits(.tbl, "tbl_dbi") || inherits(.tbl, "tbl_spark")) {
       
       tbl_info <- get_tbl_information(tbl = .tbl)
       

--- a/R/col_vals_between.R
+++ b/R/col_vals_between.R
@@ -15,9 +15,12 @@
 #' table or with an *agent* object (technically, a `ptblank_agent` object)
 #' whereas the expectation and test functions can only be used with a data
 #' table. The types of data tables that can be used include data frames,
-#' tibbles, and even database tables of `tbl_dbi` class. Each validation step or
-#' expectation will operate over the number of test units that is equal to the
-#' number of rows in the table (after any `preconditions` have been applied).
+#' tibbles, database tables (`tbl_dbi`), and Spark DataFrames (`tbl_spark`).
+#' Each validation step or expectation will operate over a single test unit,
+#' which is whether the column is an integer-type column or not. Each validation
+#' step or expectation will operate over the number of test units that is equal
+#' to the number of rows in the table (after any `preconditions` have been
+#' applied).
 #'
 #' If providing multiple column names to `columns`, the result will be an
 #' expansion of validation steps to that number of column names (e.g.,

--- a/R/col_vals_equal.R
+++ b/R/col_vals_equal.R
@@ -7,10 +7,10 @@
 #' in `vars()`. The validation function can be used directly on a data table or
 #' with an *agent* object (technically, a `ptblank_agent` object) whereas the
 #' expectation and test functions can only be used with a data table. The types
-#' of data tables that can be used include data frames, tibbles, and even
-#' database tables of `tbl_dbi` class. Each validation step or expectation will
-#' operate over the number of test units that is equal to the number of rows in
-#' the table (after any `preconditions` have been applied).
+#' of data tables that can be used include data frames, tibbles, database tables
+#' (`tbl_dbi`), and Spark DataFrames (`tbl_spark`). Each validation step or
+#' expectation will operate over the number of test units that is equal to the
+#' number of rows in the table (after any `preconditions` have been applied).
 #'
 #' If providing multiple column names to `columns`, the result will be an
 #' expansion of validation steps to that number of column names (e.g.,

--- a/R/col_vals_expr.R
+++ b/R/col_vals_expr.R
@@ -5,10 +5,10 @@
 #' can be used directly on a data table or with an *agent* object (technically,
 #' a `ptblank_agent` object) whereas the expectation and test functions can only
 #' be used with a data table. The types of data tables that can be used include
-#' data frames, tibbles, and even database tables of `tbl_dbi` class. Each
-#' validation step or expectation will operate over the number of test units
-#' that is equal to the number of rows in the table (after any `preconditions`
-#' have been applied).
+#' data frames, tibbles, database tables (`tbl_dbi`), and Spark DataFrames
+#' (`tbl_spark`). Each validation step or expectation will operate over the
+#' number of test units that is equal to the number of rows in the table (after
+#' any `preconditions` have been applied).
 #' 
 #' Having table `preconditions` means **pointblank** will mutate the table just
 #' before interrogation. Such a table mutation is isolated in scope to the

--- a/R/col_vals_gt.R
+++ b/R/col_vals_gt.R
@@ -8,10 +8,10 @@
 #' `vars()`. The validation function can be used directly on a data table or
 #' with an *agent* object (technically, a `ptblank_agent` object) whereas the
 #' expectation and test functions can only be used with a data table. The types
-#' of data tables that can be used include data frames, tibbles, and even
-#' database tables of `tbl_dbi` class. Each validation step or expectation will
-#' operate over the number of test units that is equal to the number of rows in
-#' the table (after any `preconditions` have been applied).
+#' of data tables that can be used include data frames, tibbles, database tables
+#' (`tbl_dbi`), and Spark DataFrames (`tbl_spark`). Each validation step or
+#' expectation will operate over the number of test units that is equal to the
+#' number of rows in the table (after any `preconditions` have been applied).
 #'
 #' If providing multiple column names to `columns`, the result will be an
 #' expansion of validation steps to that number of column names (e.g.,
@@ -56,10 +56,12 @@
 #' *autobrief* protocol is kicked in when `brief = NULL` and a simple brief will
 #' then be automatically generated.
 #'
-#' @param x A data frame, tibble (`tbl_df` or `tbl_dbi`), or, an agent object of
-#'   class `ptblank_agent` that is created with [create_agent()].
-#' @param object A data frame or tibble (`tbl_df` or `tbl_dbi`) that serves as
-#'   the target table for the expectation function.
+#' @param x A data frame, tibble (`tbl_df` or `tbl_dbi`), Spark DataFrame
+#'   (`tbl_spark`), or, an agent object of class `ptblank_agent` that is created
+#'   with [create_agent()].
+#' @param object A data frame, tibble (`tbl_df` or `tbl_dbi`), or Spark
+#'   DataFrame (`tbl_spark`) that serves as the target table for the expectation
+#'   function or the test function.
 #' @param columns The column (or a set of columns, provided as a character
 #'   vector) to which this validation should be applied.
 #' @param value A numeric value used for this test. Any column values `>value`

--- a/R/col_vals_gte.R
+++ b/R/col_vals_gte.R
@@ -9,9 +9,10 @@
 #' data table or with an *agent* object (technically, a `ptblank_agent` object)
 #' whereas the expectation and test functions can only be used with a data
 #' table. The types of data tables that can be used include data frames,
-#' tibbles, and even database tables of `tbl_dbi` class. Each validation step or
-#' expectation will operate over the number of test units that is equal to the
-#' number of rows in the table (after any `preconditions` have been applied).
+#' tibbles, database tables (`tbl_dbi`), and Spark DataFrames (`tbl_spark`).
+#' Each validation step or expectation will operate over the number of test
+#' units that is equal to the number of rows in the table (after any
+#' `preconditions` have been applied).
 #'
 #' If providing multiple column names to `columns`, the result will be an
 #' expansion of validation steps to that number of column names (e.g.,

--- a/R/col_vals_in_set.R
+++ b/R/col_vals_in_set.R
@@ -6,10 +6,10 @@
 #' values. The validation step function can be used directly on a data table or
 #' with an *agent* object (technically, a `ptblank_agent` object) whereas the
 #' expectation and test functions can only be used with a data table. The types
-#' of data tables that can be used include data frames, tibbles, and even
-#' database tables of `tbl_dbi` class. Each validation step or expectation will
-#' operate over the number of test units that is equal to the number of rows in
-#' the table (after any `preconditions` have been applied).
+#' of data tables that can be used include data frames, tibbles, database tables
+#' (`tbl_dbi`), and Spark DataFrames (`tbl_spark`). Each validation step or
+#' expectation will operate over the number of test units that is equal to the
+#' number of rows in the table (after any `preconditions` have been applied).
 #'
 #' If providing multiple column names, the result will be an expansion of
 #' validation steps to that number of column names (e.g., `vars(col_a, col_b)`

--- a/R/col_vals_lt.R
+++ b/R/col_vals_lt.R
@@ -8,10 +8,10 @@
 #' `vars()`. The validation function can be used directly on a data table or
 #' with an *agent* object (technically, a `ptblank_agent` object) whereas the
 #' expectation and test functions can only be used with a data table. The types
-#' of data tables that can be used include data frames, tibbles, and even
-#' database tables of `tbl_dbi` class. Each validation step or expectation will
-#' operate over the number of test units that is equal to the number of rows in
-#' the table (after any `preconditions` have been applied).
+#' of data tables that can be used include data frames, tibbles, database tables
+#' (`tbl_dbi`), and Spark DataFrames (`tbl_spark`). Each validation step or
+#' expectation will operate over the number of test units that is equal to the
+#' number of rows in the table (after any `preconditions` have been applied).
 #'
 #' If providing multiple column names to `columns`, the result will be an
 #' expansion of validation steps to that number of column names (e.g.,

--- a/R/col_vals_lte.R
+++ b/R/col_vals_lte.R
@@ -9,9 +9,10 @@
 #' data table or with an *agent* object (technically, a `ptblank_agent` object)
 #' whereas the expectation and test functions can only be used with a data
 #' table. The types of data tables that can be used include data frames,
-#' tibbles, and even database tables of `tbl_dbi` class. Each validation step or
-#' expectation will operate over the number of test units that is equal to the
-#' number of rows in the table (after any `preconditions` have been applied).
+#' tibbles, database tables (`tbl_dbi`), and Spark DataFrames (`tbl_spark`).
+#' Each validation step or expectation will operate over the number of test
+#' units that is equal to the number of rows in the table (after any
+#' `preconditions` have been applied).
 #'
 #' If providing multiple column names to `columns`, the result will be an
 #' expansion of validation steps to that number of column names (e.g.,

--- a/R/col_vals_not_between.R
+++ b/R/col_vals_not_between.R
@@ -16,9 +16,10 @@
 #' table or with an *agent* object (technically, a `ptblank_agent` object)
 #' whereas the expectation and test functions can only be used with a data
 #' table. The types of data tables that can be used include data frames,
-#' tibbles, and even database tables of `tbl_dbi` class. Each validation step or
-#' expectation will operate over the number of test units that is equal to the
-#' number of rows in the table (after any `preconditions` have been applied).
+#' tibbles, database tables (`tbl_dbi`), and Spark DataFrames (`tbl_spark`).
+#' Each validation step or expectation will operate over the number of test
+#' units that is equal to the number of rows in the table (after any
+#' `preconditions` have been applied).
 #'
 #' If providing multiple column names to `columns`, the result will be an
 #' expansion of validation steps to that number of column names (e.g.,

--- a/R/col_vals_not_equal.R
+++ b/R/col_vals_not_equal.R
@@ -7,10 +7,10 @@
 #' can be used directly on a data table or with an *agent* object (technically,
 #' a `ptblank_agent` object) whereas the expectation and test functions can only
 #' be used with a data table. The types of data tables that can be used include
-#' data frames, tibbles, and even database tables of `tbl_dbi` class. Each
-#' validation step or expectation will operate over the number of test units
-#' that is equal to the number of rows in the table (after any `preconditions`
-#' have been applied).
+#' data frames, tibbles, database tables (`tbl_dbi`), and Spark DataFrames
+#' (`tbl_spark`). Each validation step or expectation will operate over the
+#' number of test units that is equal to the number of rows in the table (after
+#' any `preconditions` have been applied).
 #'
 #' If providing multiple column names, the result will be an expansion of
 #' validation steps to that number of column names (e.g., `vars(col_a, col_b)`

--- a/R/col_vals_not_in_set.R
+++ b/R/col_vals_not_in_set.R
@@ -7,10 +7,10 @@
 #' function can be used directly on a data table or with an *agent* object
 #' (technically, a `ptblank_agent` object) whereas the expectation and test
 #' functions can only be used with a data table. The types of data tables that
-#' can be used include data frames, tibbles, and even database tables of
-#' `tbl_dbi` class. Each validation step or expectation will operate over the
-#' number of test units that is equal to the number of rows in the table (after
-#' any `preconditions` have been applied).
+#' can be used include data frames, tibbles, database tables (`tbl_dbi`), and
+#' Spark DataFrames (`tbl_spark`). Each validation step or expectation will
+#' operate over the number of test units that is equal to the number of rows in
+#' the table (after any `preconditions` have been applied).
 #'
 #' If providing multiple column names, the result will be an expansion of
 #' validation steps to that number of column names (e.g., `vars(col_a, col_b)`

--- a/R/col_vals_not_null.R
+++ b/R/col_vals_not_null.R
@@ -7,10 +7,10 @@
 #' The validation function can be used directly on a data table or with an
 #' *agent* object (technically, a `ptblank_agent` object) whereas the
 #' expectation and test functions can only be used with a data table. The types
-#' of data tables that can be used include data frames, tibbles, and even
-#' database tables of `tbl_dbi` class. Each validation step or expectation will
-#' operate over the number of test units that is equal to the number of rows in
-#' the table (after any `preconditions` have been applied).
+#' of data tables that can be used include data frames, tibbles, database tables
+#' (`tbl_dbi`), and Spark DataFrames (`tbl_spark`). Each validation step or
+#' expectation will operate over the number of test units that is equal to the
+#' number of rows in the table (after any `preconditions` have been applied).
 #'
 #' If providing multiple column names, the result will be an expansion of
 #' validation steps to that number of column names (e.g., `vars(col_a, col_b)`

--- a/R/col_vals_null.R
+++ b/R/col_vals_null.R
@@ -6,10 +6,10 @@
 #' `NULL` values. The validation function can be used directly on a data table
 #' or with an *agent* object (technically, a `ptblank_agent` object) whereas the
 #' expectation and test functions can only be used with a data table. The types
-#' of data tables that can be used include data frames, tibbles, and even
-#' database tables of `tbl_dbi` class. Each validation step or expectation will
-#' operate over the number of test units that is equal to the number of rows in
-#' the table (after any `preconditions` have been applied).
+#' of data tables that can be used include data frames, tibbles, database tables
+#' (`tbl_dbi`), and Spark DataFrames (`tbl_spark`). Each validation step or
+#' expectation will operate over the number of test units that is equal to the
+#' number of rows in the table (after any `preconditions` have been applied).
 #'
 #' If providing multiple column names, the result will be an expansion of
 #' validation steps to that number of column names (e.g., `vars(col_a, col_b)`

--- a/R/col_vals_regex.R
+++ b/R/col_vals_regex.R
@@ -6,10 +6,10 @@
 #' The validation step function can be used directly on a data table or with an
 #' *agent* object (technically, a `ptblank_agent` object) whereas the
 #' expectation and test functions can only be used with a data table. The types
-#' of data tables that can be used include data frames, tibbles, and even
-#' database tables of `tbl_dbi` class. Each validation step or expectation will
-#' operate over the number of test units that is equal to the number of rows in
-#' the table (after any `preconditions` have been applied).
+#' of data tables that can be used include data frames, tibbles, database tables
+#' (`tbl_dbi`), and Spark DataFrames (`tbl_spark`). Each validation step or
+#' expectation will operate over the number of test units that is equal to the
+#' number of rows in the table (after any `preconditions` have been applied).
 #'
 #' If providing multiple column names, the result will be an expansion of
 #' validation steps to that number of column names (e.g., `vars(col_a, col_b)`

--- a/R/create_agent.R
+++ b/R/create_agent.R
@@ -33,10 +33,10 @@
 #' on the *agent*. However, in practice, it's not often the case that all data
 #' validation steps are free from any failing units.
 #'
-#' @param tbl The input table. This can be a data frame, a tibble, or a
-#'   `tbl_dbi` object. Alternatively, a function can be used to read in the
-#'   input data table with the `read_fn` argument (in which case, `tbl` can be
-#'   `NULL`).
+#' @param tbl The input table. This can be a data frame, a tibble, a `tbl_dbi`
+#'   object, or a `tbl_spark` object. Alternatively, a function can be used to
+#'   read in the input data table with the `read_fn` argument (in which case,
+#'   `tbl` can be `NULL`).
 #' @param read_fn A function that's used for reading in the data. If a `tbl` is
 #'   not provided, then this function will be invoked. However, if both a `tbl`
 #'   *and* a `read_fn` is specified, then the supplied `tbl` will take priority.

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -744,7 +744,17 @@ interrogate_regex <- function(agent, idx, table) {
       stop("Regex-based validations are currently not supported on SQLite database tables", call. = FALSE)
     }
     
-    if (tbl_type == "mysql") {
+    if (tbl_type == "tbl_spark") { 
+      
+      tbl <- 
+        table %>%
+        dplyr::mutate(pb_is_good_ = ifelse(!is.na({{ column }}), RLIKE({{ column }}, regex), NA)) %>%
+        dplyr::mutate(pb_is_good_ = dplyr::case_when(
+          is.na(pb_is_good_) ~ na_pass,
+          TRUE ~ pb_is_good_
+        ))
+      
+    } else if (tbl_type == "mysql") {
 
       tbl <- 
         table %>%

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -955,7 +955,7 @@ interrogate_col_schema_match <- function(agent, idx, table) {
   table_schema_y <- agent$validation_set$values[[idx]]
   
   # Get the `table` `col_schema` object (this is constructed from the table)
-  if (inherits(table, "tbl_dbi")) {
+  if (inherits(table, "tbl_dbi") || inherits(table, "tbl_spark")) {
     
     if (inherits(table_schema_y, "sql_type")) {
       

--- a/R/rows_distinct.R
+++ b/R/rows_distinct.R
@@ -7,10 +7,10 @@
 #' in the table. The validation function can be used directly on a data table or
 #' with an *agent* object (technically, a `ptblank_agent` object) whereas the
 #' expectation and test functions can only be used with a data table. The types
-#' of data tables that can be used include data frames, tibbles, and even
-#' database tables of `tbl_dbi` class. As a validation step or as an
-#' expectation, this will operate over the number of test units that is equal to
-#' the number of rows in the table (after any `preconditions` have been
+#' of data tables that can be used include data frames, tibbles, database tables
+#' (`tbl_dbi`), and Spark DataFrames (`tbl_spark`). As a validation step or as
+#' an expectation, this will operate over the number of test units that is equal
+#' to the number of rows in the table (after any `preconditions` have been
 #' applied).
 #'
 #' We can specify the constraining column names in quotes, in `vars()`, and with

--- a/R/scan_data.R
+++ b/R/scan_data.R
@@ -23,14 +23,14 @@
 #' `scan_data(tbl = mtcars) %>% as.character()`). The resulting HTML string is a
 #' complete HTML document where Bootstrap and jQuery are embedded within.
 #' 
-#' @param tbl The input table. This can be a data frame, tibble, or `tbl_dbi`.
-#'   object.
+#' @param tbl The input table. This can be a data frame, tibble, a `tbl_dbi`
+#'   object, or a `tbl_spark` object.
 #' @param sections The sections to include in the finalized `Table Scan` report.
 #'   A character vector with section names is required here. The sections in
 #'   their default order are: `"overview"`, `"variables"`, `"interactions"`,
 #'   `"correlations"`, `"missing"`, and `"sample"`. This vector can be comprised
 #'   of less elements and the order can be changed to suit the desired layout of
-#'   the report. For `tbl_dbi` objects, the `"interactions"` and
+#'   the report. For `tbl_dbi` and `tbl_spark` objects, the `"interactions"` and
 #'   `"correlations"` sections are excluded.
 #' @param navbar Should there be a navigation bar anchored to the top of the
 #'   report page? By default this is `TRUE`.

--- a/R/scan_data.R
+++ b/R/scan_data.R
@@ -57,7 +57,7 @@ scan_data <- function(tbl,
   # nocov start
   
   # Limit components if a `tbl_dbi` object is supplied as the `tbl`
-  if (inherits(tbl, "tbl_dbi")) {
+  if (inherits(tbl, "tbl_dbi") || inherits(tbl, "tbl_spark")) {
     sections <- setdiff(sections, c("interactions", "correlations"))
   }
   

--- a/R/utils.R
+++ b/R/utils.R
@@ -274,6 +274,27 @@ get_tbl_information <- function(tbl) {
       )
     )
     
+  } else if (inherits(tbl, "tbl_spark")) {
+    
+    r_column_names_types <- get_r_column_names_types(tbl)
+    
+    tbl_schema <- sparklyr::sdf_schema(tbl)
+    
+    db_col_types <- 
+      lapply(tbl_schema, `[[`, 2) %>%
+      unlist() %>% unname() %>% tolower()
+    
+    return(
+      list(
+        tbl_src = "tbl_spark",
+        tbl_src_details = "Spark",
+        db_tbl_name = NA_character_,
+        col_names = r_column_names_types$col_names,
+        r_col_types = r_column_names_types$r_col_types,
+        db_col_types = db_col_types
+      )
+    )
+    
   } else if (inherits(tbl, "tbl_dbi")) {
     
     tbl_src <- gsub("^([a-z]*).*", "\\1", get_tbl_dbi_src_details(tbl))

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -78,6 +78,7 @@ utils::globalVariables(
     "q_1",
     "q_3",
     "%REGEXP%",
+    "RLIKE",
     "S",
     "schema",
     "sd",

--- a/man/agent_write.Rd
+++ b/man/agent_write.Rd
@@ -19,8 +19,8 @@ agent_write(agent, filename, path = NULL, keep_tbl = FALSE)
 \emph{agent} (which is the case when the \emph{agent} is created using
 \verb{create_agent(tbl = <data table, ...)}). The default is \code{FALSE} where the
 data table is removed before writing to disk. For database tables of the
-class \code{tbl_dbi}, the table is always removed (even if \code{keep_tbl} is set to
-\code{TRUE}).}
+class \code{tbl_dbi} and for Spark DataFrames (\code{tbl_spark}) the table is always
+removed (even if \code{keep_tbl} is set to \code{TRUE}).}
 }
 \description{
 Writing an \emph{agent} to disk with \code{agent_write()} is good practice for keeping
@@ -28,7 +28,7 @@ data validation intel close at hand for later retrieval (with
 \code{\link[=agent_read]{agent_read()}}). By default, any data table that the \emph{agent} may have before
 being committed to disk will be expunged. This behavior can be changed by
 setting \code{keep_tbl} to \code{TRUE} but this only works in the case where the table
-is not of the \code{tbl_dbi} class.
+is not of the \code{tbl_dbi} or the \code{tbl_spark} class.
 }
 \details{
 It can be helpful to set a table-reading function to later reuse the \emph{agent}

--- a/man/col_exists.Rd
+++ b/man/col_exists.Rd
@@ -20,8 +20,9 @@ expect_col_exists(object, columns, threshold = 1)
 test_col_exists(object, columns, threshold = 1)
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{One or more columns from the table in focus. This can be
 provided as a vector of column names using \code{c()} or bare column names
@@ -52,8 +53,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -79,9 +81,9 @@ of the column names. The validation function can be used directly on a data
 table or with an \emph{agent} object (technically, a \code{ptblank_agent} object)
 whereas the expectation and test functions can only be used with a data
 table. The types of data tables that can be used include data frames,
-tibbles, and even database tables of the \code{tbl_dbi} class. Each validation
-step or expectation will operate over a single test unit, which is whether
-the column exists or not.
+tibbles, database tables (\code{tbl_dbi}), and Spark DataFrames (\code{tbl_spark}).
+Each validation step or expectation will operate over a single test unit,
+which is whether the column exists or not.
 }
 \details{
 If providing multiple column names, the result will be an expansion of

--- a/man/col_is_character.Rd
+++ b/man/col_is_character.Rd
@@ -20,8 +20,9 @@ expect_col_is_character(object, columns, threshold = 1)
 test_col_is_character(object, columns, threshold = 1)
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -51,8 +52,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -79,9 +81,9 @@ requirement is a specification of the column names. The validation function
 can be used directly on a data table or with an \emph{agent} object (technically,
 a \code{ptblank_agent} object) whereas the expectation and test functions can only
 be used with a data table. The types of data tables that can be used include
-data frames, tibbles, and even database tables of the \code{tbl_dbi} class. Each
-validation step or expectation will operate over a single test unit, which is
-whether the column is a character-type column or not.
+data frames, tibbles, database tables (\code{tbl_dbi}), and Spark DataFrames
+(\code{tbl_spark}). Each validation step or expectation will operate over a single
+test unit, which is whether the column is a character-type column or not.
 }
 \details{
 If providing multiple column names, the result will be an expansion of

--- a/man/col_is_date.Rd
+++ b/man/col_is_date.Rd
@@ -20,8 +20,9 @@ expect_col_is_date(object, columns, threshold = 1)
 test_col_is_date(object, columns, threshold = 1)
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -51,8 +52,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -79,9 +81,9 @@ a specification of the column names. The validation function can be used
 directly on a data table or with an \emph{agent} object (technically, a
 \code{ptblank_agent} object) whereas the expectation and test functions can only
 be used with a data table. The types of data tables that can be used include
-data frames, tibbles, and even database tables of the \code{tbl_dbi} class. Each
-validation step or expectation will operate over a single test unit, which is
-whether the column is a \code{Date}-type column or not.
+data frames, tibbles, database tables (\code{tbl_dbi}), and Spark DataFrames
+(\code{tbl_spark}). Each validation step or expectation will operate over a single
+test unit, which is whether the column is a \code{Date}-type column or not.
 }
 \details{
 If providing multiple column names, the result will be an expansion of

--- a/man/col_is_factor.Rd
+++ b/man/col_is_factor.Rd
@@ -20,8 +20,9 @@ expect_col_is_factor(object, columns, threshold = 1)
 test_col_is_factor(object, columns, threshold = 1)
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -51,8 +52,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -79,9 +81,9 @@ specification of the column names. The validation function can be used
 directly on a data table or with an \emph{agent} object (technically, a
 \code{ptblank_agent} object) whereas the expectation and test functions can only
 be used with a data table. The types of data tables that can be used include
-data frames, tibbles, and even database tables of the \code{tbl_dbi} class. Each
-validation step or expectation will operate over a single test unit, which is
-whether the column is a factor-type column or not.
+data frames, tibbles, database tables (\code{tbl_dbi}), and Spark DataFrames
+(\code{tbl_spark}). Each validation step or expectation will operate over a single
+test unit, which is whether the column is a factor-type column or not.
 }
 \details{
 If providing multiple column names, the result will be an expansion of

--- a/man/col_is_integer.Rd
+++ b/man/col_is_integer.Rd
@@ -20,8 +20,9 @@ expect_col_is_integer(object, columns, threshold = 1)
 test_col_is_integer(object, columns, threshold = 1)
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -51,8 +52,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -79,9 +81,9 @@ specification of the column names. The validation function can be used
 directly on a data table or with an \emph{agent} object (technically, a
 \code{ptblank_agent} object) whereas the expectation and test functions can only
 be used with a data table. The types of data tables that can be used include
-data frames, tibbles, and even database tables of the \code{tbl_dbi} class. Each
-validation step or expectation will operate over a single test unit, which is
-whether the column is an integer-type column or not.
+data frames, tibbles, database tables (\code{tbl_dbi}), and Spark DataFrames
+(\code{tbl_spark}). Each validation step or expectation will operate over a single
+test unit, which is whether the column is an integer-type column or not.
 }
 \details{
 If providing multiple column names, the result will be an expansion of

--- a/man/col_is_logical.Rd
+++ b/man/col_is_logical.Rd
@@ -20,8 +20,9 @@ expect_col_is_logical(object, columns, threshold = 1)
 test_col_is_logical(object, columns, threshold = 1)
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -51,8 +52,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -79,10 +81,10 @@ only requirement is a specification of the column names. The validation
 function can be used directly on a data table or with an \emph{agent} object
 (technically, a \code{ptblank_agent} object) whereas the expectation and test
 functions can only be used with a data table. The types of data tables that
-can be used include data frames, tibbles, and even database tables of the
-\code{tbl_dbi} class. Each validation step or expectation will operate over a
-single test unit, which is whether the column is an logical-type column or
-not.
+can be used include data frames, tibbles, database tables (\code{tbl_dbi}), and
+Spark DataFrames (\code{tbl_spark}). Each validation step or expectation will
+operate over a single test unit, which is whether the column is an
+logical-type column or not.
 }
 \details{
 If providing multiple column names, the result will be an expansion of

--- a/man/col_is_numeric.Rd
+++ b/man/col_is_numeric.Rd
@@ -20,8 +20,9 @@ expect_col_is_numeric(object, columns, threshold = 1)
 test_col_is_numeric(object, columns, threshold = 1)
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -51,8 +52,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -79,9 +81,9 @@ specification of the column names. The validation function can be used
 directly on a data table or with an \emph{agent} object (technically, a
 \code{ptblank_agent} object) whereas the expectation and test functions can only
 be used with a data table. The types of data tables that can be used include
-data frames, tibbles, and even database tables of \code{tbl_dbi} class. Each
-validation step or expectation will operate over a single test unit, which is
-whether the column is a numeric-type column or not.
+data frames, tibbles, database tables (\code{tbl_dbi}), and Spark DataFrames
+(\code{tbl_spark}). Each validation step or expectation will operate over a single
+test unit, which is whether the column is a numeric-type column or not.
 }
 \details{
 If providing multiple column names, the result will be an expansion of

--- a/man/col_is_posix.Rd
+++ b/man/col_is_posix.Rd
@@ -20,8 +20,9 @@ expect_col_is_posix(object, columns, threshold = 1)
 test_col_is_posix(object, columns, threshold = 1)
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -51,8 +52,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -79,9 +81,9 @@ requirement is a specification of the column names. The validation function
 can be used directly on a data table or with an \emph{agent} object (technically,
 a \code{ptblank_agent} object) whereas the expectation and test functions can only
 be used with a data table. The types of data tables that can be used include
-data frames, tibbles, and even database tables of \code{tbl_dbi} class. Each
-validation step or expectation will operate over a single test unit, which is
-whether the column is a \code{POSIXct}-type column or not.
+data frames, tibbles, database tables (\code{tbl_dbi}), and Spark DataFrames
+(\code{tbl_spark}). Each validation step or expectation will operate over a single
+test unit, which is whether the column is a \code{POSIXct}-type column or not.
 }
 \details{
 If providing multiple column names, the result will be an expansion of

--- a/man/col_schema.Rd
+++ b/man/col_schema.Rd
@@ -22,12 +22,14 @@ necessary when using the \code{\link[=col_schema_match]{col_schema_match()}} val
 checks whether the table object under study matches a known column schema).
 The \code{col_schema} object can be made by carefully supplying the column names
 and their types as a set of named arguments, or, we could provide a table
-object, which could by of the \code{data.frame}, \code{tbl_df}, or \code{tbl_dbi} varieties.
-There's an additional option, which is just for validating the schema of a
-\code{tbl_dbi} object: we can validate the schema based on R column types (e.g.,
-\code{"numeric"}, \code{"character"}, etc.), or, SQL column types (e.g., \code{"double"},
-\code{"varchar"}, etc.). This is great if we want to validate table column schemas
-both on the server side and when tabular data is collected and loaded into R.
+object, which could by of the \code{data.frame}, \code{tbl_df}, \code{tbl_dbi}, or
+\code{tbl_spark} varieties. There's an additional option, which is just for
+validating the schema of a \code{tbl_dbi} or \code{tbl_spark} object: we can validate
+the schema based on R column types (e.g., \code{"numeric"}, \code{"character"}, etc.),
+SQL column types (e.g., \code{"double"}, \code{"varchar"}, etc.), or Spark SQL column
+types (\code{"DoubleType"}, \code{"StringType"}, etc.). This is great if we want to
+validate table column schemas both on the server side and when tabular data
+is collected and loaded into R.
 }
 \section{Function ID}{
 
@@ -55,9 +57,9 @@ schema_obj <-
   )
 
 # Validate that the schema object
-# `col_schema_x` exactly defines
+# `schema_obj` exactly defines
 # the column names and column types
-# of the `tbl_x` table
+# of the `tbl` table
 agent <-
   create_agent(tbl = tbl) \%>\%
   col_schema_match(schema_obj) \%>\%

--- a/man/col_schema_match.Rd
+++ b/man/col_schema_match.Rd
@@ -34,8 +34,9 @@ test_col_schema_match(
 )
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{schema}{A table schema of type \code{col_schema} which can be generated
 using the \code{\link[=col_schema]{col_schema()}} function.}
@@ -76,8 +77,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -104,14 +106,17 @@ that of the target table. The validation function can be used directly on a
 data table or with an \emph{agent} object (technically, a \code{ptblank_agent} object)
 whereas the expectation and test functions can only be used with a data
 table. The types of data tables that can be used include data frames,
-tibbles, and even database tables of \code{tbl_dbi} class. The validation step or
-expectation operates over a single test unit, which is whether the schema
-matches that of the table (within the constraints enforced by the \code{complete}
-and \code{in_order} options). If the target table is a \code{tbl_dbi} object, we can
-choose to validate the column schema that is based on R column types (e.g.,
-\code{"numeric"}, \code{"character"}, etc.), or, SQL column types (e.g., \code{"double"},
-\code{"varchar"}, etc.). That option is defined in the \code{\link[=col_schema]{col_schema()}} function (it
-is the \code{.db_col_types} argument).
+tibbles, database tables (\code{tbl_dbi}), and Spark DataFrames (\code{tbl_spark}).
+Each validation step or expectation will operate over a single test unit,
+which is whether the column is an integer-type column or not. The validation
+step or expectation operates over a single test unit, which is whether the
+schema matches that of the table (within the constraints enforced by the
+\code{complete} and \code{in_order} options). If the target table is a \code{tbl_dbi} or a
+\code{tbl_spark} object, we can choose to validate the column schema that is based
+on R column types (e.g., \code{"numeric"}, \code{"character"}, etc.), SQL column types
+(e.g., \code{"double"}, \code{"varchar"}, etc.), or Spark SQL types (e.g,.
+\code{"DoubleType"}, \code{"StringType"}, etc.). That option is defined in the
+\code{\link[=col_schema]{col_schema()}} function (it is the \code{.db_col_types} argument).
 }
 \details{
 Often, we will want to specify \code{actions} for the validation. This argument,

--- a/man/col_vals_between.Rd
+++ b/man/col_vals_between.Rd
@@ -43,8 +43,9 @@ test_col_vals_between(
 )
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -98,8 +99,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -133,9 +135,12 @@ validation functions. The validation function can be used directly on a data
 table or with an \emph{agent} object (technically, a \code{ptblank_agent} object)
 whereas the expectation and test functions can only be used with a data
 table. The types of data tables that can be used include data frames,
-tibbles, and even database tables of \code{tbl_dbi} class. Each validation step or
-expectation will operate over the number of test units that is equal to the
-number of rows in the table (after any \code{preconditions} have been applied).
+tibbles, database tables (\code{tbl_dbi}), and Spark DataFrames (\code{tbl_spark}).
+Each validation step or expectation will operate over a single test unit,
+which is whether the column is an integer-type column or not. Each validation
+step or expectation will operate over the number of test units that is equal
+to the number of rows in the table (after any \code{preconditions} have been
+applied).
 }
 \details{
 If providing multiple column names to \code{columns}, the result will be an

--- a/man/col_vals_equal.Rd
+++ b/man/col_vals_equal.Rd
@@ -37,8 +37,9 @@ test_col_vals_equal(
 )
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -80,8 +81,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -107,10 +109,10 @@ whether column values in a table are equal to a specified \code{value}. The
 in \code{vars()}. The validation function can be used directly on a data table or
 with an \emph{agent} object (technically, a \code{ptblank_agent} object) whereas the
 expectation and test functions can only be used with a data table. The types
-of data tables that can be used include data frames, tibbles, and even
-database tables of \code{tbl_dbi} class. Each validation step or expectation will
-operate over the number of test units that is equal to the number of rows in
-the table (after any \code{preconditions} have been applied).
+of data tables that can be used include data frames, tibbles, database tables
+(\code{tbl_dbi}), and Spark DataFrames (\code{tbl_spark}). Each validation step or
+expectation will operate over the number of test units that is equal to the
+number of rows in the table (after any \code{preconditions} have been applied).
 }
 \details{
 If providing multiple column names to \code{columns}, the result will be an

--- a/man/col_vals_expr.Rd
+++ b/man/col_vals_expr.Rd
@@ -21,8 +21,9 @@ expect_col_vals_expr(object, expr, preconditions = NULL, threshold = 1)
 test_col_vals_expr(object, expr, preconditions = NULL, threshold = 1)
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{expr}{An expression to use for this test. This can either be in the
 form of a call made with the \code{expr()} function or as a one-sided \strong{R}
@@ -59,8 +60,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -84,10 +86,10 @@ a table match a user-defined predicate expression. The validation function
 can be used directly on a data table or with an \emph{agent} object (technically,
 a \code{ptblank_agent} object) whereas the expectation and test functions can only
 be used with a data table. The types of data tables that can be used include
-data frames, tibbles, and even database tables of \code{tbl_dbi} class. Each
-validation step or expectation will operate over the number of test units
-that is equal to the number of rows in the table (after any \code{preconditions}
-have been applied).
+data frames, tibbles, database tables (\code{tbl_dbi}), and Spark DataFrames
+(\code{tbl_spark}). Each validation step or expectation will operate over the
+number of test units that is equal to the number of rows in the table (after
+any \code{preconditions} have been applied).
 }
 \details{
 Having table \code{preconditions} means \strong{pointblank} will mutate the table just

--- a/man/col_vals_gt.Rd
+++ b/man/col_vals_gt.Rd
@@ -37,8 +37,9 @@ test_col_vals_gt(
 )
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -81,8 +82,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -109,10 +111,10 @@ be specified as a single, literal value or as a column name given in
 \code{vars()}. The validation function can be used directly on a data table or
 with an \emph{agent} object (technically, a \code{ptblank_agent} object) whereas the
 expectation and test functions can only be used with a data table. The types
-of data tables that can be used include data frames, tibbles, and even
-database tables of \code{tbl_dbi} class. Each validation step or expectation will
-operate over the number of test units that is equal to the number of rows in
-the table (after any \code{preconditions} have been applied).
+of data tables that can be used include data frames, tibbles, database tables
+(\code{tbl_dbi}), and Spark DataFrames (\code{tbl_spark}). Each validation step or
+expectation will operate over the number of test units that is equal to the
+number of rows in the table (after any \code{preconditions} have been applied).
 }
 \details{
 If providing multiple column names to \code{columns}, the result will be an

--- a/man/col_vals_gte.Rd
+++ b/man/col_vals_gte.Rd
@@ -37,8 +37,9 @@ test_col_vals_gte(
 )
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -80,8 +81,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -109,9 +111,10 @@ given in \code{vars()}. The validation step function can be used directly on a
 data table or with an \emph{agent} object (technically, a \code{ptblank_agent} object)
 whereas the expectation and test functions can only be used with a data
 table. The types of data tables that can be used include data frames,
-tibbles, and even database tables of \code{tbl_dbi} class. Each validation step or
-expectation will operate over the number of test units that is equal to the
-number of rows in the table (after any \code{preconditions} have been applied).
+tibbles, database tables (\code{tbl_dbi}), and Spark DataFrames (\code{tbl_spark}).
+Each validation step or expectation will operate over the number of test
+units that is equal to the number of rows in the table (after any
+\code{preconditions} have been applied).
 }
 \details{
 If providing multiple column names to \code{columns}, the result will be an

--- a/man/col_vals_in_set.Rd
+++ b/man/col_vals_in_set.Rd
@@ -28,8 +28,9 @@ expect_col_vals_in_set(
 test_col_vals_in_set(object, columns, set, preconditions = NULL, threshold = 1)
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -68,8 +69,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -94,10 +96,10 @@ check whether column values in a table are part of a specified \code{set} of
 values. The validation step function can be used directly on a data table or
 with an \emph{agent} object (technically, a \code{ptblank_agent} object) whereas the
 expectation and test functions can only be used with a data table. The types
-of data tables that can be used include data frames, tibbles, and even
-database tables of \code{tbl_dbi} class. Each validation step or expectation will
-operate over the number of test units that is equal to the number of rows in
-the table (after any \code{preconditions} have been applied).
+of data tables that can be used include data frames, tibbles, database tables
+(\code{tbl_dbi}), and Spark DataFrames (\code{tbl_spark}). Each validation step or
+expectation will operate over the number of test units that is equal to the
+number of rows in the table (after any \code{preconditions} have been applied).
 }
 \details{
 If providing multiple column names, the result will be an expansion of

--- a/man/col_vals_lt.Rd
+++ b/man/col_vals_lt.Rd
@@ -37,8 +37,9 @@ test_col_vals_lt(
 )
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -81,8 +82,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -109,10 +111,10 @@ be specified as a single, literal value or as a column name given in
 \code{vars()}. The validation function can be used directly on a data table or
 with an \emph{agent} object (technically, a \code{ptblank_agent} object) whereas the
 expectation and test functions can only be used with a data table. The types
-of data tables that can be used include data frames, tibbles, and even
-database tables of \code{tbl_dbi} class. Each validation step or expectation will
-operate over the number of test units that is equal to the number of rows in
-the table (after any \code{preconditions} have been applied).
+of data tables that can be used include data frames, tibbles, database tables
+(\code{tbl_dbi}), and Spark DataFrames (\code{tbl_spark}). Each validation step or
+expectation will operate over the number of test units that is equal to the
+number of rows in the table (after any \code{preconditions} have been applied).
 }
 \details{
 If providing multiple column names to \code{columns}, the result will be an

--- a/man/col_vals_lte.Rd
+++ b/man/col_vals_lte.Rd
@@ -37,8 +37,9 @@ test_col_vals_lte(
 )
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -81,8 +82,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -110,9 +112,10 @@ given in \code{vars()}. The validation step function can be used directly on a
 data table or with an \emph{agent} object (technically, a \code{ptblank_agent} object)
 whereas the expectation and test functions can only be used with a data
 table. The types of data tables that can be used include data frames,
-tibbles, and even database tables of \code{tbl_dbi} class. Each validation step or
-expectation will operate over the number of test units that is equal to the
-number of rows in the table (after any \code{preconditions} have been applied).
+tibbles, database tables (\code{tbl_dbi}), and Spark DataFrames (\code{tbl_spark}).
+Each validation step or expectation will operate over the number of test
+units that is equal to the number of rows in the table (after any
+\code{preconditions} have been applied).
 }
 \details{
 If providing multiple column names to \code{columns}, the result will be an

--- a/man/col_vals_not_between.Rd
+++ b/man/col_vals_not_between.Rd
@@ -43,8 +43,9 @@ test_col_vals_not_between(
 )
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -91,8 +92,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -126,9 +128,10 @@ validation functions. The validation function can be used directly on a data
 table or with an \emph{agent} object (technically, a \code{ptblank_agent} object)
 whereas the expectation and test functions can only be used with a data
 table. The types of data tables that can be used include data frames,
-tibbles, and even database tables of \code{tbl_dbi} class. Each validation step or
-expectation will operate over the number of test units that is equal to the
-number of rows in the table (after any \code{preconditions} have been applied).
+tibbles, database tables (\code{tbl_dbi}), and Spark DataFrames (\code{tbl_spark}).
+Each validation step or expectation will operate over the number of test
+units that is equal to the number of rows in the table (after any
+\code{preconditions} have been applied).
 }
 \details{
 If providing multiple column names to \code{columns}, the result will be an

--- a/man/col_vals_not_equal.Rd
+++ b/man/col_vals_not_equal.Rd
@@ -37,8 +37,9 @@ test_col_vals_not_equal(
 )
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -80,8 +81,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -107,10 +109,10 @@ a table \emph{are not} equal to a specified \code{value}. The validation step fu
 can be used directly on a data table or with an \emph{agent} object (technically,
 a \code{ptblank_agent} object) whereas the expectation and test functions can only
 be used with a data table. The types of data tables that can be used include
-data frames, tibbles, and even database tables of \code{tbl_dbi} class. Each
-validation step or expectation will operate over the number of test units
-that is equal to the number of rows in the table (after any \code{preconditions}
-have been applied).
+data frames, tibbles, database tables (\code{tbl_dbi}), and Spark DataFrames
+(\code{tbl_spark}). Each validation step or expectation will operate over the
+number of test units that is equal to the number of rows in the table (after
+any \code{preconditions} have been applied).
 }
 \details{
 If providing multiple column names, the result will be an expansion of

--- a/man/col_vals_not_in_set.Rd
+++ b/man/col_vals_not_in_set.Rd
@@ -34,8 +34,9 @@ test_col_vals_not_in_set(
 )
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -74,8 +75,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -101,10 +103,10 @@ a table \emph{are not part} of a specified \code{set} of values. The validation
 function can be used directly on a data table or with an \emph{agent} object
 (technically, a \code{ptblank_agent} object) whereas the expectation and test
 functions can only be used with a data table. The types of data tables that
-can be used include data frames, tibbles, and even database tables of
-\code{tbl_dbi} class. Each validation step or expectation will operate over the
-number of test units that is equal to the number of rows in the table (after
-any \code{preconditions} have been applied).
+can be used include data frames, tibbles, database tables (\code{tbl_dbi}), and
+Spark DataFrames (\code{tbl_spark}). Each validation step or expectation will
+operate over the number of test units that is equal to the number of rows in
+the table (after any \code{preconditions} have been applied).
 }
 \details{
 If providing multiple column names, the result will be an expansion of

--- a/man/col_vals_not_null.Rd
+++ b/man/col_vals_not_null.Rd
@@ -21,8 +21,9 @@ expect_col_vals_not_null(object, columns, preconditions = NULL, threshold = 1)
 test_col_vals_not_null(object, columns, preconditions = NULL, threshold = 1)
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -58,8 +59,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -85,10 +87,10 @@ table \emph{are not} \code{NA} values or, in the database context, \emph{not} \c
 The validation function can be used directly on a data table or with an
 \emph{agent} object (technically, a \code{ptblank_agent} object) whereas the
 expectation and test functions can only be used with a data table. The types
-of data tables that can be used include data frames, tibbles, and even
-database tables of \code{tbl_dbi} class. Each validation step or expectation will
-operate over the number of test units that is equal to the number of rows in
-the table (after any \code{preconditions} have been applied).
+of data tables that can be used include data frames, tibbles, database tables
+(\code{tbl_dbi}), and Spark DataFrames (\code{tbl_spark}). Each validation step or
+expectation will operate over the number of test units that is equal to the
+number of rows in the table (after any \code{preconditions} have been applied).
 }
 \details{
 If providing multiple column names, the result will be an expansion of

--- a/man/col_vals_null.Rd
+++ b/man/col_vals_null.Rd
@@ -21,8 +21,9 @@ expect_col_vals_null(object, columns, preconditions = NULL, threshold = 1)
 test_col_vals_null(object, columns, preconditions = NULL, threshold = 1)
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -58,8 +59,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -84,10 +86,10 @@ whether column values in a table are \code{NA} values or, in the database contex
 \code{NULL} values. The validation function can be used directly on a data table
 or with an \emph{agent} object (technically, a \code{ptblank_agent} object) whereas the
 expectation and test functions can only be used with a data table. The types
-of data tables that can be used include data frames, tibbles, and even
-database tables of \code{tbl_dbi} class. Each validation step or expectation will
-operate over the number of test units that is equal to the number of rows in
-the table (after any \code{preconditions} have been applied).
+of data tables that can be used include data frames, tibbles, database tables
+(\code{tbl_dbi}), and Spark DataFrames (\code{tbl_spark}). Each validation step or
+expectation will operate over the number of test units that is equal to the
+number of rows in the table (after any \code{preconditions} have been applied).
 }
 \details{
 If providing multiple column names, the result will be an expansion of

--- a/man/col_vals_regex.Rd
+++ b/man/col_vals_regex.Rd
@@ -37,8 +37,9 @@ test_col_vals_regex(
 )
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -80,8 +81,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -106,10 +108,10 @@ whether column values in a table correspond to a \code{regex} matching expressio
 The validation step function can be used directly on a data table or with an
 \emph{agent} object (technically, a \code{ptblank_agent} object) whereas the
 expectation and test functions can only be used with a data table. The types
-of data tables that can be used include data frames, tibbles, and even
-database tables of \code{tbl_dbi} class. Each validation step or expectation will
-operate over the number of test units that is equal to the number of rows in
-the table (after any \code{preconditions} have been applied).
+of data tables that can be used include data frames, tibbles, database tables
+(\code{tbl_dbi}), and Spark DataFrames (\code{tbl_spark}). Each validation step or
+expectation will operate over the number of test units that is equal to the
+number of rows in the table (after any \code{preconditions} have been applied).
 }
 \details{
 If providing multiple column names, the result will be an expansion of

--- a/man/conjointly.Rd
+++ b/man/conjointly.Rd
@@ -34,8 +34,9 @@ test_conjointly(
 )
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{...}{a collection one-sided formulas that consist of validation step
 functions that validate row units. Specifically, these functions should be
@@ -75,8 +76,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any

--- a/man/create_agent.Rd
+++ b/man/create_agent.Rd
@@ -15,10 +15,10 @@ create_agent(
 )
 }
 \arguments{
-\item{tbl}{The input table. This can be a data frame, a tibble, or a
-\code{tbl_dbi} object. Alternatively, a function can be used to read in the
-input data table with the \code{read_fn} argument (in which case, \code{tbl} can be
-\code{NULL}).}
+\item{tbl}{The input table. This can be a data frame, a tibble, a \code{tbl_dbi}
+object, or a \code{tbl_spark} object. Alternatively, a function can be used to
+read in the input data table with the \code{read_fn} argument (in which case,
+\code{tbl} can be \code{NULL}).}
 
 \item{read_fn}{A function that's used for reading in the data. If a \code{tbl} is
 not provided, then this function will be invoked. However, if both a \code{tbl}

--- a/man/remove_read_fn.Rd
+++ b/man/remove_read_fn.Rd
@@ -12,7 +12,8 @@ remove_read_fn(agent)
 }
 \description{
 Removing an \emph{agent}'s association to a table-reading function can be done
-with \code{remove_read_fn()}. This may be good idea when relying on the direct
-association of a data table (settable in \code{\link[=create_agent]{create_agent()}}'s \code{tbl} argument or
-with \code{\link[=set_tbl]{set_tbl()}}), where the table-reading function is no longer relevant.
+with \code{remove_read_fn()}. This may be good idea when instead relying on the
+direct association of a data table (settable in \code{\link[=create_agent]{create_agent()}}'s \code{tbl}
+argument or with \code{\link[=set_tbl]{set_tbl()}}), where the table-reading function is no longer
+relevant.
 }

--- a/man/rows_distinct.Rd
+++ b/man/rows_distinct.Rd
@@ -26,8 +26,9 @@ expect_rows_distinct(
 test_rows_distinct(object, columns = NULL, preconditions = NULL, threshold = 1)
 }
 \arguments{
-\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or, an agent object of
-class \code{ptblank_agent} that is created with \code{\link[=create_agent]{create_agent()}}.}
+\item{x}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), Spark DataFrame
+(\code{tbl_spark}), or, an agent object of class \code{ptblank_agent} that is created
+with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{The column (or a set of columns, provided as a character
 vector) to which this validation should be applied.}
@@ -63,8 +64,9 @@ indexes for the steps unchanged). If the step function will be operating
 directly on data, then any step with \code{active = FALSE} will simply pass the
 data through with no validation whatsoever. The default for this is \code{TRUE}.}
 
-\item{object}{A data frame or tibble (\code{tbl_df} or \code{tbl_dbi}) that serves as
-the target table for the expectation function.}
+\item{object}{A data frame, tibble (\code{tbl_df} or \code{tbl_dbi}), or Spark
+DataFrame (\code{tbl_spark}) that serves as the target table for the expectation
+function or the test function.}
 
 \item{threshold}{A simple failure threshold value for use with the
 expectation function. By default, this is set to \code{1} meaning that any
@@ -90,10 +92,10 @@ whether row values (optionally constrained to a selection of specified
 in the table. The validation function can be used directly on a data table or
 with an \emph{agent} object (technically, a \code{ptblank_agent} object) whereas the
 expectation and test functions can only be used with a data table. The types
-of data tables that can be used include data frames, tibbles, and even
-database tables of \code{tbl_dbi} class. As a validation step or as an
-expectation, this will operate over the number of test units that is equal to
-the number of rows in the table (after any \code{preconditions} have been
+of data tables that can be used include data frames, tibbles, database tables
+(\code{tbl_dbi}), and Spark DataFrames (\code{tbl_spark}). As a validation step or as
+an expectation, this will operate over the number of test units that is equal
+to the number of rows in the table (after any \code{preconditions} have been
 applied).
 }
 \details{

--- a/man/scan_data.Rd
+++ b/man/scan_data.Rd
@@ -13,15 +13,15 @@ scan_data(
 )
 }
 \arguments{
-\item{tbl}{The input table. This can be a data frame, tibble, or \code{tbl_dbi}.
-object.}
+\item{tbl}{The input table. This can be a data frame, tibble, a \code{tbl_dbi}
+object, or a \code{tbl_spark} object.}
 
 \item{sections}{The sections to include in the finalized \verb{Table Scan} report.
 A character vector with section names is required here. The sections in
 their default order are: \code{"overview"}, \code{"variables"}, \code{"interactions"},
 \code{"correlations"}, \code{"missing"}, and \code{"sample"}. This vector can be comprised
 of less elements and the order can be changed to suit the desired layout of
-the report. For \code{tbl_dbi} objects, the \code{"interactions"} and
+the report. For \code{tbl_dbi} and \code{tbl_spark} objects, the \code{"interactions"} and
 \code{"correlations"} sections are excluded.}
 
 \item{navbar}{Should there be a navigation bar anchored to the top of the

--- a/man/set_tbl.Rd
+++ b/man/set_tbl.Rd
@@ -11,13 +11,13 @@ set_tbl(agent, tbl)
 \code{\link[=create_agent]{create_agent()}}.}
 
 \item{tbl}{The input table for the \code{agent}. This can be a data frame, a
-tibble, or a \code{tbl_dbi} object. Any table already associated with the
-\emph{agent} will be overwritten.}
+tibble, a \code{tbl_dbi} object, or a \code{tbl_spark} object. Any table already
+associated with the \emph{agent} will be overwritten.}
 }
 \description{
-Setting a data table to \emph{agent} with \code{set_tbl()} replaces any table (data
-frame, a tibble, or a \code{tbl_dbi} object) associated with the \emph{agent}. If no
-data table is associated with an \emph{agent}, setting one will mean the data
-table takes precedence over table-reading function (settable in
+Setting a data table to \emph{agent} with \code{set_tbl()} replaces any table (a data
+frame, a tibble, objects of class \code{tbl_dbi} or \code{tbl_spark}) associated with
+the \emph{agent}. If no data table is associated with an \emph{agent}, setting one will
+mean the data table takes precedence over table-reading function (settable in
 \code{\link[=create_agent]{create_agent()}}'s \code{read_fn} argument or with \code{\link[=set_read_fn]{set_read_fn()}}).
 }

--- a/tests/manual_tests/tests_mysql.R
+++ b/tests/manual_tests/tests_mysql.R
@@ -15,8 +15,13 @@ con <-
   port = 3306
 )
 
-# Set failure thresholds and functions that are
-# actioned from exceeding certain error levels
+##
+## Data Quality Analysis
+##
+
+# Create an `action_levels` object, setting
+# *warn*, *stop*, and *notify* thresholds at
+# 0.02, 0.05, and 0.10
 al <- action_levels(warn_at = 0.02, stop_at = 0.05, notify_at = 0.10)
 
 # Validate the `assembly` table in the `aedes_aegypti_core_55_1d` DB
@@ -61,3 +66,10 @@ DBI::dbDisconnect(con)
 
 # Get a report from the `agent`
 agent
+
+##
+## Table Scan
+##
+
+assembly_tbl <- dplyr::tbl(con, "assembly")
+scan_data(assembly_tbl)

--- a/tests/manual_tests/tests_sparklyr.R
+++ b/tests/manual_tests/tests_sparklyr.R
@@ -1,0 +1,96 @@
+library(tidyvere)
+library(pointblank)
+library(sparklyr)
+library(intendo)
+
+# Set an environment variable for the location of
+# Java 8 JDK; this library was obtained by using
+# `brew cask install homebrew/cask-versions/adoptopenjdk8`
+Sys.setenv(JAVA_HOME="/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home")
+
+# Install Spark if necessary
+# spark_install(version = "2.4.3", hadoop_version = "2.7")
+
+# Generate a Spark table with `intendo::intendo_revenue`
+sc <- spark_connect(master = "local")
+intendo_revenue_sp <- dplyr::copy_to(sc, intendo::intendo_revenue)
+
+##
+## Data Quality Analysis
+##
+
+# Make a vector of known product types
+intendo_products <-
+  c(
+    "gems1", "gems2", "gems3", "gems4", "gems5",
+    "gold1", "gold2", "gold3", "gold4", "gold5", "gold6", "gold7",
+    "offer1", "offer2", "offer3", "offer4", "offer5",
+    "ad_5sec", "pass"
+  )
+
+# Generate an expected schema for the table
+revenue_tbl_schema <- 
+  col_schema(
+    user_id = "StringType",
+    session_id = "StringType",
+    time = "TimestampType",
+    name = "StringType",
+    size = "StringType",
+    type = "StringType",
+    price = "DoubleType",
+    revenue = "DoubleType", 
+    .db_col_types = "sql"
+  )
+
+# Create an `action_levels` object, setting
+# *warn* and *stop* thresholds at 0.1 and 0.10
+al <- action_levels(warn_at = 0.01, stop_at = 0.10)
+
+agent <-
+  create_agent(tbl = intendo_revenue_sp, actions = al) %>%
+  col_vals_between(
+    vars(revenue),
+    left = 0.01, right = 150
+  ) %>%
+  col_vals_between(
+    vars(time),
+    left = "2015-01-01", right = "2016-01-01"
+  ) %>%
+  col_vals_lt(
+    vars(revenue),
+    value = vars(price),
+    preconditions = ~ . %>% filter(type != "ad")
+  ) %>%
+  col_vals_in_set(
+    vars(type),
+    set = c(
+      "ad", "currency", "season_pass",
+      "offer_agent", NA
+    ),
+  ) %>%
+  col_vals_in_set(
+    vars(name),
+    set = intendo_products
+  ) %>%
+  col_vals_regex(
+    vars(user_id),
+    regex = "[A-Y]{12}"
+  ) %>%
+  col_vals_regex(
+    vars(session_id),
+    regex = "[A-Z]{5}_[a-z]{8}"
+  ) %>%
+   col_schema_match(schema = revenue_tbl_schema) %>%
+  interrogate()
+
+agent
+
+##
+## Table Scan
+##
+
+# Use a smaller version of the `intendo::intendo_revenue` table
+intendo_revenue_small <- dplyr::copy_to(sc, intendo::intendo_revenue[1:2000, ])
+
+# Use `scan_data()` to get a Table Scan
+scan_data(intendo_revenue_small)

--- a/tests/manual_tests/tests_sparklyr.R
+++ b/tests/manual_tests/tests_sparklyr.R
@@ -1,4 +1,4 @@
-library(tidyvere)
+library(tidyverse)
 library(pointblank)
 library(sparklyr)
 library(intendo)

--- a/tests/manual_tests/tests_sparklyr.R
+++ b/tests/manual_tests/tests_sparklyr.R
@@ -52,6 +52,7 @@ agent <-
     vars(revenue),
     left = 0.01, right = 150
   ) %>%
+  col_vals_not_null(vars(user_id, session_id, time, name, type, revenue)) %>%
   col_vals_between(
     vars(time),
     left = "2015-01-01", right = "2016-01-01"
@@ -80,7 +81,8 @@ agent <-
     vars(session_id),
     regex = "[A-Z]{5}_[a-z]{8}"
   ) %>%
-   col_schema_match(schema = revenue_tbl_schema) %>%
+  col_is_character(vars(user_id, session_id)) %>%
+  col_schema_match(schema = revenue_tbl_schema) %>%
   interrogate()
 
 agent


### PR DESCRIPTION
This adds support for Spark DataFrames produced by the **sparklyr** package (`tbl_spark`). The goal is to have `tbl_spark` tables entirely compatible with all validation, expectation, and test functions, with `scan_data()`, and with all the post-interrogation functions.

A significant number of tests need to be added to ensure that there are no problems with `tbl_spark` tables across all relevant functions in **pointblank**.

Fixes: #62 