### PR TITLE
Fixes to make agents survive the YAML roundtrip 

### DIFF
--- a/R/yaml_read_agent.R
+++ b/R/yaml_read_agent.R
@@ -506,19 +506,32 @@ make_validation_steps <- function(steps) {
         
         step_i <- steps[[x]]
         step_fn <- names(step_i)
-        
+
         args <- 
           vapply(
             seq_along(step_i[[1]]),
             FUN.VALUE = character(1), 
             FUN = function(x) {
-              
               arg_name <- names(step_i[[1]][x])
               val <- step_i[[1]][[x]]
               others <- c("preconditions", "expr", "schema")
-
+              
               if (arg_name == "fns") {
                 return(paste("  ", val, collapse = ",\n"))
+              }
+              
+              if (arg_name == "inclusive") {
+                if (all(val)) {
+                  return("")
+                } else {
+                  return(
+                    paste0(
+                      "  inclusive = c(",
+                      paste(as.character(val), collapse = ", "),
+                      ")"
+                    )
+                  )
+                }
               }
 
               # Return empty string if seeing default values
@@ -593,15 +606,26 @@ make_validation_steps <- function(steps) {
                          !grepl(tidyselect_regex, val[1]) &&
                          !(arg_name %in% others)) {
                 
-                val <- paste0("\"", val, "\"")
+                val <- 
+                  vapply(
+                    val,
+                    FUN.VALUE = character(1),
+                    USE.NAMES = FALSE,
+                    FUN = function(x) {
+                      if (is.na(x)) {
+                        return(x)
+                      } else {
+                        paste0("\"", x, "\"")
+                      }
+                    }
+                  )
+                
+                #val <- paste0("\"", val, "\"")
               }
               
               if (length(val) > 1) {
                 val <- 
-                  paste0(
-                    "c(", paste(as.character(val), collapse = ", "),
-                    ")"
-                  )
+                  paste0("c(", paste(as.character(val), collapse = ", "), ")")
               } else {
                 val <- as.character(val)
               }

--- a/R/yaml_write.R
+++ b/R/yaml_write.R
@@ -450,7 +450,7 @@ get_arg_value_lr <- function(value) {
 }
 
 prune_lst_step <- function(lst_step) {
-  
+
   if ("preconditions" %in% names(lst_step[[1]]) &&
       is.null(lst_step[[1]][["preconditions"]])) {
     lst_step[[1]]["preconditions"] <- NULL
@@ -629,7 +629,7 @@ as_agent_yaml_list <- function(agent,
           step_list = step_list,
           expanded = expanded
         )
-      
+
       lst_step <- 
         list(
           validation_fn = list(
@@ -639,7 +639,7 @@ as_agent_yaml_list <- function(agent,
             inclusive = as.logical(
               c(
                 names(step_list$values[[1]][1]),
-                names(step_list$values[[1]][1])
+                names(step_list$values[[1]][2])
               )
             ),
             na_pass = step_list$na_pass,
@@ -706,7 +706,11 @@ as_agent_yaml_list <- function(agent,
         decreasing_tol <- step_list$values[[1]][2]
       }
       
-      column_text <- get_column_text(step_list)
+      column_text <- 
+        get_column_text(
+          step_list = step_list,
+          expanded = expanded
+        )
       
       lst_step <- 
         list(

--- a/R/yaml_write.R
+++ b/R/yaml_write.R
@@ -496,6 +496,10 @@ prune_lst_step <- function(lst_step) {
       lst_step[[1]][["actions"]] <- NULL
     }
   }
+  if ("label" %in% names(lst_step[[1]]) &&
+      is.na(lst_step[[1]][["label"]])) {
+    lst_step[[1]]["label"] <- NULL
+  }
   
   lst_step
 }
@@ -560,7 +564,7 @@ as_agent_yaml_list <- function(agent,
       agent$validation_set %>% 
       dplyr::select(
         i_o, assertion_type, columns_expr, column, values, na_pass,
-        preconditions, actions, brief, active
+        preconditions, actions, label, brief, active
       ) %>%
       dplyr::group_by(i_o) %>%
       dplyr::filter(dplyr::row_number() == 1) %>%
@@ -578,7 +582,7 @@ as_agent_yaml_list <- function(agent,
       agent$validation_set %>% 
       dplyr::select(
         i, assertion_type, columns_expr, column, values, na_pass,
-        preconditions, actions, brief, active
+        preconditions, actions, label, brief, active
       )
   }
   
@@ -613,6 +617,7 @@ as_agent_yaml_list <- function(agent,
               step_list$actions[[1]],
               action_levels_default
             ),
+            label = step_list$label,
             active = as_list_active(step_list$active)
           )
         )
@@ -643,6 +648,7 @@ as_agent_yaml_list <- function(agent,
               step_list$actions[[1]],
               action_levels_default
             ),
+            label = step_list$label,
             active = as_list_active(step_list$active)
           )
         )
@@ -665,6 +671,7 @@ as_agent_yaml_list <- function(agent,
               step_list$actions[[1]],
               action_levels_default
             ),
+            label = step_list$label,
             active = as_list_active(step_list$active)
           )
         )
@@ -686,6 +693,7 @@ as_agent_yaml_list <- function(agent,
               step_list$actions[[1]],
               action_levels_default
             ),
+            label = step_list$label,
             active = as_list_active(step_list$active)
           )
         )
