### PR TITLE
Provide support for locale-specific number formatting in informants

### DIFF
--- a/R/create_informant.R
+++ b/R/create_informant.R
@@ -167,7 +167,11 @@ create_informant <- function(tbl = NULL,
   .tbl <- x$tbl
   
   table.columns <- length(column_names)
-  table.rows <- dplyr::count(.tbl, name = "n") %>% dplyr::pull(n) %>% as.numeric()
+  
+  table.rows <- 
+    dplyr::count(.tbl, name = "n") %>%
+    dplyr::pull(n) %>%
+    as.numeric()
   
   column_list <- list(columns = lapply(col_schema(.tbl = .tbl), as.list))
   

--- a/R/get_agent_report.R
+++ b/R/get_agent_report.R
@@ -1244,6 +1244,9 @@ get_agent_report <- function(agent,
       gt::opt_css("@import url(\"https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&display=swap\");") %>%
       gt::opt_css(
         css = "
+          #pb_information {
+            -webkit-font-smoothing: antialiased;
+          }
           #report .gt_row {
             overflow: visible;
           }
@@ -1254,6 +1257,8 @@ get_agent_report <- function(agent,
           #report code {
             font-family: 'IBM Plex Mono', monospace, courier;
             font-size: 11px;
+            background-color: transparent;
+            padding: 0;
           }
         "
       )

--- a/R/get_informant_report.R
+++ b/R/get_informant_report.R
@@ -410,6 +410,18 @@ get_informant_report <- function(informant,
       gt::opt_table_font(font = gt::google_font("IBM Plex Sans")) %>%
       gt::opt_css(
         css = "
+          #pb_information {
+            -webkit-font-smoothing: antialiased;
+            letter-spacing: .15px;
+          }
+          #pb_information a {
+            color: #375F84;
+            text-decoration: none;
+          }
+          #pb_information a:hover {
+            color: #375F84;
+            text-decoration: underline;
+          }
           #pb_information p {
             overflow: visible;
             margin-top: 2px;
@@ -426,10 +438,17 @@ get_informant_report <- function(informant,
           #pb_information li {
             text-indent: -1px;
           }
+          #pb_information h4 {
+            font-weight: 500;
+            color: #444444;
+          }
           #pb_information code {
             font-family: 'IBM Plex Mono', monospace, courier;
             font-size: 90%;
             font-weight: 500;
+            color: #666666;
+            background-color: transparent;
+            padding: 0;
           }
           #pb_information .pb_date {
             text-decoration-style: solid;
@@ -455,6 +474,9 @@ get_informant_report <- function(informant,
           #pb_information .gt_sourcenote {
             height: 35px;
             padding: 0
+          }
+          #pb_information .gt_group_heading {
+            text-ident: -3px;
           }
         "
       )

--- a/R/get_informant_report.R
+++ b/R/get_informant_report.R
@@ -10,6 +10,20 @@
 #' @param informant An informant object of class `ptblank_informant`.
 #' @param size The size of the display table, which can be either `"standard"`
 #'   (the default, with a width of 875px) or `"small"` (width of 575px).
+#' @param lang The language to use for the *information report* (a summary table
+#'   that provides the validation plan and the results from the interrogation.
+#'   By default, `NULL` will create English (`"en"`) text. Other options include
+#'   French (`"fr"`), German (`"de"`), Italian (`"it"`), Spanish (`"es"`),
+#'   Portuguese, (`"pt"`), Chinese (`"zh"`), and Russian (`"ru"`). This `lang`
+#'   option will override any previously set lang value (e.g., by the
+#'   [create_agent()] call).
+#' @param locale An optional locale ID to use for formatting values in the
+#'   *information report* summary table according the locale's rules. Examples
+#'   include `"en_US"` for English (United States) and `"fr_FR"` for French
+#'   (France); more simply, this can be a language identifier without a country
+#'   designation, like `"es"` for Spanish (Spain, same as `"es_ES"`). This
+#'   `locale` option will override any previously set locale value (e.g., by the
+#'   [create_agent()] call).
 #' 
 #' @return A **gt** table object.
 #' 

