### PR TITLE
Fix for `get_sundered_data()` where a single validation step is used

### DIFF
--- a/R/get_sundered_data.R
+++ b/R/get_sundered_data.R
@@ -140,6 +140,8 @@ get_sundered_data <- function(agent,
     
     new_col_ii <- paste0("pb_is_good_", i + 1)
     
+    if (length(seq(tbl_check_obj)) == 1) break
+    
     tbl_check_join_r <- tbl_check_obj[[i + 1]][[1]]
     
     if (!(agent$tbl_src %in% c("tbl_df", "data.frame"))) {
@@ -180,7 +182,7 @@ get_sundered_data <- function(agent,
 
     if (i == (max(seq(tbl_check_obj)) - 1)) break
   }
-  
+
   columns_str_vec <- paste0("pb_is_good_", seq(tbl_check_obj))
   columns_str_add <- paste0("pb_is_good_", seq(tbl_check_obj), collapse = " + ")
   validation_n <- length(seq(tbl_check_obj))

--- a/tests/testthat/test-sundering.R
+++ b/tests/testthat/test-sundering.R
@@ -1,5 +1,3 @@
-context("Tests of the `get_sundered_data()` function")
-
 library(dplyr)
 library(RSQLite)
 library(DBI)
@@ -14,6 +12,12 @@ agent <-
   col_vals_gt(vars(d), 100) %>%
   col_vals_equal(vars(d), vars(d), na_pass = TRUE) %>%
   col_vals_between(vars(c), left = vars(a), right = vars(d), na_pass = TRUE) %>%
+  interrogate()
+
+# Create an agent with one validation step, perform interrogation
+agent_1 <-
+  create_agent(tbl = small_table) %>%
+  col_vals_gt(vars(d), 1000) %>%
   interrogate()
 
 # Create an agent with no validation steps, perform interrogation
@@ -125,7 +129,77 @@ test_that("sundered data can be generated and retrieved with a `tbl_df`", {
   )
 })
 
-test_that("sundered data from an agent is effectively all the data", {
+test_that("sundered data can be generated and retrieved with a `tbl_df` (one step)", {
+  
+  # These tests ensure that a single-step interrogation works
+  
+  # Get the 'pass' data piece using `get_sundered_data()`
+  pass_data_tbl <- 
+    get_sundered_data(agent_1, type = "pass")
+  
+  # Get the 'fail' data piece using `get_sundered_data()`
+  fail_data_tbl <- 
+    get_sundered_data(agent_1, type = "fail")
+  
+  # Expect that both tables are of the same type as the
+  # input data
+  expect_is(small_table, "tbl_df")
+  expect_is(pass_data_tbl, "tbl_df")
+  expect_is(fail_data_tbl, "tbl_df")
+  
+  # Expect certain dimensions for each table
+  expect_equal(dim(pass_data_tbl), c(7, 8))
+  expect_equal(dim(fail_data_tbl), c(6, 8))
+  
+  # Expect that the sum of rows from each data piece
+  # should equal the number of rows in the input table
+  expect_equal(nrow(pass_data_tbl) + nrow(fail_data_tbl), nrow(small_table))
+  
+  # Expect no common rows between the two
+  # data pieces
+  pass_data_tbl %>%
+    dplyr::semi_join(
+      fail_data_tbl,
+      by = c("date_time", "date", "a", "b", "c", "d", "e", "f")
+    ) %>%
+    nrow() %>%
+    expect_equal(0L)
+  
+  # Expect all column names to be the same between the
+  # input table and the two data pieces
+  expect_equal(
+    colnames(small_table),
+    colnames(pass_data_tbl),
+    colnames(fail_data_tbl)
+  )
+  
+  # Expect a list of data pieces if `NULL` provided
+  # to the `type` argument
+  data_tbl_list <- get_sundered_data(agent_1, type = NULL)
+  
+  # Expect the resulting list to hold the
+  # same two data pieces as before
+  expect_is(data_tbl_list, "list")
+  expect_equal(names(data_tbl_list), c("pass", "fail"))
+  expect_equal(length(data_tbl_list), 2)
+  expect_equal(data_tbl_list$pass, pass_data_tbl)
+  expect_equal(data_tbl_list$fail, fail_data_tbl)
+  
+  # Expect no common rows between the two
+  # data pieces in the list object
+  data_tbl_list$pass %>%
+    dplyr::semi_join(
+      data_tbl_list$fail,
+      by = c("date_time", "date", "a", "b", "c", "d", "e", "f")
+    ) %>%
+    nrow() %>%
+    expect_equal(0L)
+})
+
+
+test_that("sundered data can be generated and retrieved with a `tbl_df` (no steps)", {
+  
+  # These tests ensure that a no-step interrogation works
   
   # Get the 'pass' data piece using `get_sundered_data()`
   pass_data_tbl <- agent_zero %>% get_sundered_data(type = "pass")
@@ -256,4 +330,21 @@ test_that("sundered data can be generated and retrieved with a `tbl_dbi` (SQLite
   expect_error(get_sundered_data(agent_sqlite_no_id, type = "pass"))
   expect_error(get_sundered_data(agent_sqlite_no_id, type = "fail"))
   expect_error(get_sundered_data(agent_sqlite_no_id, type = NULL))
+})
+
+test_that("an error occurs if using `get_sundered_data()` when agent has no intel", {
+  
+  # Expect an error if the agent hasn't performed
+  # an interrogation before calling `get_sundered_data()`
+  expect_error(
+    create_agent(tbl = small_table) %>%
+      col_vals_gt(vars(date_time), vars(date), na_pass = TRUE) %>%
+      col_vals_gt(vars(b), vars(g), na_pass = TRUE) %>%
+      rows_distinct(vars(d, e)) %>%
+      rows_distinct(vars(a, f)) %>%
+      col_vals_gt(vars(d), 100) %>%
+      col_vals_equal(vars(d), vars(d), na_pass = TRUE) %>%
+      col_vals_between(vars(c), left = vars(a), right = vars(d), na_pass = TRUE) %>%
+      get_sundered_data()
+  )
 })


### PR DESCRIPTION
This fixes #145 and adds tests to ensure that interrogations with a single validation step work with the `get_sundered_data()` function.