### PR TITLE
Add the `combined` option to `get_sundered_data()`

### DIFF
--- a/R/get_sundered_data.R
+++ b/R/get_sundered_data.R
@@ -52,9 +52,16 @@
 #' 
 #' @export
 get_sundered_data <- function(agent,
-                              type = "pass",
+                              type = c("pass", "fail", "combined"),
+                              pass_fail = c("pass", "fail"),
                               id_cols = NULL) {
 
+  # Match to one of the three choices (`pass`, `fail`, `combined`)
+  # while still allowing for the NULL optiona
+  if (!is.null(type)) {
+    type <- match.arg(type)
+  }
+  
   # Stop function if the agent hasn't
   # yet performed an interrogation
   if (!inherits(agent, "has_intel")) {
@@ -215,6 +222,20 @@ get_sundered_data <- function(agent,
       dplyr::select(-pb_is_good_)
     
     return(sundered_tbl_fail)
+  }
+  
+  if (!is.null(type) && type == "combined") {
+    
+    sundered_tbl_combined <- 
+      tbl_check_join %>%
+      dplyr::mutate(pb_is_good_ = dplyr::case_when(
+        pb_is_good_ ~ pass_fail[1],
+        !pb_is_good_ ~ pass_fail[2],
+        TRUE ~ pass_fail[1]
+      )) %>%
+      dplyr::rename(`.pb_combined` = pb_is_good_)
+    
+    return(sundered_tbl_combined)
   }
   
   if (is.null(type)) {

--- a/R/get_sundered_data.R
+++ b/R/get_sundered_data.R
@@ -25,8 +25,8 @@
 #'   the `pass_fail` argument) in a new `.pb_combined` flag column. For this
 #'   case the ordering of rows is fully retained from the input table.
 #' @param pass_fail A vector for encoding the flag column with 'pass' and 'fail'
-#'   value when `type = "combined"`. The default is `c("pass", "fail")` but
-#'   other options might be `c(TRUE, FALSE)`, `c(1, 0)`, or `c(1L, 0L)`.
+#'   values when `type = "combined"`. The default is `c("pass", "fail")` but
+#'   other options could be `c(TRUE, FALSE)`, `c(1, 0)`, or `c(1L, 0L)`.
 #' @param id_cols An optional specification of one or more identifying columns.
 #'   When taken together, we can count on this single column or grouping of
 #'   columns to distinguish rows.

--- a/R/get_sundered_data.R
+++ b/R/get_sundered_data.R
@@ -4,24 +4,34 @@
 #' part of the input dataset for something else. The `get_sundered_data()`
 #' function works with an agent object that has intel (i.e., post
 #' `interrogate()`) and gets either the 'pass' data piece (rows with no failing
-#' units across all row-based validation functions), or, the 'fail' data
-#' piece (rows with at least one failing unit across the same series of
-#' validations). There are some caveats, only those validation steps with
-#' no `preconditions` are considered. And, the validation steps used for this
-#' must, again, be of the row-based variety (e.g., the `col_vals_*()` functions,
-#' and [conjointly()]).
+#' test units across all row-based validation functions), or, the 'fail' data
+#' piece (rows with at least one failing test unit across the same series of
+#' validations). There are some caveats, only those validation steps with no
+#' `preconditions` are considered. And, the validation steps used for this
+#' splitting must be of the row-based variety (e.g., the `col_vals_*()`
+#' functions or [conjointly()]).
 #'
 #' @param agent An agent object of class `ptblank_agent`. It should have had
 #'   [interrogate()] called on it, such that the validation steps were actually
 #'   carried out.
 #' @param type The desired piece of data resulting from the splitting. Options
-#'   are `"pass"` (the default) and `"fail"`.
+#'   for returning a single table are `"pass"` (the default) and `"fail"`. Each
+#'   of these options return a single table with, in the `"pass"` case, only the
+#'   rows that passed across all validation steps (i.e., had no failing test
+#'   units in any part of a row for any validation step), or, the complementary
+#'   set of rows in the `"fail"` case. Providing `NULL` returns both of the
+#'   split data tables in a list (with the names of `"pass"` and `"fail"`). The
+#'   option `"combined"` applies a categorical (pass/fail) label (settable in
+#'   the `pass_fail` argument) in a new `.pb_combined` flag column. For this
+#'   case the ordering of rows is fully retained from the input table.
+#' @param pass_fail A vector for encoding the flag column with 'pass' and 'fail'
+#'   value when `type = "combined"`. The default is `c("pass", "fail")` but
+#'   other options might be `c(TRUE, FALSE)`, `c(1, 0)`, or `c(1L, 0L)`.
 #' @param id_cols An optional specification of one or more identifying columns.
 #'   When taken together, we can count on this single column or grouping of
 #'   columns to distinguish rows.
-#' 
-#' @return A list of table objects if `type` is `NULL`, or, a table object piece
-#'   if a `type` is given.
+#' @return A list of table objects if `type` is `NULL`, or, a single table if a
+#'   `type` is given.
 #' 
 #' @examples
 #' # Create a series of three validation

--- a/man/get_sundered_data.Rd
+++ b/man/get_sundered_data.Rd
@@ -28,8 +28,8 @@ the \code{pass_fail} argument) in a new \code{.pb_combined} flag column. For thi
 case the ordering of rows is fully retained from the input table.}
 
 \item{pass_fail}{A vector for encoding the flag column with 'pass' and 'fail'
-value when \code{type = "combined"}. The default is \code{c("pass", "fail")} but
-other options might be \code{c(TRUE, FALSE)}, \code{c(1, 0)}, or \code{c(1L, 0L)}.}
+values when \code{type = "combined"}. The default is \code{c("pass", "fail")} but
+other options could be \code{c(TRUE, FALSE)}, \code{c(1, 0)}, or \code{c(1L, 0L)}.}
 
 \item{id_cols}{An optional specification of one or more identifying columns.
 When taken together, we can count on this single column or grouping of

--- a/man/get_sundered_data.Rd
+++ b/man/get_sundered_data.Rd
@@ -4,7 +4,12 @@
 \alias{get_sundered_data}
 \title{Sunder the data, splitting it into 'pass' and 'fail' pieces}
 \usage{
-get_sundered_data(agent, type = "pass", id_cols = NULL)
+get_sundered_data(
+  agent,
+  type = c("pass", "fail", "combined"),
+  pass_fail = c("pass", "fail"),
+  id_cols = NULL
+)
 }
 \arguments{
 \item{agent}{An agent object of class \code{ptblank_agent}. It should have had
@@ -12,27 +17,39 @@ get_sundered_data(agent, type = "pass", id_cols = NULL)
 carried out.}
 
 \item{type}{The desired piece of data resulting from the splitting. Options
-are \code{"pass"} (the default) and \code{"fail"}.}
+for returning a single table are \code{"pass"} (the default) and \code{"fail"}. Each
+of these options return a single table with, in the \code{"pass"} case, only the
+rows that passed across all validation steps (i.e., had no failing test
+units in any part of a row for any validation step), or, the complementary
+set of rows in the \code{"fail"} case. Providing \code{NULL} returns both of the
+split data tables in a list (with the names of \code{"pass"} and \code{"fail"}). The
+option \code{"combined"} applies a categorical (pass/fail) label (settable in
+the \code{pass_fail} argument) in a new \code{.pb_combined} flag column. For this
+case the ordering of rows is fully retained from the input table.}
+
+\item{pass_fail}{A vector for encoding the flag column with 'pass' and 'fail'
+value when \code{type = "combined"}. The default is \code{c("pass", "fail")} but
+other options might be \code{c(TRUE, FALSE)}, \code{c(1, 0)}, or \code{c(1L, 0L)}.}
 
 \item{id_cols}{An optional specification of one or more identifying columns.
 When taken together, we can count on this single column or grouping of
 columns to distinguish rows.}
 }
 \value{
-A list of table objects if \code{type} is \code{NULL}, or, a table object piece
-if a \code{type} is given.
+A list of table objects if \code{type} is \code{NULL}, or, a single table if a
+\code{type} is given.
 }
 \description{
 Validation of the data is one thing but, sometimes, you want to use the best
 part of the input dataset for something else. The \code{get_sundered_data()}
 function works with an agent object that has intel (i.e., post
 \code{interrogate()}) and gets either the 'pass' data piece (rows with no failing
-units across all row-based validation functions), or, the 'fail' data
-piece (rows with at least one failing unit across the same series of
-validations). There are some caveats, only those validation steps with
-no \code{preconditions} are considered. And, the validation steps used for this
-must, again, be of the row-based variety (e.g., the \verb{col_vals_*()} functions,
-and \code{\link[=conjointly]{conjointly()}}).
+test units across all row-based validation functions), or, the 'fail' data
+piece (rows with at least one failing test unit across the same series of
+validations). There are some caveats, only those validation steps with no
+\code{preconditions} are considered. And, the validation steps used for this
+splitting must be of the row-based variety (e.g., the \verb{col_vals_*()}
+functions or \code{\link[=conjointly]{conjointly()}}).
 }
 \section{Function ID}{
 

--- a/tests/testthat/test-sundering.R
+++ b/tests/testthat/test-sundering.R
@@ -129,6 +129,46 @@ test_that("sundered data can be generated and retrieved with a `tbl_df`", {
   )
 })
 
