### PR TITLE
Fixes for `get_sundered_data()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,8 @@
 
 * The `set_tbl()`, `remove_tbl()`, `set_read_fn()`, and `remove_read_fn()` functions can now also be used with an *informant* object.
 
+* The `get_sundered_data()` function is more clear with regard to which validation steps are considered for splitting of the data. Using validation steps with `preconditions` must fulfill the rule that the target table only have a single form across steps.
+
 * Refactored a large portion of the code that produces the agent report to increase rendering speed.
 
 * Improved printing of errors/warnings (in the tooltips of the `EVAL` column in the agent report) thanks to implementation of HTML escaping.

--- a/R/get_sundered_data.R
+++ b/R/get_sundered_data.R
@@ -25,10 +25,21 @@
 #' `interrogate()`) and gets either the 'pass' data piece (rows with no failing
 #' test units across all row-based validation functions), or, the 'fail' data
 #' piece (rows with at least one failing test unit across the same series of
-#' validations). There are some caveats, only those validation steps with no
-#' `preconditions` are considered. And, the validation steps used for this
-#' splitting must be of the row-based variety (e.g., the `col_vals_*()`
-#' functions or [conjointly()]).
+#' validations).
+#' 
+#' There are some caveats to sundering. The validation steps considered for this
+#' splitting has to be of the row-based variety (e.g., the `col_vals_*()`
+#' functions or [conjointly()], but not `rows_distinct()`). Furthermore,
+#' validation steps that experienced evaluation issues during interrogation are
+#' not considered, and, validation steps where `active = FALSE` will be
+#' disregarded. The collection of validation steps that fulfill the above
+#' requirements for sundering are termed in-consideration validation steps.
+#'
+#' If using any `preconditions` for validation steps, we must ensure that all
+#' in-consideration validation steps use the same specified `preconditions`
+#' function. Put another way, we cannot split the target table using a
+#' collection of in-consideration validation steps that use different forms of
+#' the input table.
 #'
 #' @param agent An agent object of class `ptblank_agent`. It should have had
 #'   [interrogate()] called on it, such that the validation steps were actually
@@ -48,7 +59,8 @@
 #'   other options could be `c(TRUE, FALSE)`, `c(1, 0)`, or `c(1L, 0L)`.
 #' @param id_cols An optional specification of one or more identifying columns.
 #'   When taken together, we can count on this single column or grouping of
-#'   columns to distinguish rows.
+#'   columns to distinguish rows. If the table undergoing validation is not a
+#'   data frame or tibble, then columns need to be specified for `id_cols`.
 #' @return A list of table objects if `type` is `NULL`, or, a single table if a
 #'   `type` is given.
 #' 

--- a/man/get_sundered_data.Rd
+++ b/man/get_sundered_data.Rd
@@ -33,7 +33,8 @@ other options could be \code{c(TRUE, FALSE)}, \code{c(1, 0)}, or \code{c(1L, 0L)
 
 \item{id_cols}{An optional specification of one or more identifying columns.
 When taken together, we can count on this single column or grouping of
-columns to distinguish rows.}
+columns to distinguish rows. If the table undergoing validation is not a
+data frame or tibble, then columns need to be specified for \code{id_cols}.}
 }
 \value{
 A list of table objects if \code{type} is \code{NULL}, or, a single table if a
@@ -46,10 +47,22 @@ function works with an agent object that has intel (i.e., post
 \code{interrogate()}) and gets either the 'pass' data piece (rows with no failing
 test units across all row-based validation functions), or, the 'fail' data
 piece (rows with at least one failing test unit across the same series of
-validations). There are some caveats, only those validation steps with no
-\code{preconditions} are considered. And, the validation steps used for this
-splitting must be of the row-based variety (e.g., the \verb{col_vals_*()}
-functions or \code{\link[=conjointly]{conjointly()}}).
+validations).
+}
+\details{
+There are some caveats to sundering. The validation steps considered for this
+splitting has to be of the row-based variety (e.g., the \verb{col_vals_*()}
+functions or \code{\link[=conjointly]{conjointly()}}, but not \code{rows_distinct()}). Furthermore,
+validation steps that experienced evaluation issues during interrogation are
+not considered, and, validation steps where \code{active = FALSE} will be
+disregarded. The collection of validation steps that fulfill the above
+requirements for sundering are termed in-consideration validation steps.
+
+If using any \code{preconditions} for validation steps, we must ensure that all
+in-consideration validation steps use the same specified \code{preconditions}
+function. Put another way, we cannot split the target table using a
+collection of in-consideration validation steps that use different forms of
+the input table.
 }
 \section{Function ID}{
 


### PR DESCRIPTION
This PR addresses an issue with using the `get_sundered_data()` function with an agent that had used `preconditions` in one or more validation steps. 

If using any `preconditions` for validation steps, we must ensure that all in-consideration validation steps use the same specified `preconditions` function. Put another way, we cannot split the target table using a collection of in-consideration validation steps that use different forms of the input table. The changes here include a clear error message if the above policy is violated.

Several testthat tests were added to ensure that the changes are subject to testing.

Fixes: https://github.com/rich-iannone/pointblank/issues/213