### PR TITLE
Add the `is_exact` arg to `col_schema_match()`

### DIFF
--- a/R/col_schema_match.R
+++ b/R/col_schema_match.R
@@ -28,16 +28,25 @@
 #' whereas the expectation and test functions can only be used with a data
 #' table. The types of data tables that can be used include data frames,
 #' tibbles, database tables (`tbl_dbi`), and Spark DataFrames (`tbl_spark`).
-#' Each validation step or expectation will operate over a single test unit,
-#' which is whether the column is an integer-type column or not. The validation
-#' step or expectation operates over a single test unit, which is whether the
-#' schema matches that of the table (within the constraints enforced by the
-#' `complete` and `in_order` options). If the target table is a `tbl_dbi` or a
-#' `tbl_spark` object, we can choose to validate the column schema that is based
-#' on R column types (e.g., `"numeric"`, `"character"`, etc.), SQL column types
-#' (e.g., `"double"`, `"varchar"`, etc.), or Spark SQL types (e.g,.
-#' `"DoubleType"`, `"StringType"`, etc.). That option is defined in the
-#' [col_schema()] function (it is the `.db_col_types` argument).
+#' 
+#' The validation step or expectation operates over a single test unit, which is
+#' whether the schema matches that of the table (within the constraints enforced
+#' by the `complete`, `in_order`, and `is_exact` options). If the target table
+#' is a `tbl_dbi` or a `tbl_spark` object, we can choose to validate the column
+#' schema that is based on R column types (e.g., `"numeric"`, `"character"`,
+#' etc.), SQL column types (e.g., `"double"`, `"varchar"`, etc.), or Spark SQL
+#' types (e.g,. `"DoubleType"`, `"StringType"`, etc.). That option is defined in
+#' the [col_schema()] function (it is the `.db_col_types` argument).
+#' 
+#' There are options to make schema checking less stringent (by default, this
+#' validation operates with highest level of strictness). With the `complete`
+#' option set to `FALSE`, we can supply a `col_schema` object with a partial
+#' inclusion of columns. Using `in_order` set to `FALSE` means that there is no
+#' requirement for the columns defined in the `schema` object to be in the same
+#' order as in the target table. Finally, the `is_exact` option set to `FALSE`
+#' means that all column classes/types don't have to be provided for a
+#' particular column. It can even be `NULL`, skipping the check of the column
+#' type.
 #'
 #' Often, we will want to specify `actions` for the validation. This argument,
 #' present in every validation function, takes a specially-crafted list object
@@ -60,15 +69,23 @@
 #' @param schema A table schema of type `col_schema` which can be generated
 #'   using the [col_schema()] function.
 #' @param complete A requirement to account for all table columns in the
-#'   `schema`. By default, this is `TRUE` and so that all column names in the
-#'   target table must be present in the schema object. This restriction can be
-#'   relaxed by using `FALSE`, where we can provide a subset of table columns in
-#'   the schema.
+#'   provided `schema`. By default, this is `TRUE` and so that all column names
+#'   in the target table must be present in the schema object. This restriction
+#'   can be relaxed by using `FALSE`, where we can provide a subset of table
+#'   columns in the schema.
 #' @param in_order A stringent requirement for enforcing the order of columns in
 #'   the provided `schema`. By default, this is `TRUE` and the order of columns
 #'   in both the schema and the target table must match. By setting to `FALSE`,
 #'   this strict order requirement is removed.
-#' 
+#' @param is_exact Determines whether the check for column types should be exact
+#'   or even performed at all. For example, columns in R data frames may have
+#'   multiple classes (e.g., a date-time column can have both the `"POSIXct"`
+#'   and the `"POSIXt"` classes). If using `is_exact == FALSE`, the column type
+#'   in the user-defined schema for a date-time value can be set as either
+#'   `"POSIXct"` *or* `"POSIXt"` and pass validation (with this column, at
+#'   least). This can be taken a step further and using `NULL` for a column type
+#'   in the user-defined schema will skip the validation check of a column type.
+#'   By default, `is_exact` is set to `TRUE`.
 #' @return For the validation function, the return value is either a
 #'   `ptblank_agent` object or a table object (depending on whether an agent
 #'   object or a table was passed to `x`). The expectation function invisibly