@@ -713,6 +721,7 @@ as_agent_yaml_list <- function(agent,
               step_list$actions[[1]],
               action_levels_default
             ),
+            label = step_list$label,
             active = as_list_active(step_list$active)
           )
         )
@@ -744,6 +753,7 @@ as_agent_yaml_list <- function(agent,
               step_list$actions[[1]],
               action_levels_default
             ),
+            label = step_list$label,
             active = as_list_active(step_list$active)
           )
         )
@@ -766,6 +776,7 @@ as_agent_yaml_list <- function(agent,
               step_list$actions[[1]],
               action_levels_default
             ),
+            label = step_list$label,
             active = as_list_active(step_list$active)
           )
         )
@@ -787,6 +798,7 @@ as_agent_yaml_list <- function(agent,
               step_list$actions[[1]],
               action_levels_default
             ),
+            label = step_list$label,
             active = as_list_active(step_list$active)
           )
         )
@@ -802,6 +814,7 @@ as_agent_yaml_list <- function(agent,
               step_list$actions[[1]],
               action_levels_default
             ),
+            label = step_list$label,
             active = as_list_active(step_list$active)
           )
         )
@@ -823,6 +836,7 @@ as_agent_yaml_list <- function(agent,
               step_list$actions[[1]],
               action_levels_default
             ),
+            label = step_list$label,
             active = as_list_active(step_list$active)
           )
         )
@@ -842,6 +856,7 @@ as_agent_yaml_list <- function(agent,
               step_list$actions[[1]],
               action_levels_default
             ),
+            label = step_list$label,
             active = as_list_active(step_list$active)
           )
         )
@@ -857,6 +872,7 @@ as_agent_yaml_list <- function(agent,
               step_list$actions[[1]],
               action_levels_default
             ),
+            label = step_list$label,
             active = as_list_active(step_list$active)
           )
         )

--- a/tests/testthat/test-yaml.R
+++ b/tests/testthat/test-yaml.R
@@ -258,10 +258,10 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
   #   get_oneline_expr_str(agent %>% col_vals_lt(vars(a), 1, brief = "Expect `a` < `1`.")),
   #   "col_vals_lt(columns = vars(a, c),value = 1,brief = \"Expect `a` < `1`.\")"
   # )
-  # expect_equal(
-  #   get_oneline_expr_str(agent %>% col_vals_lt(vars(a, c), 1, label = "my_label")),
-  #   "col_vals_lt(columns = vars(a, c),value = 1,label = \"my_label\")"
-  # )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_vals_lt(vars(a, c), 1, label = "my_label")),
+    "col_vals_lt(columns = vars(a, c),value = 1,label = \"my_label\")"
+  )
   # expect_equal(
   #   get_oneline_expr_str(agent %>% col_vals_lt(vars(a, c), 1, active = TRUE)),
   #   "col_vals_lt(columns = vars(a, c),value = 1,active = TRUE)"
