### PR TITLE
Translate text in agent report that refers to the extract CSV

### DIFF
--- a/R/get_agent_report.R
+++ b/R/get_agent_report.R
@@ -803,8 +803,12 @@ get_agent_report <- function(agent,
           df <- 
             extracts[as.character(x)][[1]] %>%
             as.data.frame(stringsAsFactors = FALSE)
+
+          fail_rows_extract <- 
+            pb_fmt_number(nrow(df), decimals = 0, locale = locale)
           
-          title_text <- paste0(nrow(df), " failing rows available.")
+          title_text <- 
+            glue::glue(get_lsv("agent_report/report_fail_rows_available")[[lang]])
           
           temp_file <- 
             tempfile(pattern = paste0("csv_file_", x), fileext = ".csv")

--- a/R/utils.R
+++ b/R/utils.R
@@ -394,7 +394,9 @@ pb_fmt_number <- function(x,
   
   if (is.null(x)) return(NULL)
   
-  if (length(x) == 1 && !inherits(x, "numeric")) return(x)
+  if (length(x) == 1 && (!inherits(x, "numeric") && !inherits(x, "integer"))) {
+    return(x)
+  } 
   
   ((dplyr::tibble(a = x) %>%
       gt::gt() %>%

--- a/inst/text/translations
+++ b/inst/text/translations
@@ -216,6 +216,12 @@ agent_report:
     de: Keine Abfrage durchgeführt
     it: Nessuna interrogazione eseguita
     es: No se realizaron interrogatorios
+  report_fail_rows_available:
+    en: "There are {fail_rows_extract} 'fail' rows available as a CSV file."
+    fr: "Il existe des {fail_rows_extract} lignes 'fail' disponibles sous forme de fichier CSV."
+    de: "Es sind {fail_rows_extract} 'fail'-Zeilen als CSV-Datei verfügbar."
+    it: "Sono disponibili {fail_rows_extract} righe 'fail' come file CSV."
+    es: "Hay {fail_rows_extract} filas 'fail' disponibles como archivo CSV."
   report_col_step:
     en: STEP
     fr: ÉTAPE


### PR DESCRIPTION
This fixes text that was hardcoded in English only. It's now translated to all supported languages. The associated numeric value is also now formatted according the the chosen locale.

Fixes #176 