@@ -165,6 +182,7 @@ col_schema_match <- function(x,
                              schema,
                              complete = TRUE,
                              in_order = TRUE,
+                             is_exact = TRUE,
                              actions = NULL,
                              step_id = NULL,
                              label = NULL,
@@ -176,14 +194,22 @@ col_schema_match <- function(x,
          "* A schema can be defined using the `col_schema()` function",
          call. = FALSE)
   }
-  
+
   # Incorporate `complete` and `in_order` options into
   # the `schema` object
-  if (is.null(schema$`__complete__`) && is.null(schema$`__in_order__`)) {
+  if (is.null(schema$`__complete__`) &&
+      is.null(schema$`__in_order__`) &&
+      is.null(schema$`__is_exact__`)) {
     
     schema <- 
       structure(
-        c(schema, list(`__complete__` = complete, `__in_order__` = in_order)),
+        c(schema, 
+          list(
+            `__complete__` = complete,
+            `__in_order__` = in_order,
+            `__is_exact__` = is_exact
+          )
+        ),
         class = c("match_options", class(schema))
       )
   }

--- a/R/col_schema_match.R
+++ b/R/col_schema_match.R
@@ -220,6 +220,9 @@ col_schema_match <- function(x,
       create_agent(x, label = "::QUIET::") %>%
       col_schema_match(
         schema = schema,
+        complete = complete,
+        in_order = in_order,
+        is_exact = is_exact,
         label = label,
         brief = brief,
         actions = prime_actions(actions),
@@ -271,6 +274,7 @@ expect_col_schema_match <- function(object,
                                     schema,
                                     complete = TRUE,
                                     in_order = TRUE,
+                                    is_exact = TRUE,
                                     threshold = 1) {
   
   fn_name <- "expect_col_schema_match"
@@ -279,6 +283,9 @@ expect_col_schema_match <- function(object,
     create_agent(tbl = object, label = "::QUIET::") %>%
     col_schema_match(
       schema = {{ schema }},
+      complete = complete,
+      in_order = in_order,
+      is_exact = is_exact,
       actions = action_levels(notify_at = threshold)
     ) %>%
     interrogate() %>%
@@ -324,12 +331,16 @@ test_col_schema_match <- function(object,
                                   schema,
                                   complete = TRUE,
                                   in_order = TRUE,
+                                  is_exact = TRUE,
                                   threshold = 1) {
   
   vs <- 
     create_agent(tbl = object, label = "::QUIET::") %>%
     col_schema_match(
       schema = {{ schema }},
+      complete = complete,
+      in_order = in_order,
+      is_exact = is_exact,
       actions = action_levels(notify_at = threshold)
     ) %>%
     interrogate() %>%

--- a/R/utils.R
+++ b/R/utils.R
@@ -41,6 +41,10 @@ is_tbl_dbi <- function(x) {
   inherits(x, "tbl_dbi")
 }
 
+has_agent_intel <- function(agent) {
+  inherits(agent, "has_intel")
+}
+
 get_tbl_object <- function(agent) {
   agent$tbl
 }
@@ -74,10 +78,6 @@ glue_safely <- function(...,
       .envir = .envir
     )
   )
-}
-
-has_agent_intel <- function(agent) {
-  inherits(agent, "has_intel")
 }
 
 is_agent_empty <- function(agent) {

--- a/R/yaml_write.R
+++ b/R/yaml_write.R
@@ -350,13 +350,15 @@ as_action_levels <- function(actions, actions_default = NULL) {
 get_schema_list <- function(schema) {
 
   vals <- schema
-  
+
   complete <- schema$`__complete__`
   in_order <- schema$`__in_order__`
+  is_exact <- schema$`__is_exact__`
   
   type <- ifelse(inherits(schema, "r_type"), "r", "sql")
   
-  vals <- vals[!(names(vals) %in% c("__complete__", "__in_order__"))]
+  vals <- 
+    vals[!(names(vals) %in% c("__complete__", "__in_order__", "__is_exact__"))]
   
   if (type == "sql") {
     vals <- c(vals, list(`.db_col_types` = "sql"))
@@ -365,7 +367,8 @@ get_schema_list <- function(schema) {
   list(
     schema = vals, 
     complete = complete,
-    in_order = in_order
+    in_order = in_order,
+    is_exact = is_exact
   )
 }
 
@@ -428,6 +431,10 @@ prune_lst_step <- function(lst_step) {
   if ("in_order" %in% names(lst_step[[1]]) &&
       lst_step[[1]][["in_order"]]) {
     lst_step[[1]]["in_order"] <- NULL
+  }
+  if ("is_exact" %in% names(lst_step[[1]]) &&
+      lst_step[[1]][["is_exact"]]) {
+    lst_step[[1]]["is_exact"] <- NULL
   }
   if ("actions" %in% names(lst_step[[1]])) {
     if (length(lst_step[[1]][["actions"]][["action_levels"]]) == 1 &&
@@ -652,13 +659,14 @@ as_agent_yaml_list <- function(agent) {
     } else if (validation_fn == "col_schema_match") {
       
       schema_list <- get_schema_list(schema = step_list$values[[1]])
-      
+
       lst_step <- 
         list(
           validation_fn = list(
             schema = schema_list$schema,
             complete = schema_list$complete,
             in_order = schema_list$in_order,
+            is_exact = schema_list$is_exact,
             actions = as_action_levels(
               step_list$actions[[1]],
               action_levels_default

--- a/man/col_schema_match.Rd
+++ b/man/col_schema_match.Rd
@@ -11,6 +11,7 @@ col_schema_match(
   schema,
   complete = TRUE,
   in_order = TRUE,
+  is_exact = TRUE,
   actions = NULL,
   step_id = NULL,
   label = NULL,
@@ -43,15 +44,25 @@ with \code{\link[=create_agent]{create_agent()}}.}
 using the \code{\link[=col_schema]{col_schema()}} function.}
 
 \item{complete}{A requirement to account for all table columns in the
-\code{schema}. By default, this is \code{TRUE} and so that all column names in the
-target table must be present in the schema object. This restriction can be
-relaxed by using \code{FALSE}, where we can provide a subset of table columns in
-the schema.}
+provided \code{schema}. By default, this is \code{TRUE} and so that all column names
+in the target table must be present in the schema object. This restriction
+can be relaxed by using \code{FALSE}, where we can provide a subset of table
+columns in the schema.}
 
 \item{in_order}{A stringent requirement for enforcing the order of columns in
 the provided \code{schema}. By default, this is \code{TRUE} and the order of columns
 in both the schema and the target table must match. By setting to \code{FALSE},
 this strict order requirement is removed.}
+
+\item{is_exact}{Determines whether the check for column types should be exact
+or even performed at all. For example, columns in R data frames may have
+multiple classes (e.g., a date-time column can have both the \code{"POSIXct"}
+and the \code{"POSIXt"} classes). If using \code{is_exact == FALSE}, the column type
+in the user-defined schema for a date-time value can be set as either
+\code{"POSIXct"} \emph{or} \code{"POSIXt"} and pass validation (with this column, at
+least). This can be taken a step further and using \code{NULL} for a column type
+in the user-defined schema will skip the validation check of a column type.
+By default, \code{is_exact} is set to \code{TRUE}.}
 
 \item{actions}{A list containing threshold levels so that the validation step
 can react accordingly when exceeding the set levels. This is to be created
@@ -110,18 +121,27 @@ data table or with an \emph{agent} object (technically, a \code{ptblank_agent} o
 whereas the expectation and test functions can only be used with a data
 table. The types of data tables that can be used include data frames,
 tibbles, database tables (\code{tbl_dbi}), and Spark DataFrames (\code{tbl_spark}).
-Each validation step or expectation will operate over a single test unit,
-which is whether the column is an integer-type column or not. The validation
-step or expectation operates over a single test unit, which is whether the
-schema matches that of the table (within the constraints enforced by the
-\code{complete} and \code{in_order} options). If the target table is a \code{tbl_dbi} or a
-\code{tbl_spark} object, we can choose to validate the column schema that is based
-on R column types (e.g., \code{"numeric"}, \code{"character"}, etc.), SQL column types
-(e.g., \code{"double"}, \code{"varchar"}, etc.), or Spark SQL types (e.g,.
-\code{"DoubleType"}, \code{"StringType"}, etc.). That option is defined in the
-\code{\link[=col_schema]{col_schema()}} function (it is the \code{.db_col_types} argument).
 }
 \details{
+The validation step or expectation operates over a single test unit, which is
+whether the schema matches that of the table (within the constraints enforced
+by the \code{complete}, \code{in_order}, and \code{is_exact} options). If the target table
+is a \code{tbl_dbi} or a \code{tbl_spark} object, we can choose to validate the column
+schema that is based on R column types (e.g., \code{"numeric"}, \code{"character"},
+etc.), SQL column types (e.g., \code{"double"}, \code{"varchar"}, etc.), or Spark SQL
+types (e.g,. \code{"DoubleType"}, \code{"StringType"}, etc.). That option is defined in
+the \code{\link[=col_schema]{col_schema()}} function (it is the \code{.db_col_types} argument).
+
+There are options to make schema checking less stringent (by default, this
+validation operates with highest level of strictness). With the \code{complete}
+option set to \code{FALSE}, we can supply a \code{col_schema} object with a partial
+inclusion of columns. Using \code{in_order} set to \code{FALSE} means that there is no
+requirement for the columns defined in the \code{schema} object to be in the same
+order as in the target table. Finally, the \code{is_exact} option set to \code{FALSE}
+means that all column classes/types don't have to be provided for a
+particular column. It can even be \code{NULL}, skipping the check of the column
+type.
+
 Often, we will want to specify \code{actions} for the validation. This argument,
 present in every validation function, takes a specially-crafted list object
 that is best produced by the \code{\link[=action_levels]{action_levels()}} function. Read that function's

--- a/man/col_schema_match.Rd
+++ b/man/col_schema_match.Rd
@@ -24,6 +24,7 @@ expect_col_schema_match(
   schema,
   complete = TRUE,
   in_order = TRUE,
+  is_exact = TRUE,
   threshold = 1
 )
 
@@ -32,6 +33,7 @@ test_col_schema_match(
   schema,
   complete = TRUE,
   in_order = TRUE,
+  is_exact = TRUE,
   threshold = 1
 )
 }

--- a/tests/testthat/test-schema.R
+++ b/tests/testthat/test-schema.R
@@ -1,0 +1,718 @@
+al <- action_levels(stop_at = 1)
+
+test_that("The `cols_schema_match()` function works with an agent", {
+  
+  # [#1] Check that a user-defined schema works in the most
+  # stringent case of `col_schema_match()`
+  agent_1 <-
+    create_agent(
+      tbl = small_table,
+      actions = al
+    ) %>%
+    col_schema_match(
+      schema = col_schema(
+        date_time = c("POSIXct", "POSIXt"),
+        date = "Date",
+        a = "integer",
+        b = "character",
+        c = "numeric",
+        d = "numeric",
+        e = "logical",
+        f = "character"
+      )
+    ) %>%
+    interrogate()
+  
+  expect_true(is_ptblank_agent(agent_1))
+  expect_true(has_agent_intel(agent_1))
+  expect_true(all_passed(agent_1))
+  
+  # [#2] Check that a schema based on a table works
+  # in the most stringent case of `col_schema_match()`
+  agent_2 <-
+    create_agent(
+      tbl = small_table,
+      actions = al
+    ) %>%
+    col_schema_match(
+      schema = col_schema(.tbl = small_table)
+    ) %>%
+    interrogate()
+  
+  expect_true(is_ptblank_agent(agent_2))
+  expect_true(has_agent_intel(agent_2))
+  expect_true(all_passed(agent_2))
+  
+  # [#3] Check that a user-defined schema (incomplete)
+  # works with `complete = FALSE`
+  agent_3 <-
+    create_agent(
+      tbl = small_table,
+      actions = al
+    ) %>%
+    col_schema_match(
+      schema = col_schema(
+        a = "integer",
+        b = "character",
+        c = "numeric",
+        d = "numeric"
+      ),
+      complete = FALSE
+    ) %>%
+    interrogate()
+  
+  expect_true(is_ptblank_agent(agent_3))
+  expect_true(has_agent_intel(agent_3))
+  expect_true(all_passed(agent_3))
+  
+  # [#4] Check that a user-defined schema (incomplete)
+  # doesn't work when `complete = TRUE` (the default)
+  agent_4 <-
+    create_agent(
+      tbl = small_table,
+      actions = al
+    ) %>%
+    col_schema_match(
+      schema = col_schema(
+        a = "integer",
+        b = "character",
+        c = "numeric",
+        d = "numeric"
+      )
+    ) %>%
+    interrogate()
+  
+  expect_true(is_ptblank_agent(agent_4))
+  expect_true(has_agent_intel(agent_4))
+  expect_false(all_passed(agent_4))
+  
+  # [#5] Check that a user-defined schema works with
+  # out-of-order column definitions when `in_order = FALSE`
+  agent_5 <-
+    create_agent(
+      tbl = small_table,
+      actions = al
+    ) %>%
+    col_schema_match(
+      schema = col_schema(
+        date = "Date",
+        date_time = c("POSIXct", "POSIXt"),
+        a = "integer",
+        c = "numeric",
+        b = "character",
+        d = "numeric",
+        f = "character",
+        e = "logical"
+      ),
+      in_order = FALSE
+    ) %>%
+    interrogate()
+  
+  expect_true(is_ptblank_agent(agent_5))
+  expect_true(has_agent_intel(agent_5))
+  expect_true(all_passed(agent_5))
+  
+  # [#6] Check that a user-defined schema works does not
+  # work with an out-of-order column definition
+  # when `in_order = TRUE` (the default)
+  agent_6 <-
+    create_agent(
+      tbl = small_table,
+      actions = al
+    ) %>%
+    col_schema_match(
+      schema = col_schema(
+        date = "Date",
+        date_time = c("POSIXct", "POSIXt"),
+        a = "integer",
+        c = "numeric",
+        b = "character",
+        d = "numeric",
+        f = "character",
+        e = "logical"
+      )
+    ) %>%
+    interrogate()
+  
+  expect_true(is_ptblank_agent(agent_6))
+  expect_true(has_agent_intel(agent_6))
+  expect_false(all_passed(agent_6))
+  
+  # [#7] Check that a user-defined schema works with
+  # less defined or not defined column types when
+  # `is_exact = FALSE`
+  agent_7 <-
+    create_agent(
+      tbl = small_table,
+      actions = al
+    ) %>%
+    col_schema_match(
+      schema = col_schema(
+        date_time = "POSIXt",
+        date = "Date",
+        a = "integer",
+        b = "character",
+        c = "numeric",
+        d = NULL,
+        e = "logical",
+        f = NULL
+      ),
+      is_exact = FALSE
+    ) %>%
+    interrogate()
+  
+  expect_true(is_ptblank_agent(agent_7))
+  expect_true(has_agent_intel(agent_7))
+  expect_true(all_passed(agent_7))
+  
+  # [#8] Check that a user-defined schema does not
+  # work with less defined or not defined column
+  # types when `is_exact = TRUE` (the default)
+  agent_8 <-
+    create_agent(
+      tbl = small_table,
+      actions = al
+    ) %>%
+    col_schema_match(
+      schema = col_schema(
+        date_time = "POSIXt",
+        date = "Date",
+        a = "integer",
+        b = "character",
+        c = "numeric",
+        d = NULL,
+        e = "logical",
+        f = NULL
+      )
+    ) %>%
+    interrogate()
+  
+  expect_true(is_ptblank_agent(agent_8))
+  expect_true(has_agent_intel(agent_8))
+  expect_false(all_passed(agent_8))
+  
+  # [#9] Check where two stringency options are
+  # `FALSE`: `complete` and `in_order`
+  agent_9 <-
+    create_agent(
+      tbl = small_table,
+      actions = al
+    ) %>%
+    col_schema_match(
+      schema = col_schema(
+        date = "Date",
+        date_time = c("POSIXct", "POSIXt"),
+        c = "numeric",
+        b = "character",
+        d = "numeric",
+        e = "logical"
+      ),
+      complete = FALSE,
+      in_order = FALSE
+    ) %>%
+    interrogate()
+  
+  expect_true(is_ptblank_agent(agent_9))
+  expect_true(has_agent_intel(agent_9))
+  expect_true(all_passed(agent_9))
+  
+  # [#10] Check where two stringency options are
+  # `FALSE`: `complete` and `is_exact`
+  agent_10 <-
+    create_agent(
+      tbl = small_table,
+      actions = al
+    ) %>%
+    col_schema_match(
+      schema = col_schema(
+        date_time = "POSIXt",
+        date = "Date",
+        a = "integer",
+        b = NULL,
+        c = "numeric",
+        d = "numeric"
+      ),
+      complete = FALSE,
+      is_exact = FALSE
+    ) %>%
+    interrogate()
+  
+  expect_true(is_ptblank_agent(agent_10))
+  expect_true(has_agent_intel(agent_10))
+  expect_true(all_passed(agent_10))
+  
+  # [#11] Check where two stringency options are
+  # `FALSE`: `in_order` and `is_exact`
+  agent_11 <-
+    create_agent(
+      tbl = small_table,
+      actions = al
+    ) %>%
+    col_schema_match(
+      schema = col_schema(
+        date_time = "POSIXct",
+        date = "Date",
+        a = NULL,
+        b = NULL,
+        d = "numeric",
+        c = "numeric",
+        f = "character",
+        e = "logical"
+      ),
+      in_order = FALSE,
+      is_exact = FALSE
+    ) %>%
+    interrogate()
+  
+  expect_true(is_ptblank_agent(agent_11))
+  expect_true(has_agent_intel(agent_11))
+  expect_true(all_passed(agent_11))
+  
+  # [#12] Check where all three stringency options
+  # are `FALSE`
+  agent_12 <-
+    create_agent(
+      tbl = small_table,
+      actions = al
+    ) %>%
+    col_schema_match(
+      schema = col_schema(
+        date_time = "POSIXct",
+        date = "Date",
+        a = NULL,
+        b = NULL,
+        f = "character",
+        e = "logical"
+      ),
+      complete = FALSE,
+      in_order = FALSE,
+      is_exact = FALSE
+    ) %>%
+    interrogate()
+  
+  expect_true(is_ptblank_agent(agent_12))
+  expect_true(has_agent_intel(agent_12))
+  expect_true(all_passed(agent_12))
+})
+
+test_that("The `expect_cols_schema_match()` function works", {
+  
+  # [#1] Check that a user-defined schema works in the most
+  # stringent case of `col_schema_match()`
+  expect_success(
+    small_table %>%
+      expect_col_schema_match(
+        schema = col_schema(
+          date_time = c("POSIXct", "POSIXt"),
+          date = "Date",
+          a = "integer",
+          b = "character",
+          c = "numeric",
+          d = "numeric",
+          e = "logical",
+          f = "character"
+        )
+      )
+  )
+  
+  # [#2] Check that a schema based on a table works
+  # in the most stringent case of `col_schema_match()`
+  expect_success(
+    small_table %>%
+      expect_col_schema_match(
+        schema = col_schema(.tbl = small_table)
+      )
+  )
+  
+  # [#3] Check that a user-defined schema (incomplete)
+  # works with `complete = FALSE`
+  expect_success(
+    small_table %>%
+      expect_col_schema_match(
+        schema = col_schema(
+          a = "integer",
+          b = "character",
+          c = "numeric",
+          d = "numeric"
+        ),
+        complete = FALSE
+      )
+  )
+  
+  # [#4] Check that a user-defined schema (incomplete)
+  # doesn't work when `complete = TRUE` (the default)
+  expect_failure(
+    small_table %>%
+      expect_col_schema_match(
+        schema = col_schema(
+          a = "integer",
+          b = "character",
+          c = "numeric",
+          d = "numeric"
+        )
+      )
+  )
+  
+  # [#5] Check that a user-defined schema works with
+  # out-of-order column definitions when `in_order = FALSE`
+  expect_success(
+    small_table %>%
+      expect_col_schema_match(
+        schema = col_schema(
+          date = "Date",
+          date_time = c("POSIXct", "POSIXt"),
+          a = "integer",
+          c = "numeric",
+          b = "character",
+          d = "numeric",
+          f = "character",
+          e = "logical"
+        ),
+        in_order = FALSE
+      )
+  )
+  
+  # [#6] Check that a user-defined schema works does not
+  # work with an out-of-order column definition
+  # when `in_order = TRUE` (the default)
+  expect_failure(
+    small_table %>%
+      expect_col_schema_match(
+        schema = col_schema(
+          date = "Date",
+          date_time = c("POSIXct", "POSIXt"),
+          a = "integer",
+          c = "numeric",
+          b = "character",
+          d = "numeric",
+          f = "character",
+          e = "logical"
+        )
+      )
+  )
+  
+  # [#7] Check that a user-defined schema works with
+  # less defined or not defined column types when
+  # `is_exact = FALSE`
+  expect_success(
+    small_table %>%
+      expect_col_schema_match(
+        schema = col_schema(
+          date_time = "POSIXt",
+          date = "Date",
+          a = "integer",
+          b = "character",
+          c = "numeric",
+          d = NULL,
+          e = "logical",
+          f = NULL
+        ),
+        is_exact = FALSE
+      )
+  )
+  
+  # [#8] Check that a user-defined schema does not
+  # work with less defined or not defined column
+  # types when `is_exact = TRUE` (the default)
+  expect_failure(
+    small_table %>%
+      expect_col_schema_match(
+        schema = col_schema(
+          date_time = "POSIXt",
+          date = "Date",
+          a = "integer",
+          b = "character",
+          c = "numeric",
+          d = NULL,
+          e = "logical",
+          f = NULL
+        )
+      )
+  )
+  
+  # [#9] Check where two stringency options are
+  # `FALSE`: `complete` and `in_order`
+  expect_success(
+    small_table %>%
+      expect_col_schema_match(
+        schema = col_schema(
+          date = "Date",
+          date_time = c("POSIXct", "POSIXt"),
+          c = "numeric",
+          b = "character",
+          d = "numeric",
+          e = "logical"
+        ),
+        complete = FALSE,
+        in_order = FALSE
+      )
+  )
+  
+  # [#10] Check where two stringency options are
+  # `FALSE`: `complete` and `is_exact`
+  expect_success(
+    small_table %>%
+      expect_col_schema_match(
+        schema = col_schema(
+          date_time = "POSIXt",
+          date = "Date",
+          a = "integer",
+          b = NULL,
+          c = "numeric",
+          d = "numeric"
+        ),
+        complete = FALSE,
+        is_exact = FALSE
+      )
+  )
+  
+  # [#11] Check where two stringency options are
+  # `FALSE`: `in_order` and `is_exact`
+  expect_success(
+    small_table %>%
+      expect_col_schema_match(
+        schema = col_schema(
+          date_time = "POSIXct",
+          date = "Date",
+          a = NULL,
+          b = NULL,
+          d = "numeric",
+          c = "numeric",
+          f = "character",
+          e = "logical"
+        ),
+        in_order = FALSE,
+        is_exact = FALSE
+      )
+  )
+  
+  # [#12] Check where all three stringency options
+  # are `FALSE`
+  expect_success(
+    small_table %>%
+      expect_col_schema_match(
+        schema = col_schema(
+          date_time = "POSIXct",
+          date = "Date",
+          a = NULL,
+          b = NULL,
+          f = "character",
+          e = "logical"
+        ),
+        complete = FALSE,
+        in_order = FALSE,
+        is_exact = FALSE
+      )
+  )
+})
+
+test_that("The `test_cols_schema_match()` function works", {
+
+  # [#1] Check that a user-defined schema works in the most
+  # stringent case of `col_schema_match()`
+  expect_true(
+    small_table %>%
+      test_col_schema_match(
+        schema = col_schema(
+          date_time = c("POSIXct", "POSIXt"),
+          date = "Date",
+          a = "integer",
+          b = "character",
+          c = "numeric",
+          d = "numeric",
+          e = "logical",
+          f = "character"
+        )
+      )
+  )
+  
+  # [#2] Check that a schema based on a table works
+  # in the most stringent case of `col_schema_match()`
+  expect_true(
+    small_table %>%
+      test_col_schema_match(
+        schema = col_schema(.tbl = small_table)
+      )
+  )
+  
+  # [#3] Check that a user-defined schema (incomplete)
+  # works with `complete = FALSE`
+  expect_true(
+    small_table %>%
+      test_col_schema_match(
+        schema = col_schema(
+          a = "integer",
+          b = "character",
+          c = "numeric",
+          d = "numeric"
+        ),
+        complete = FALSE
+      )
+  )
+  
+  # [#4] Check that a user-defined schema (incomplete)
+  # doesn't work when `complete = TRUE` (the default)
+  expect_false(
+    small_table %>%
+      test_col_schema_match(
+        schema = col_schema(
+          a = "integer",
+          b = "character",
+          c = "numeric",
+          d = "numeric"
+        )
+      )
+  )
+  
+  # [#5] Check that a user-defined schema works with
+  # out-of-order column definitions when `in_order = FALSE`
+  expect_true(
+    small_table %>%
+      test_col_schema_match(
+        schema = col_schema(
+          date = "Date",
+          date_time = c("POSIXct", "POSIXt"),
+          a = "integer",
+          c = "numeric",
+          b = "character",
+          d = "numeric",
+          f = "character",
+          e = "logical"
+        ),
+        in_order = FALSE
+      )
+  )
+  
+  # [#6] Check that a user-defined schema works does not
+  # work with an out-of-order column definition
+  # when `in_order = TRUE` (the default)
+  expect_false(
+    small_table %>%
+      test_col_schema_match(
+        schema = col_schema(
+          date = "Date",
+          date_time = c("POSIXct", "POSIXt"),
+          a = "integer",
+          c = "numeric",
+          b = "character",
+          d = "numeric",
+          f = "character",
+          e = "logical"
+        )
+      )
+  )
+  
+  # [#7] Check that a user-defined schema works with
+  # less defined or not defined column types when
+  # `is_exact = FALSE`
+  expect_true(
+    small_table %>%
+      test_col_schema_match(
+        schema = col_schema(
+          date_time = "POSIXt",
+          date = "Date",
+          a = "integer",
+          b = "character",
+          c = "numeric",
+          d = NULL,
+          e = "logical",
+          f = NULL
+        ),
+        is_exact = FALSE
+      )
+  )
+  
+  # [#8] Check that a user-defined schema does not
+  # work with less defined or not defined column
+  # types when `is_exact = TRUE` (the default)
+  expect_false(
+    small_table %>%
+      test_col_schema_match(
+        schema = col_schema(
+          date_time = "POSIXt",
+          date = "Date",
+          a = "integer",
+          b = "character",
+          c = "numeric",
+          d = NULL,
+          e = "logical",
+          f = NULL
+        )
+      )
+  )
+  
+  # [#9] Check where two stringency options are
+  # `FALSE`: `complete` and `in_order`
+  expect_true(
+    small_table %>%
+      test_col_schema_match(
+        schema = col_schema(
+          date = "Date",
+          date_time = c("POSIXct", "POSIXt"),
+          c = "numeric",
+          b = "character",
+          d = "numeric",
+          e = "logical"
+        ),
+        complete = FALSE,
+        in_order = FALSE
+      )
+  )
+  
+  # [#10] Check where two stringency options are
+  # `FALSE`: `complete` and `is_exact`
+  expect_true(
+    small_table %>%
+      test_col_schema_match(
+        schema = col_schema(
+          date_time = "POSIXt",
+          date = "Date",
+          a = "integer",
+          b = NULL,
+          c = "numeric",
+          d = "numeric"
+        ),
+        complete = FALSE,
+        is_exact = FALSE
+      )
+  )
+  
+  # [#11] Check where two stringency options are
+  # `FALSE`: `in_order` and `is_exact`
+  expect_true(
+    small_table %>%
+      test_col_schema_match(
+        schema = col_schema(
+          date_time = "POSIXct",
+          date = "Date",
+          a = NULL,
+          b = NULL,
+          d = "numeric",
+          c = "numeric",
+          f = "character",
+          e = "logical"
+        ),
+        in_order = FALSE,
+        is_exact = FALSE
+      )
+  )
+  
+  # [#12] Check where all three stringency options
+  # are `FALSE`
+  expect_true(
+    small_table %>%
+      test_col_schema_match(
+        schema = col_schema(
+          date_time = "POSIXct",
+          date = "Date",
+          a = NULL,
+          b = NULL,
+          f = "character",
+          e = "logical"
+        ),
+        complete = FALSE,
+        in_order = FALSE,
+        is_exact = FALSE
+      )
+  )
+})


### PR DESCRIPTION
This PR adds the `is_exact` argument to the `col_schema_match()` function to further make these types of validations less stringent. This argument loosens the requirement to include all class names for a column that may have multiple. Also, we can specify `NULL` to entirely skip the checking of a class/type.

Fixes: #124 