+test_that("sundered data can be combined to a single `tbl_df` with a single flag column", {
+  
+  # Use the `"combined"` option in `get_sundered_data()`
+  combined_data_tbl <- get_sundered_data(agent, type = "combined")
+  
+  # Expect that the table ius of the same type as the input data
+  expect_is(small_table, "tbl_df")
+  expect_is(combined_data_tbl, "tbl_df")
+  
+  # Expect there to be the same number of rows as the
+  # input table but one more column
+  expect_equal(nrow(combined_data_tbl), nrow(small_table))
+  expect_equal(ncol(combined_data_tbl), ncol(small_table) + 1)
+  
+  # Expect the same column names as the input table but
+  # with one more column at the end
+  expect_equal(
+    colnames(combined_data_tbl),
+    c(colnames(small_table), ".pb_combined")
+  )
+  
+  # Using different encodings for the 'pass' and 'label' status, expect
+  # the column type and available values to change accordingly
+  c_1 <- get_sundered_data(agent, type = "combined", pass_fail = c(1, 0))
+  c_2 <- get_sundered_data(agent, type = "combined", pass_fail = c(TRUE, FALSE))
+  c_3 <- get_sundered_data(agent, type = "combined", pass_fail = c("good", "bad"))
+  c_4 <- get_sundered_data(agent, type = "combined", pass_fail = c(1L, 0L))
+  expect_is(c_1$.pb_combined, "numeric")
+  expect_is(c_2$.pb_combined, "logical")
+  expect_is(c_3$.pb_combined, "character")
+  expect_is(c_4$.pb_combined, "integer")
+  expect_equal(unique(c_1$.pb_combined), c(1, 0))
+  expect_equal(unique(c_2$.pb_combined), c(TRUE, FALSE))
+  expect_equal(unique(c_3$.pb_combined), c("good", "bad"))
+  expect_equal(unique(c_4$.pb_combined), c(1L, 0L))
+  
+  # Expect the rows to be in the same order as the input table
+  expect_equivalent(combined_data_tbl %>% dplyr::select(-.pb_combined), small_table)
+})
+
 test_that("sundered data can be generated and retrieved with a `tbl_df` (one step)", {
   
   # These tests ensure that a single-step interrogation works


### PR DESCRIPTION
This PR allows for a new option in the `get_sundered_data()` function, where `type` can also be `"combined"`. This option applies a categorical (pass/fail) label (settable in the `pass_fail` argument) in a new `.pb_combined` flag column. For this case the ordering of rows is fully retained from the input table. 

On top of this, there is a new `pass_fail` argument. It uses a vector for encoding the flag column with 'pass' and 'fail' values when `type = "combined"`. The default is `c("pass", "fail")` but other useful options are `c(TRUE, FALSE)`, `c(1, 0)`, or `c(1L, 0L)`.

Fixes: #152 