@@ -315,6 +315,10 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
     ),
     "col_vals_between(columns = vars(c),left = vars(a),right = vars(d),actions = action_levels(warn_at = 0.1,stop_at = 0.2))"
   )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_vals_between(vars(c), left = -5, right = 15, label = "my_label")),
+    "col_vals_between(columns = vars(c),left = -5,right = 15,label = \"my_label\")"
+  )
   # expect_equal(
   #   get_oneline_expr_str(agent %>% col_vals_between(vars(c), left = vars(a), right = vars(d), inclusive = c(TRUE, FALSE))),
   #   "col_vals_between(columns = vars(a),left = vars(a),right = vars(d),inclusive = c(TRUE, FALSE))"
@@ -365,6 +369,10 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
     ),
     "col_vals_not_between(columns = vars(c),left = vars(a),right = vars(d),actions = action_levels(warn_at = 0.1,stop_at = 0.2))"
   )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_vals_not_between(vars(a), left = -5, right = 15, label = "my_label")),
+    "col_vals_not_between(columns = vars(a),left = -5,right = 15,label = \"my_label\")"
+  )
   
   #
   # col_vals_in_set
@@ -405,6 +413,10 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
         )
     ),
     "col_vals_in_set(columns = vars(c),set = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),actions = action_levels(warn_at = 0.1,stop_at = 0.2))"
+  )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_vals_in_set(vars(f), set = c("low", "high"), label = "my_label")),
+    "col_vals_in_set(columns = vars(f),set = c(\"low\", \"high\"),label = \"my_label\")"
   )
   
   #
@@ -447,6 +459,10 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
     ),
     "col_vals_not_in_set(columns = vars(c),set = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),actions = action_levels(warn_at = 0.1,stop_at = 0.2))"
   )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_vals_not_in_set(vars(f), set = c("low", "high"), label = "my_label")),
+    "col_vals_not_in_set(columns = vars(f),set = c(\"low\", \"high\"),label = \"my_label\")"
+  )
   
   #
   # col_vals_make_set
@@ -487,6 +503,10 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
         )
     ),
     "col_vals_make_set(columns = vars(c),set = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),actions = action_levels(warn_at = 0.1,stop_at = 0.2))"
+  )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_vals_make_set(vars(f), set = c("low", "high"), label = "my_label")),
+    "col_vals_make_set(columns = vars(f),set = c(\"low\", \"high\"),label = \"my_label\")"
   )
   
   #
@@ -529,6 +549,10 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
     ),
     "col_vals_make_subset(columns = vars(c),set = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),actions = action_levels(warn_at = 0.1,stop_at = 0.2))"
   )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_vals_make_subset(vars(f), set = c("low", "high"), label = "my_label")),
+    "col_vals_make_subset(columns = vars(f),set = c(\"low\", \"high\"),label = \"my_label\")"
+  )
   
   #
   # col_vals_increasing
@@ -560,6 +584,10 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
     get_oneline_expr_str(agent %>% col_vals_null(vars(a, c))),
     "col_vals_null(columns = vars(a, c))"
   )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_vals_null(vars(c), label = "my_label")),
+    "col_vals_null(columns = vars(c),label = \"my_label\")"
+  )
   
   #
   # col_vals_not_null
@@ -573,6 +601,10 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
     get_oneline_expr_str(agent %>% col_vals_not_null(vars(a, c))),
     "col_vals_not_null(columns = vars(a, c))"
   )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_vals_not_null(vars(c), label = "my_label")),
+    "col_vals_not_null(columns = vars(c),label = \"my_label\")"
+  )
   
   #
   # col_vals_regex
@@ -581,6 +613,10 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
   expect_equal(
     get_oneline_expr_str(agent %>% col_vals_regex(vars(b), regex = "[0-9]-[a-z]{3}-[0-9]{3}")),
     "col_vals_regex(columns = vars(b),regex = \"[0-9]-[a-z]{3}-[0-9]{3}\")"
+  )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_vals_regex(vars(b), regex = "[0-9]-[a-z]{3}-[0-9]{3}", label = "my_label")),
+    "col_vals_regex(columns = vars(b),regex = \"[0-9]-[a-z]{3}-[0-9]{3}\",label = \"my_label\")"
   )
   
   #
