### PR TITLE
Options for customizing the main title in the report headings

### DIFF
--- a/R/get_agent_report.R
+++ b/R/get_agent_report.R
@@ -100,6 +100,17 @@
 #' @param size The size of the display table, which can be either `"standard"`
 #'   (the default) or `"small"`. This only applies to a display table (where
 #'   `display_table = TRUE`).
+#' @param title Options for customizing the title of the report. The default is
+#'   the keyword `":default:"` which produces generic title text that refers to
+#'   the **pointblank** package in the language governed by the `lang` option.
+#'   Another keyword option is `":tbl_name:"`, and that presents the name of the
+#'   table as the title for the report. If no title is wanted, then the
+#'   `":none:"` keyword option can be used. Aside from keyword options, text can
+#'   be provided for the title and `glue::glue()` calls can be used to construct
+#'   the text string. If providing text, it will be interpreted as Markdown text
+#'   and transformed internally to HTML. To circumvent such a transformation,
+#'   use text in [I()] to explicitly state that the supplied text should not be
+#'   transformed.
 #' @param lang The language to use for automatic creation of briefs (short
 #'   descriptions for each validation step) and for the *agent report* (a
 #'   summary table that provides the validation plan and the results from the
@@ -171,6 +182,7 @@ get_agent_report <- function(agent,
                              keep = c("all", "fail_states"),
                              display_table = TRUE,
                              size = "standard",
+                             title = ":default:",
                              lang = NULL,
                              locale = NULL) {
   
@@ -326,6 +338,8 @@ get_agent_report <- function(agent,
   briefs <- validation_set$brief
   assertion_type <- validation_set$assertion_type
   label <- validation_set$label
+  tbl_src <- agent$tbl_src
+  tbl_name <- agent$tbl_name
   
   # Generate agent label HTML
   agent_label_styled <- create_agent_label_html(agent)
@@ -333,8 +347,8 @@ get_agent_report <- function(agent,
   # Generate table type HTML
   table_type <- 
     create_table_type_html(
-      tbl_src = agent$tbl_src,
-      tbl_name = agent$tbl_name
+      tbl_src = tbl_src,
+      tbl_name = tbl_name
     )
 
   # Generate action levels HTML
@@ -718,7 +732,7 @@ get_agent_report <- function(agent,
                 "<div><p title=\"",
                 x %>% tidy_gsub("~", "") %>% paste(., collapse = ", "),
                 "\" style=\"margin-top: 0px; margin-bottom: 0px; ",
-                "font-family: monospace; white-space: nowrap; ",
+                "font-size: 11px; white-space: nowrap; ",
                 "text-overflow: ellipsis; overflow: hidden;\">",
                 text,
                 "</p></div>"
@@ -730,7 +744,7 @@ get_agent_report <- function(agent,
                 x %>% tidy_gsub("~", "") %>% paste(., collapse = ", "),
                 "\" data-balloon-pos=\"left\"><p style=\"margin-top: 0px; ",
                 "margin-bottom: 0px; ",
-                "font-family: monospace; white-space: nowrap; ",
+                "font-size: 11px; white-space: nowrap; ",
                 "text-overflow: ellipsis; overflow: hidden;\">",
                 "<code>", text, "</code>",
                 "</p></div>"
@@ -1036,6 +1050,16 @@ get_agent_report <- function(agent,
   f_fail_val <- ifelse(f_fail_val < 1 & f_fail_val > 0.99, 0.99, f_fail_val)
   f_fail_val <- as.numeric(f_fail_val)
 
+  
+  # Generate the report title with the `title` option
+  title_text <- 
+    process_title_text(
+      title = title,
+      tbl_name = tbl_name,
+      report_type = "agent",
+      lang = lang
+    )
+  
   # Generate a gt table
   gt_agent_report <- 
     report_tbl %>%
@@ -1064,7 +1088,11 @@ get_agent_report <- function(agent,
       n_pass, f_pass, n_fail, f_fail, W, S, N, extract,
       W_val, S_val, N_val, eval, active
     ) %>%
-    gt::gt(id = "report") %>%
+    gt::gt(id = "pb_agent") %>%
+    gt::tab_header(
+      title = title_text,
+      subtitle = gt::md(combined_subtitle)
+    ) %>%
     gt::cols_merge(
       columns = gt::vars(n_pass, f_pass),
       hide_columns = gt::vars(f_pass)
@@ -1096,10 +1124,6 @@ get_agent_report <- function(agent,
       n_pass = "PASS",
       n_fail = "FAIL",
       extract = "EXT"
-    ) %>%
-    gt::tab_header(
-      title = get_lsv("agent_report/pointblank_validation_title_text")[[lang]],
-      subtitle = gt::md(combined_subtitle)
     ) %>%
     gt::tab_source_note(source_note = gt::md(table_time)) %>%
     gt::tab_options(
@@ -1249,6 +1273,12 @@ get_agent_report <- function(agent,
       locations = gt::cells_body(
         columns = TRUE,
         rows = eval == "ERROR"
+      )
+    ) %>%
+    gt::tab_style(
+      style = gt::cell_text(size = gt::px(11)),
+      locations = gt::cells_body(
+        columns = gt::vars(units, n_pass, n_fail)
       )
     )
   
@@ -1402,26 +1432,19 @@ get_agent_report <- function(agent,
         )
       ) %>%
       gt::opt_css(
-        paste0(
-          "@import url(\"https://fonts.googleapis.com/",
-          "css2?family=IBM+Plex+Mono&display=swap\");"
-        )
-      ) %>%
-      gt::opt_css(
         css = "
-          #report {
+          #pb_agent {
             -webkit-font-smoothing: antialiased;
           }
-          #report .gt_row {
+          #pb_agent .gt_row {
             overflow: visible;
           }
-          #report .gt_sourcenote {
+          #pb_agent .gt_sourcenote {
             height: 35px;
             padding: 0
           }
-          #report code {
+          #pb_agent code {
             font-family: 'IBM Plex Mono', monospace, courier;
-            font-size: 11px;
             background-color: transparent;
             padding: 0;
           }
@@ -1429,9 +1452,58 @@ get_agent_report <- function(agent,
       )
   }
   
+
+  
   # nocov end
   
   gt_agent_report
+}
+
+get_default_title_text <- function(report_type,
+                                   lang) {
+  
+  if (report_type == "informant") {
+    title_text <- 
+      get_lsv(text = c(
+        "informant_report",
+        "pointblank_information_title_text"
+      ))[[lang]]
+  } else if (report_type == "agent") {
+    title_text <- 
+      get_lsv(text = c(
+        "agent_report",
+        "pointblank_validation_title_text"
+      ))[[lang]]
+  }
+  
+  title_text
+}
+
+process_title_text <- function(title,
+                               tbl_name,
+                               report_type,
+                               lang) {
+  
+  if (is.null(title)) {
+    title_text <- ""
+  } else if (is.na(title)) {
+    title_text <- ""
+  } else if (title == ":default:") {
+    title_text <- get_default_title_text(report_type = report_type, lang = lang)
+  } else if (title == ":none:") {
+    title_text <- ""
+  } else if (title == ":tbl_name:") {
+    if (!is.na(tbl_name) && tbl_name != "NA") {
+      title_text <- gt::md(paste0("<code>", tbl_name, "</code>"))
+    } else {
+      title_text <- ""
+    }
+  } else if (inherits(title, "AsIs")) {
+    title_text <- unclass(title)
+  } else if (inherits(title, "character")) {
+    title_text <- gt::md(title)
+  }
+  title_text
 }
 
 create_table_time_html <- function(time_start,
@@ -1451,7 +1523,7 @@ create_table_time_html <- function(time_start,
     "color: #444;padding: 0.5em 0.5em;",
     "position: inherit;text-transform: uppercase;margin-left: 10px;",
     "border: solid 1px #999999;font-variant-numeric: tabular-nums;",
-    "border-radius: 0;padding: 2px 10px 2px 10px;font-size: smaller;\">",
+    "border-radius: 0;padding: 2px 10px 2px 10px;\">",
     format(time_start, "%Y-%m-%d %H:%M:%S %Z"),
     "</span>",
     
@@ -1460,7 +1532,7 @@ create_table_time_html <- function(time_start,
     "position: inherit;margin: 5px 1px 5px 0;",
     "border: solid 1px #999999;border-left: none;",
     "font-variant-numeric: tabular-nums;",
-    "border-radius: 0;padding: 2px 10px 2px 10px;font-size: smaller;\">",
+    "border-radius: 0;padding: 2px 10px 2px 10px;\">",
     time_duration_formatted,
     "</span>",
     
@@ -1468,7 +1540,7 @@ create_table_time_html <- function(time_start,
     "color: #444;padding: 0.5em 0.5em;",
     "position: inherit;text-transform: uppercase;margin: 5px 1px 5px -1px;",
     "border: solid 1px #999999;border-left: none;",
-    "border-radius: 0;padding: 2px 10px 2px 10px;font-size: smaller;\">",
+    "border-radius: 0;padding: 2px 10px 2px 10px;\">",
     format(time_end, "%Y-%m-%d %H:%M:%S %Z"),
     "</span>"
   )
@@ -1522,8 +1594,8 @@ create_table_type_html <- function(tbl_src, tbl_name) {
       tbl_spark = c("#E66F21", "#FFFFFF", "Spark DataFrame"),
       c("#E2E2E2", "#222222", tbl_src)
     )
-  
-  if (all(!is.na(text)) && is.na(tbl_name)) {
+
+  if (all(!is.na(text)) && (is.na(tbl_name) || tbl_name == "NA")) {
     
     paste0(
       "<span style=\"background-color: ", text[1], ";",

--- a/R/get_agent_report.R
+++ b/R/get_agent_report.R
@@ -1474,6 +1474,8 @@ get_default_title_text <- function(report_type,
         "agent_report",
         "pointblank_validation_title_text"
       ))[[lang]]
+  } else if (report_type == "multiagent") {
+    title_text <- "Pointblank Validation Series"
   }
   
   title_text
@@ -1483,6 +1485,15 @@ process_title_text <- function(title,
                                tbl_name,
                                report_type,
                                lang) {
+  
+  if (report_type == "multiagent") {
+    if (title == ":tbl_name:") {
+      stop(
+        "The `:tbl_name:` option can't be used with `get_multiagent_report()`.",
+        call. = FALSE
+      )
+    }
+  }
   
   if (is.null(title)) {
     title_text <- ""

--- a/R/get_informant_report.R
+++ b/R/get_informant_report.R
@@ -29,6 +29,17 @@
 #' @param informant An informant object of class `ptblank_informant`.
 #' @param size The size of the display table, which can be either `"standard"`
 #'   (the default, with a width of 875px) or `"small"` (width of 575px).
+#' @param title Options for customizing the title of the report. The default is
+#'   the keyword `":default:"` which produces generic title text that refers to
+#'   the **pointblank** package in the language governed by the `lang` option.
+#'   Another keyword option is `":tbl_name:"`, and that presents the name of the
+#'   table as the title for the report. If no title is wanted, then the
+#'   `":none:"` keyword option can be used. Aside from keyword options, text can
+#'   be provided for the title and `glue::glue()` calls can be used to construct
+#'   the text string. If providing text, it will be interpreted as Markdown text
+#'   and transformed internally to HTML. To circumvent such a transformation,
+#'   use text in [I()] to explicitly state that the supplied text should not be
+#'   transformed.
 #' @param lang The language to use for the *information report* (a summary table
 #'   that provides the validation plan and the results from the interrogation.
 #'   By default, `NULL` will create English (`"en"`) text. Other options include
@@ -70,6 +81,7 @@
 #' @export
 get_informant_report <- function(informant,
                                  size = "standard",
+                                 title = ":default:",
                                  lang = NULL,
                                  locale = NULL) {
   
@@ -449,6 +461,15 @@ get_informant_report <- function(informant,
       time_start = time_start,
       time_end = time_end
     )
+
+  # Generate the report title with the `title` option
+  title_text <- 
+    process_title_text(
+      title = title,
+      tbl_name = tbl_name,
+      report_type = "informant",
+      lang = lang
+    )
   
   # Generate a gt table
   gt_informant_report <- 
@@ -458,10 +479,7 @@ get_informant_report <- function(informant,
       id = "pb_information"
     ) %>%
     gt::tab_header(
-      title = get_lsv(text = c(
-        "informant_report",
-        "pointblank_information_title_text"
-      ))[[lang]],
+      title = title_text,
       subtitle = gt::md(combined_subtitle)
     ) %>%
     gt::tab_source_note(source_note = gt::md(table_time)) %>%

--- a/R/get_multiagent_report.R
+++ b/R/get_multiagent_report.R
@@ -46,6 +46,14 @@
 #' @param display_table Should a display table be generated? If `TRUE` (the
 #'   default) a display table for the report will be shown in the Viewer. If
 #'   `FALSE` then a tibble will be returned.
+#' @param title Options for customizing the title of the report. The default is
+#'   the keyword `":default:"` which produces generic title text. If no title is
+#'   wanted, then the `":none:"` keyword option can be used. Aside from keyword
+#'   options, text can be provided for the title and `glue::glue()` calls can be
+#'   used to construct the text string. If providing text, it will be
+#'   interpreted as Markdown text and transformed internally to HTML. To
+#'   circumvent such a transformation, use text in [I()] to explicitly state
+#'   that the supplied text should not be transformed.
 #' 
 #' @return A **gt** table object if `display_table = TRUE` or a tibble if
 #'   `display_table = FALSE`.
@@ -56,7 +64,8 @@
 #'
 #' @export
 get_multiagent_report <- function(multiagent,
-                                  display_table = TRUE) {
+                                  display_table = TRUE,
+                                  title = ":default:") {
 
   for (i in seq_along(multiagent[["agents"]])) {
     
@@ -519,10 +528,19 @@ get_multiagent_report <- function(multiagent,
       gt::tab_options(container.width = gt::px(875))
   }
   
+  # Generate the report title with the `title` option
+  title_text <- 
+    process_title_text(
+      title = title,
+      tbl_name = NULL,
+      report_type = "multiagent",
+      lang = "en"
+    )
+  
   report_tbl <- 
     report_tbl %>%
     gt::tab_header(
-      title = "Pointblank Validation Series",
+      title = title_text,
       subtitle = gt::md(combined_subtitle)
     ) %>%
     gt::tab_source_note(

--- a/man/get_agent_report.Rd
+++ b/man/get_agent_report.Rd
@@ -10,6 +10,7 @@ get_agent_report(
   keep = c("all", "fail_states"),
   display_table = TRUE,
   size = "standard",
+  title = ":default:",
   lang = NULL,
   locale = NULL
 )
@@ -33,6 +34,18 @@ available, then a tibble will be returned.}
 \item{size}{The size of the display table, which can be either \code{"standard"}
 (the default) or \code{"small"}. This only applies to a display table (where
 \code{display_table = TRUE}).}
+
+\item{title}{Options for customizing the title of the report. The default is
+the keyword \code{":default:"} which produces generic title text that refers to
+the \strong{pointblank} package in the language governed by the \code{lang} option.
+Another keyword option is \code{":tbl_name:"}, and that presents the name of the
+table as the title for the report. If no title is wanted, then the
+\code{":none:"} keyword option can be used. Aside from keyword options, text can
+be provided for the title and \code{glue::glue()} calls can be used to construct
+the text string. If providing text, it will be interpreted as Markdown text
+and transformed internally to HTML. To circumvent such a transformation,
+use text in \code{\link[=I]{I()}} to explicitly state that the supplied text should not be
+transformed.}
 
 \item{lang}{The language to use for automatic creation of briefs (short
 descriptions for each validation step) and for the \emph{agent report} (a

--- a/man/get_informant_report.Rd
+++ b/man/get_informant_report.Rd
@@ -4,13 +4,31 @@
 \alias{get_informant_report}
 \title{Get a table information report from an \emph{informant} object}
 \usage{
-get_informant_report(informant, size = "standard", lang = NULL, locale = NULL)
+get_informant_report(
+  informant,
+  size = "standard",
+  title = ":default:",
+  lang = NULL,
+  locale = NULL
+)
 }
 \arguments{
 \item{informant}{An informant object of class \code{ptblank_informant}.}
 
 \item{size}{The size of the display table, which can be either \code{"standard"}
 (the default, with a width of 875px) or \code{"small"} (width of 575px).}
+
+\item{title}{Options for customizing the title of the report. The default is
+the keyword \code{":default:"} which produces generic title text that refers to
+the \strong{pointblank} package in the language governed by the \code{lang} option.
+Another keyword option is \code{":tbl_name:"}, and that presents the name of the
+table as the title for the report. If no title is wanted, then the
+\code{":none:"} keyword option can be used. Aside from keyword options, text can
+be provided for the title and \code{glue::glue()} calls can be used to construct
+the text string. If providing text, it will be interpreted as Markdown text
+and transformed internally to HTML. To circumvent such a transformation,
+use text in \code{\link[=I]{I()}} to explicitly state that the supplied text should not be
+transformed.}
 
 \item{lang}{The language to use for the \emph{information report} (a summary table
 that provides the validation plan and the results from the interrogation.

--- a/man/get_multiagent_report.Rd
+++ b/man/get_multiagent_report.Rd
@@ -4,7 +4,7 @@
 \alias{get_multiagent_report}
 \title{Get a summary report using multiple agents}
 \usage{
-get_multiagent_report(multiagent, display_table = TRUE)
+get_multiagent_report(multiagent, display_table = TRUE, title = ":default:")
 }
 \arguments{
 \item{multiagent}{A multiagent object of class \code{ptblank_multiagent}.}
@@ -12,6 +12,15 @@ get_multiagent_report(multiagent, display_table = TRUE)
 \item{display_table}{Should a display table be generated? If \code{TRUE} (the
 default) a display table for the report will be shown in the Viewer. If
 \code{FALSE} then a tibble will be returned.}
+
+\item{title}{Options for customizing the title of the report. The default is
+the keyword \code{":default:"} which produces generic title text. If no title is
+wanted, then the \code{":none:"} keyword option can be used. Aside from keyword
+options, text can be provided for the title and \code{glue::glue()} calls can be
+used to construct the text string. If providing text, it will be
+interpreted as Markdown text and transformed internally to HTML. To
+circumvent such a transformation, use text in \code{\link[=I]{I()}} to explicitly state
+that the supplied text should not be transformed.}
 }
 \value{
 A \strong{gt} table object if \code{display_table = TRUE} or a tibble if

--- a/tests/manual_tests/tests_multiagent_create.R
+++ b/tests/manual_tests/tests_multiagent_create.R
@@ -76,16 +76,24 @@ agent_5 <-
 multiagent <-
   create_multiagent(agent_1, agent_2, agent_3, agent_5)
 
-# 4UP report
+## 4UP report
+
+# Standard printing
+multiagent
+
+# Printing with options in `get_multiagent_report()`
 get_multiagent_report(multiagent, title = "Report with **Multiple** Table Validations")
 
-# 8UP report
+# Option for tibble output
+get_multiagent_report(multiagent, display_table = FALSE)
+
+## 8UP report
 create_multiagent(agent_1, agent_2, agent_3, agent_2, agent_3)
 
-# 16UP report
+## 16UP report
 create_multiagent(agent_1, agent_2, agent_3, agent_2, agent_3, agent_2, agent_3, agent_2, agent_3)
 
-# 16+ report
+## 16UP+ report
 create_multiagent(
   agent_1, agent_2, agent_3, agent_2, agent_3, agent_2, agent_3, agent_2, agent_3,
   agent_1, agent_2, agent_3, agent_2, agent_3, agent_2, agent_3, agent_2, agent_3,

--- a/tests/manual_tests/tests_multiagent_create.R
+++ b/tests/manual_tests/tests_multiagent_create.R
@@ -80,6 +80,8 @@ multiagent <-
 # 4UP report
 multiagent
 
+get_multiagent_report(multiagent)
+
 # 8UP report
 create_multiagent(agent_1, agent_2, agent_3, agent_2, agent_3)
 

--- a/tests/manual_tests/tests_multiagent_create.R
+++ b/tests/manual_tests/tests_multiagent_create.R
@@ -34,7 +34,6 @@ agent_2 <-
   rows_distinct() %>%
   interrogate()
 
-
 agent_3 <- 
   create_agent(
     read_fn = ~ small_table,
@@ -78,9 +77,7 @@ multiagent <-
   create_multiagent(agent_1, agent_2, agent_3, agent_5)
 
 # 4UP report
-multiagent
-
-get_multiagent_report(multiagent)
+get_multiagent_report(multiagent, title = "Report with **Multiple** Table Validations")
 
 # 8UP report
 create_multiagent(agent_1, agent_2, agent_3, agent_2, agent_3)

--- a/tests/testthat/test-get_agent_report.R
+++ b/tests/testthat/test-get_agent_report.R
@@ -78,3 +78,125 @@ test_that("The `all_passed()` function works", {
       all_passed()
   )
 })
+
+test_that("The correct title is rendered in the agent report", {
+  
+  the_table_name <- "small_table"
+  
+  agent <-
+    create_agent(
+      tbl = small_table,
+      tbl_name = "small_table",
+      label = "Agent Report"
+    ) %>%
+    col_vals_gt(vars(a), 0) %>%
+    interrogate()
+  
+  expect_match(
+    get_agent_report(agent) %>%
+      gt::as_raw_html(inline_css = FALSE),
+    ">Pointblank Validation</th>",
+    fixed = TRUE
+  )
+  
+  expect_match(
+    get_agent_report(agent, title = ":default:") %>%
+      gt::as_raw_html(inline_css = FALSE),
+    ">Pointblank Validation</th>",
+    fixed = TRUE
+  )
+  
+  expect_match(
+    get_agent_report(agent, title = ":tbl_name:") %>%
+      gt::as_raw_html(inline_css = FALSE),
+    "><code>small_table</code></th>",
+    fixed = TRUE
+  )
+  
+  expect_match(
+    get_agent_report(agent, title = "The validation of `small_tbl`") %>%
+      gt::as_raw_html(inline_css = FALSE),
+    ">The validation of <code>small_tbl</code></th>",
+    fixed = TRUE
+  )
+  
+  expect_match(
+    get_agent_report(agent, title = I("The validation of `small_tbl`")) %>%
+      gt::as_raw_html(inline_css = FALSE),
+    ">The validation of `small_tbl`</th>",
+    fixed = TRUE
+  )
+
+  expect_match(
+    get_agent_report(agent, title = glue::glue("The validation of `{the_table_name}`")) %>%
+      gt::as_raw_html(inline_css = FALSE),
+    ">The validation of <code>small_table</code></th>",
+    fixed = TRUE
+  )
+  
+  expect_match(
+    get_agent_report(agent, title = glue::glue("The validation of `{agent$tbl_name}`")) %>%
+      gt::as_raw_html(inline_css = FALSE),
+    ">The validation of <code>small_table</code></th>",
+    fixed = TRUE
+  )
+  
+  
+  expect_false(
+    grepl(
+      ">Pointblank Validation</th>",
+      get_agent_report(agent, title = I(NA)) %>%
+        gt::as_raw_html(inline_css = FALSE),
+      fixed = TRUE
+    )
+  )
+  expect_false(
+    grepl(
+      ">Pointblank Validation</th>",
+      get_agent_report(agent, title = ":none:") %>%
+        gt::as_raw_html(inline_css = FALSE),
+      fixed = TRUE
+    )
+  )
+  expect_false(
+    grepl(
+      ">Pointblank Validation</th>",
+      get_agent_report(agent, title = "") %>%
+        gt::as_raw_html(inline_css = FALSE),
+      fixed = TRUE
+    )
+  )
+  expect_false(
+    grepl(
+      ">Pointblank Validation</th>",
+      get_agent_report(agent, title = NULL) %>%
+        gt::as_raw_html(inline_css = FALSE),
+      fixed = TRUE
+    )
+  )
+  expect_false(
+    grepl(
+      ">Pointblank Validation</th>",
+      get_agent_report(agent, title = NA) %>%
+        gt::as_raw_html(inline_css = FALSE),
+      fixed = TRUE
+    )
+  )
+  expect_false(
+    grepl(
+      ">Pointblank Validation</th>",
+      get_agent_report(agent, title = I(NA)) %>%
+        gt::as_raw_html(inline_css = FALSE),
+      fixed = TRUE
+    )
+  )
+  expect_false(
+    grepl(
+      ">Pointblank Validation</th>",
+      get_agent_report(agent, title = I("")) %>%
+        gt::as_raw_html(inline_css = FALSE),
+      fixed = TRUE
+    )
+  )
+})
+

--- a/tests/testthat/test-get_informant_report.R
+++ b/tests/testthat/test-get_informant_report.R
@@ -189,3 +189,126 @@ Dimorphism and Environmental Variability within a Community of Antarctic Penguin
   # Expect that the report is a gt table
   expect_is(report, "gt_tbl")
 })
+
+test_that("The correct title is rendered in the informant report", {
+  
+  the_table_name <- "example_tbl"
+  
+  informant <- 
+    dplyr::tibble(
+      a = c(5, 7, 6, 5, NA, 7),
+      b = c(6, 1, 0, 6,  0, 7)
+    ) %>%
+    create_informant(
+      label = "A very *simple* example.",
+      tbl_name = "example_tbl"
+    ) %>%
+    incorporate()
+  
+  expect_match(
+    get_informant_report(informant) %>%
+      gt::as_raw_html(inline_css = FALSE),
+    ">Pointblank Information</th>",
+    fixed = TRUE
+  )
+  
+  expect_match(
+    get_informant_report(informant, title = ":default:") %>%
+      gt::as_raw_html(inline_css = FALSE),
+    ">Pointblank Information</th>",
+    fixed = TRUE
+  )
+  
+  expect_match(
+    get_informant_report(informant, title = ":tbl_name:") %>%
+      gt::as_raw_html(inline_css = FALSE),
+    "><code>example_tbl</code></th>",
+    fixed = TRUE
+  )
+  
+  expect_match(
+    get_informant_report(informant, title = "All the information you need about `example_tbl`") %>%
+      gt::as_raw_html(inline_css = FALSE),
+    ">All the information you need about <code>example_tbl</code></th>",
+    fixed = TRUE
+  )
+  
+  expect_match(
+    get_informant_report(informant, title = I("All the information you need about `example_tbl`")) %>%
+      gt::as_raw_html(inline_css = FALSE),
+    ">All the information you need about `example_tbl`</th>",
+    fixed = TRUE
+  )
+  
+  expect_match(
+    get_informant_report(informant, title = glue::glue("Information on `{the_table_name}`")) %>%
+      gt::as_raw_html(inline_css = FALSE),
+    ">Information on <code>example_tbl</code></th>",
+    fixed = TRUE
+  )
+  
+  expect_match(
+    get_informant_report(informant, title = glue::glue("Information on `{informant$tbl_name}`")) %>%
+      gt::as_raw_html(inline_css = FALSE),
+    ">Information on <code>example_tbl</code></th>",
+    fixed = TRUE
+  )
+  
+  
+  expect_false(
+    grepl(
+      ">Pointblank Information</th>",
+      get_informant_report(informant, title = I(NA)) %>%
+        gt::as_raw_html(inline_css = FALSE),
+      fixed = TRUE
+    )
+  )
+  expect_false(
+    grepl(
+      ">Pointblank Information</th>",
+      get_informant_report(informant, title = ":none:") %>%
+        gt::as_raw_html(inline_css = FALSE),
+      fixed = TRUE
+    )
+  )
+  expect_false(
+    grepl(
+      ">Pointblank Information</th>",
+      get_informant_report(informant, title = "") %>%
+        gt::as_raw_html(inline_css = FALSE),
+      fixed = TRUE
+    )
+  )
+  expect_false(
+    grepl(
+      ">Pointblank Information</th>",
+      get_informant_report(informant, title = NULL) %>%
+        gt::as_raw_html(inline_css = FALSE),
+      fixed = TRUE
+    )
+  )
+  expect_false(
+    grepl(
+      ">Pointblank Information</th>",
+      get_informant_report(informant, title = NA) %>%
+        gt::as_raw_html(inline_css = FALSE),
+      fixed = TRUE
+    )
+  )
+  expect_false(
+    grepl(
+      ">Pointblank Information</th>",
+      get_informant_report(informant, title = I(NA)) %>%
+        gt::as_raw_html(inline_css = FALSE),
+      fixed = TRUE
+    )
+  )
+  expect_false(
+    grepl(
+      ">Pointblank Information</th>",
+      get_informant_report(informant, title = I("")) %>%
+        gt::as_raw_html(inline_css = FALSE),
+      fixed = TRUE
+    )
+  )
+})


### PR DESCRIPTION
This adds several options for customizing the main reporting heading in three reporting objects: the agent report, the information report, and the multiagent report.

This adds the `title` argument to `get_agent_report()`, `get_informant_report()`, and `get_multiagent_report()`. The default is the keyword `":default:"` which produces generic title text that refers to the **pointblank** package in the language governed by the `lang` option. This is current behavior.

Another keyword option is `":tbl_name:"`, and that presents the name of the table as the title for the report. This is available for all `get_*()` functions except for `get_multiagent_report()` (this may change in the future).

If no title is needed, then the `":none:"` keyword option can be used.

Aside from keyword options, text can be provided for the title and `glue::glue()` calls can be used to construct the text string. If providing text, it will be interpreted as Markdown text and transformed internally to HTML. To circumvent such a transformation, use text in `I()` to explicitly state that the supplied text should not be transformed.

Several testthat tests were added to verify that the intended title was rendered in all HTML reporting output.

Fixes: https://github.com/rich-iannone/pointblank/issues/251