### PR TITLE
Enable horizontal scrolling for multiagent reports with 16+ columns

### DIFF
--- a/R/get_multiagent_report.R
+++ b/R/get_multiagent_report.R
@@ -500,7 +500,7 @@ get_multiagent_report <- function(multiagent,
       )
   }
   
-  if (n_columns > 16) {
+  if (n_columns > 17) {
     
     report_tbl <- 
       report_tbl %>%

--- a/R/get_multiagent_report.R
+++ b/R/get_multiagent_report.R
@@ -500,6 +500,21 @@ get_multiagent_report <- function(multiagent,
       )
   }
   
+  if (n_columns > 16) {
+    
+    report_tbl <- 
+      report_tbl %>%
+      gt::tab_style(
+        style = "left: 0; position: sticky; background: white; z-index: 1;",
+        locations = gt::cells_body(columns = 1)
+      ) %>%
+      gt::tab_style(
+        style = "left: 0; position: sticky; background: white; z-index: 1;",
+        locations = gt::cells_column_labels(columns = 1)
+      ) %>%
+      gt::tab_options(container.width = gt::px(875))
+  }
+  
   report_tbl <- 
     report_tbl %>%
     gt::tab_header(

--- a/R/get_multiagent_report.R
+++ b/R/get_multiagent_report.R
@@ -550,7 +550,7 @@ get_multiagent_report <- function(multiagent,
       missing_text = ""
     ) %>%
     gt::tab_style(
-      style = gt::cell_text(font = "'IBM Plex Mono'", size = "small"),
+      style = gt::cell_text(font = "IBM Plex Mono", size = "small"),
       locations = gt::cells_body(columns = gt::vars(sha1))
     ) %>%
     gt::tab_style(

--- a/R/get_multiagent_report.R
+++ b/R/get_multiagent_report.R
@@ -468,6 +468,7 @@ get_multiagent_report <- function(multiagent,
             color = "#666666",
             size = "8px"
           ),
+          style = gt::cell_fill(color = "#FFFFFF"),
           paste(
             "line-height: 1.15em;", "padding-left: 3px;",
             "padding-right: 0; padding-bottom: 3px;",
@@ -486,6 +487,7 @@ get_multiagent_report <- function(multiagent,
             v_align = "middle",
             align = "left"
           ),
+          style = gt::cell_fill(color = "#FFFFFF"),
           paste(
             "padding-top: 8px; padding-bottom: 8px;"
           )

--- a/tests/manual_tests/tests_multiagent_create.R
+++ b/tests/manual_tests/tests_multiagent_create.R
@@ -83,5 +83,12 @@ multiagent
 # 8UP report
 create_multiagent(agent_1, agent_2, agent_3, agent_2, agent_3)
 
+# 16UP report
 create_multiagent(agent_1, agent_2, agent_3, agent_2, agent_3, agent_2, agent_3, agent_2, agent_3)
 
+# 16+ report
+create_multiagent(
+  agent_1, agent_2, agent_3, agent_2, agent_3, agent_2, agent_3, agent_2, agent_3,
+  agent_1, agent_2, agent_3, agent_2, agent_3, agent_2, agent_3, agent_2, agent_3,
+  agent_1, agent_2, agent_3, agent_2, agent_3, agent_2, agent_3, agent_2, agent_3
+)


### PR DESCRIPTION
This PR ensures that the display table of the multiagent report is always fixed at 875px when the number of interrogation columns exceeds 16. In this case the first column with step identifiers (`STEP`) is frozen in place and the content can scroll horizontally.