@@ -613,6 +649,10 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
   expect_equal(
     get_oneline_expr_str(agent_expr %>% col_vals_expr(expr = ~ dplyr::between(a, 1, 10))),
     "col_vals_expr(expr = ~dplyr::between(a, 1, 10))"
+  )
+  expect_equal(
+    get_oneline_expr_str(agent_expr %>% col_vals_expr(expr = ~ dplyr::between(a, 1, 10), label = "my_label")),
+    "col_vals_expr(expr = ~dplyr::between(a, 1, 10),label = \"my_label\")"
   )
 
   #
@@ -651,6 +691,18 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
     ),
     "conjointly(~col_vals_lt(., vars(a), 8),~col_vals_gt(., vars(c), vars(a)),~col_vals_not_null(., vars(b)),preconditions = ~. %>% dplyr::filter(a > 0))"
   )
+  expect_equal(
+    get_oneline_expr_str(
+      agent_conjointly %>%
+        conjointly(
+          ~ col_vals_lt(., vars(a), 8),
+          ~ col_vals_gt(., vars(c), vars(a)),
+          ~ col_vals_not_null(., vars(b)),
+          label = "my_label"
+        )
+    ),
+    "conjointly(~col_vals_lt(., vars(a), 8),~col_vals_gt(., vars(c), vars(a)),~col_vals_not_null(., vars(b)),label = \"my_label\")"
+  )
   
   #
   # rows_distinct()
@@ -667,6 +719,10 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
   expect_equal(
     get_oneline_expr_str(agent %>% rows_distinct(columns = vars(a, b), preconditions = ~ . %>% dplyr::filter(a > 0))),
     "rows_distinct(columns = vars(a, b),preconditions = ~. %>% dplyr::filter(a > 0))"
+  )
+  expect_equal(
+    get_oneline_expr_str(agent %>% rows_distinct(columns = vars(a, b), label = "my_label")),
+    "rows_distinct(columns = vars(a, b),label = \"my_label\")"
   )
   
   #
@@ -687,6 +743,10 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
     ),
     "col_is_character(columns = vars(b, f),actions = action_levels(warn_at = 0.1,stop_at = 0.2))"
   )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_is_character(vars(b), label = "my_label")),
+    "col_is_character(columns = vars(b),label = \"my_label\")"
+  )
   
   #
   # col_exists()
@@ -705,6 +765,10 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
       agent %>% col_exists(vars(b, f), actions = action_levels(warn_at = 0.1, stop_at = 0.2))
     ),
     "col_exists(columns = vars(b, f),actions = action_levels(warn_at = 0.1,stop_at = 0.2))"
+  )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_exists(vars(b), label = "my_label")),
+    "col_exists(columns = vars(b),label = \"my_label\")"
   )
   
   #
@@ -728,5 +792,9 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
   expect_equal(
     get_oneline_expr_str(agent_col_schema %>% col_schema_match(schema_obj)),
     "col_schema_match(schema = col_schema(a = \"integer\",b = \"character\"))"
+  )
+  expect_equal(
+    get_oneline_expr_str(agent_col_schema %>% col_schema_match(schema_obj, label = "my_label")),
+    "col_schema_match(schema = col_schema(a = \"integer\",b = \"character\"),label = \"my_label\")"
   )
 })

--- a/tests/testthat/test-yaml.R
+++ b/tests/testthat/test-yaml.R
@@ -327,10 +327,10 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
     get_oneline_expr_str(agent %>% col_vals_between(vars(c), left = -5, right = 15, label = "my_label")),
     "col_vals_between(columns = vars(c),left = -5,right = 15,label = \"my_label\")"
   )
-  # expect_equal(
-  #   get_oneline_expr_str(agent %>% col_vals_between(vars(c), left = vars(a), right = vars(d), inclusive = c(TRUE, FALSE))),
-  #   "col_vals_between(columns = vars(a),left = vars(a),right = vars(d),inclusive = c(TRUE, FALSE))"
-  # )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_vals_between(vars(c), left = vars(a), right = vars(d), inclusive = c(TRUE, FALSE))),
+    "col_vals_between(columns = vars(c),left = vars(a),right = vars(d),inclusive = c(TRUE, FALSE))"
+  )
   
   #
   # col_vals_not_between
