### PR TITLE
Use full 4 bytes for unicode values

### DIFF
--- a/data-raw/00-reencode_text.R
+++ b/data-raw/00-reencode_text.R
@@ -32,7 +32,9 @@ reencode_utf8 <- function(x) {
         
         bytes_nz <- x[x > 0]
 
-        if (length(bytes_nz) > 1) {
+        if (length(bytes_nz) > 2) {
+          out <- paste("\\U", paste(as.hexmode(x), collapse = ""), sep = "")
+        } else if (length(bytes_nz) > 1) {
           out <- paste("\\u", paste(as.hexmode(bytes_nz), collapse = ""), sep = "")
         } else if (length(bytes_nz) == 1 && bytes_nz > 127) {
           out <- paste("\\u", sprintf("%04s", paste(as.hexmode(bytes_nz)), collapse = ""), sep = "")


### PR DESCRIPTION
Hi @rich-iannone. I discovered that some emoji may not round-trip through `reencode_utf8()`:

```r
emoji <- "🧑‍💻 🧑🏽‍💻"
(emoji_utf8 <- reencode_utf8(emoji))
#> [1] "\\u01f9d1\\u200d\\u01f4bb \\u01f9d1\\u01f3fd\\u200d\\u01f4bb"
(emoji_utf8_unesc <- stringi::stri_unescape_unicode(emoji_utf8))
#> [1] "ǹd1‍Ǵbb ǹd1ǳfd‍Ǵbb"
cat(emoji_utf8_unesc)
#> ǹd1‍Ǵbb ǹd1ǳfd‍Ǵbb
```

My understanding is that emoji that fit in two bytes are prefixed with `\u`

```r
cat("\u2705")
#> ✅
```

but emoji that require the full 4 bytes need to be prefixed with `\U`

```r
cat("\u01F638")
#> Ƕ38

cat("\U0001F638")
#> 😸
```

The fix I've proposed is to use the full 4-byte chunk if there are 3 or more non-zero bytes

```r
  # reencode_utf8() ....
  if (length(bytes_nz) > 2) {
    out <- paste("\\U", paste(as.hexmode(x), collapse = ""), sep = "")
  } else if (length(bytes_nz) > 1) {
  # ...
```

Which appears to round-trip correctly (although `stri_unescape_unicode()` introduces minor modifications from the input)

```r
emoji <- "🧑‍💻 🧑🏽‍💻"
stringi::stri_escape_unicode(emoji)
#> [1] "\\U0001f9d1\\u200d\\U0001f4bb \\U0001f9d1\\U0001f3fd\\u200d\\U0001f4bb"
(emoji_utf8 <- reencode_utf8(emoji))
#> [1] "\\U0001f9d1\\u200d\\U0001f4bb \\U0001f9d1\\U0001f3fd\\u200d\\U0001f4bb"
(emoji_utf8_unesc <- stringi::stri_unescape_unicode(emoji_utf8))
#> [1] "\U0001f9d1‍\U0001f4bb \U0001f9d1\U0001f3fd‍\U0001f4bb"
cat(emoji_utf8_unesc)
#> 🧑‍💻 🧑🏽‍💻
```