--- a/R/incorporate.R
+++ b/R/incorporate.R
@@ -79,7 +79,7 @@
 incorporate <- function(informant) {
   
   # Get the target table for this informant object
-  # TODO: Use the same scheme as the `agent` does
+  # TODO: Use the same scheme that the `agent` does
   tbl <- informant$tbl
   read_fn <- informant$read_fn
   
@@ -129,7 +129,7 @@ incorporate <- function(informant) {
   meta_snippets <- informant$meta_snippets
 
   for (i in seq_along(meta_snippets)) {
-    
+
     snippet_fn <- 
       informant$meta_snippets[[i]] %>%
       rlang::f_rhs() %>%
@@ -138,6 +138,16 @@ incorporate <- function(informant) {
     if (inherits(snippet_fn, "fseq")) {
       
       snippet <- snippet_fn(tbl)
+      
+      # The following stmt always assumes that numeric
+      # values should be formatted with the default options
+      # of `pb_fmt_number()` in the informant's locale
+      # TODO: provide option to format as numeric (w/ option for
+      # decimal places) or as currency (w/ option for currency code)
+      if (is.numeric(snippet)) {
+        snippet <- snippet %>% pb_fmt_number(locale = informant$locale)
+      }
+      
       assign(x = names(informant$meta_snippets[i]), value = snippet)
     }
   }

--- a/man/get_informant_report.Rd
+++ b/man/get_informant_report.Rd
@@ -4,13 +4,29 @@
 \alias{get_informant_report}
 \title{Get a table information report from an \emph{informant} object}
 \usage{
-get_informant_report(informant, size = "standard")
+get_informant_report(informant, size = "standard", lang = NULL, locale = NULL)
 }
 \arguments{
 \item{informant}{An informant object of class \code{ptblank_informant}.}
 
 \item{size}{The size of the display table, which can be either \code{"standard"}
 (the default, with a width of 875px) or \code{"small"} (width of 575px).}
+
+\item{lang}{The language to use for the \emph{information report} (a summary table
+that provides the validation plan and the results from the interrogation.
+By default, \code{NULL} will create English (\code{"en"}) text. Other options include
+French (\code{"fr"}), German (\code{"de"}), Italian (\code{"it"}), Spanish (\code{"es"}),
+Portuguese, (\code{"pt"}), Chinese (\code{"zh"}), and Russian (\code{"ru"}). This \code{lang}
+option will override any previously set lang value (e.g., by the
+\code{\link[=create_agent]{create_agent()}} call).}
+
+\item{locale}{An optional locale ID to use for formatting values in the
+\emph{information report} summary table according the locale's rules. Examples
+include \code{"en_US"} for English (United States) and \code{"fr_FR"} for French
+(France); more simply, this can be a language identifier without a country
+designation, like \code{"es"} for Spanish (Spain, same as \code{"es_ES"}). This
+\code{locale} option will override any previously set locale value (e.g., by the
+\code{\link[=create_agent]{create_agent()}} call).}
 }
 \value{
 A \strong{gt} table object.

--- a/tests/manual_tests/tests_informant-revenue-postgres.R
+++ b/tests/manual_tests/tests_informant-revenue-postgres.R
@@ -39,8 +39,12 @@ informant_revenue_postgres <-
   info_columns("revenue", info = "The reported revenue (in USD) for the product.
                The value may change up to 3-4 weeks after the sale date due
                to processing of refunds.") %>%
+  info_columns("revenue", info = "The revenue total is ${revenue_total}.") %>%
   info_columns(vars(price, revenue), info = "(PARTNER)") %>%
-  info_snippet("columns", fn = ~ . %>% ncol()) %>%
+  info_snippet("revenue_total",
+               fn = ~ . %>%
+                 dplyr::summarize(total = sum(revenue, na.rm = TRUE)) %>%
+                 dplyr::pull(total)) %>%
   info_columns(vars(name, type), `person responsible` = "Rita Mercer (r.mercer@example.com)") %>%
   info_columns("time", TODO = "Ensure that this becomes a `DATETIME` column.") %>%
   info_section("source", 


### PR DESCRIPTION
This PR ensures that numeric values handled by the informant are formatted according to the `locale`.