@@ -356,7 +356,6 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
     get_oneline_expr_str(agent %>% col_vals_not_between(vars(c), left = vars(a), right = vars(d), na_pass = TRUE)),
     "col_vals_not_between(columns = vars(c),left = vars(a),right = vars(d),na_pass = TRUE)"
   )
-  
   expect_equal(
     get_oneline_expr_str(
       agent %>% 
@@ -390,10 +389,10 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
     get_oneline_expr_str(agent %>% col_vals_in_set(vars(f), set = c("low", "high"))),
     "col_vals_in_set(columns = vars(f),set = c(\"low\", \"high\"))"
   )
-  # expect_equal(
-  #   get_oneline_expr_str(agent %>% col_vals_in_set(vars(f), set = c("low", "high", NA))),
-  #   "col_vals_in_set(columns = vars(f),set = c(\"low\", \"high\", NA))"
-  # )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_vals_in_set(vars(f), set = c("low", "high", NA))),
+    "col_vals_in_set(columns = vars(f),set = c(\"low\", \"high\", NA))"
+  )
   expect_equal(
     get_oneline_expr_str(agent %>% col_vals_in_set(vars(c), set = c(1:10))),
     "col_vals_in_set(columns = vars(c),set = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))"
@@ -435,10 +434,10 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
     get_oneline_expr_str(agent %>% col_vals_not_in_set(vars(f), set = c("low", "high"))),
     "col_vals_not_in_set(columns = vars(f),set = c(\"low\", \"high\"))"
   )
-  # expect_equal(
-  #   get_oneline_expr_str(agent %>% col_vals_not_in_set(vars(f), set = c("low", "high", NA))),
-  #   "col_vals_not_in_set(columns = vars(f),set = c(\"low\", \"high\", NA))"
-  # )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_vals_not_in_set(vars(f), set = c("low", "high", NA))),
+    "col_vals_not_in_set(columns = vars(f),set = c(\"low\", \"high\", NA))"
+  )
   expect_equal(
     get_oneline_expr_str(agent %>% col_vals_not_in_set(vars(c), set = c(1:10))),
     "col_vals_not_in_set(columns = vars(c),set = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))"
@@ -480,10 +479,10 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
     get_oneline_expr_str(agent %>% col_vals_make_set(vars(f), set = c("low", "high"))),
     "col_vals_make_set(columns = vars(f),set = c(\"low\", \"high\"))"
   )
-  # expect_equal(
-  #   get_oneline_expr_str(agent %>% col_vals_make_set(vars(f), set = c("low", "high", NA))),
-  #   "col_vals_make_set(columns = vars(f),set = c(\"low\", \"high\", NA))"
-  # )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_vals_make_set(vars(f), set = c("low", "high", NA))),
+    "col_vals_make_set(columns = vars(f),set = c(\"low\", \"high\", NA))"
+  )
   expect_equal(
     get_oneline_expr_str(agent %>% col_vals_make_set(vars(c), set = c(1:10))),
     "col_vals_make_set(columns = vars(c),set = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))"
@@ -525,10 +524,10 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
     get_oneline_expr_str(agent %>% col_vals_make_subset(vars(f), set = c("low", "high"))),
     "col_vals_make_subset(columns = vars(f),set = c(\"low\", \"high\"))"
   )
-  # expect_equal(
-  #   get_oneline_expr_str(agent %>% col_vals_make_subset(vars(f), set = c("low", "high", NA))),
-  #   "col_vals_make_subset(columns = vars(f),set = c(\"low\", \"high\", NA))"
-  # )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_vals_make_subset(vars(f), set = c("low", "high", NA))),
+    "col_vals_make_subset(columns = vars(f),set = c(\"low\", \"high\", NA))"
+  )
   expect_equal(
     get_oneline_expr_str(agent %>% col_vals_make_subset(vars(c), set = c(1:10))),
     "col_vals_make_subset(columns = vars(c),set = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))"
@@ -566,19 +565,47 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
   # col_vals_increasing
   #
   
-  # expect_equal(
-  #   get_oneline_expr_str(agent %>% col_vals_increasing(vars(a))),
-  #   "col_vals_increasing(columns = vars(a))"
-  # )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_vals_increasing(vars(a))),
+    "col_vals_increasing(columns = vars(a))"
+  )
+  expect_equal(
+    get_oneline_expr_str(
+      agent %>%
+        col_vals_increasing(vars(a), allow_stationary = TRUE)
+    ),
+    "col_vals_increasing(columns = vars(a),allow_stationary = TRUE)"
+  )
+  expect_equal(
+    get_oneline_expr_str(
+      agent %>%
+        col_vals_increasing(vars(a), decreasing_tol = 0.52)
+    ),
+    "col_vals_increasing(columns = vars(a),decreasing_tol = 0.52)"
+  )
   
   #
   # col_vals_decreasing
   #
   
-  # expect_equal(
-  #   get_oneline_expr_str(agent %>% col_vals_decreasing(vars(a))),
-  #   "col_vals_decreasing(columns = vars(a))"
-  # )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_vals_decreasing(vars(a))),
+    "col_vals_decreasing(columns = vars(a))"
+  )
+  expect_equal(
+    get_oneline_expr_str(
+      agent %>%
+        col_vals_decreasing(vars(a), allow_stationary = TRUE)
+    ),
+    "col_vals_decreasing(columns = vars(a),allow_stationary = TRUE)"
+  )
+  expect_equal(
+    get_oneline_expr_str(
+      agent %>%
+        col_vals_decreasing(vars(a), increasing_tol = 0.52)
+    ),
+    "col_vals_decreasing(columns = vars(a),increasing_tol = 0.52)"
+  )
   
   #
   # col_vals_null

--- a/tests/testthat/test-yaml.R
+++ b/tests/testthat/test-yaml.R
@@ -254,17 +254,25 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
     ),
     "col_vals_lt(columns = vars(a, c),value = 1,actions = action_levels(warn_at = 0.1,stop_at = 0.2))"
   )
-  # expect_equal(
-  #   get_oneline_expr_str(agent %>% col_vals_lt(vars(a), 1, brief = "Expect `a` < `1`.")),
-  #   "col_vals_lt(columns = vars(a, c),value = 1,brief = \"Expect `a` < `1`.\")"
-  # )
   expect_equal(
     get_oneline_expr_str(agent %>% col_vals_lt(vars(a, c), 1, label = "my_label")),
     "col_vals_lt(columns = vars(a, c),value = 1,label = \"my_label\")"
   )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_vals_lt(vars(a, c), 1, active = FALSE)),
+    "col_vals_lt(columns = vars(a, c),value = 1,active = FALSE)"
+  )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_vals_lt(vars(a, c), 1, active = TRUE)),
+    "col_vals_lt(columns = vars(a, c),value = 1)"
+  )
+  expect_equal(
+    get_oneline_expr_str(agent %>% col_vals_lt(vars(a, c), 1, active = ~ . %>% has_columns(vars(a, c)))),
+    "col_vals_lt(columns = vars(a, c),value = 1,active = ~. %>% has_columns(vars(a, c)))"
+  )
   # expect_equal(
-  #   get_oneline_expr_str(agent %>% col_vals_lt(vars(a, c), 1, active = TRUE)),
-  #   "col_vals_lt(columns = vars(a, c),value = 1,active = TRUE)"
+  #   get_oneline_expr_str(agent %>% col_vals_lt(vars(a), 1, brief = "Expect `a` < `1`.")),
+  #   "col_vals_lt(columns = vars(a, c),value = 1,brief = \"Expect `a` < `1`.\")"
   # )
   # expect_equal(
   #   get_oneline_expr_str(agent %>% col_vals_lt(vars(a, c), 1, step_id = "my_id")),


### PR DESCRIPTION
This is a series of fixes, upgrades, and tests that improve the fidelity of agents being written to YAML and being read back as agents. The goal is to have identical agent objects in before and after.

Fixes: https://github.com/rich-iannone/pointblank/issues/218