### PR TITLE
Enhance `preconditions`

### DIFF
--- a/R/col_vals_gt.R
+++ b/R/col_vals_gt.R
@@ -177,10 +177,11 @@
 #' @param na_pass Should any encountered `NA` values be considered as passing
 #'   test units? This is by default `FALSE`. Set to `TRUE` to give `NA`s a pass.
 #' @param preconditions An optional expression for mutating the input table
-#'   before proceeding with the validation. This is ideally as a one-sided R
-#'   formula using a leading `~`. In the formula representation, the `.` serves
-#'   as the input data table to be transformed (e.g., `~ . %>% dplyr::mutate(col
-#'   = col + 10)`. See the *Preconditions* section for more information.
+#'   before proceeding with the validation. This can either be provided as a
+#'   one-sided R formula using a leading `~` (e.g.,
+#'   `~ . %>% dplyr::mutate(col = col + 10)` or as a function (e.g.,
+#'   `function(x) dplyr::mutate(x, col = col + 10)`. See the *Preconditions*
+#'   section for more information.
 #' @param segments An optional expression or set of expressions (held in a list)
 #'   that serve to segment the target table by column values. Each expression
 #'   can be given in one of two ways: (1) as column names, or (2) as a two-sided

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -744,6 +744,7 @@ tbl_val_comparison <- function(table,
   # Ensure that the input `table` is actually a table object
   tbl_validity_check(table = table)
   
+  # Ensure that the value provided is valid 
   column_validity_checks_column_value(
     table = table,
     column = {{ column }},

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -741,6 +741,9 @@ tbl_val_comparison <- function(table,
                                value,
                                na_pass) {
 
+  # Ensure that the input `table` is actually a table object
+  tbl_validity_check(table = table)
+  
   column_validity_checks_column_value(
     table = table,
     column = {{ column }},
@@ -910,6 +913,9 @@ tbl_val_ib_incl_incl <- function(table,
                                  right,
                                  na_pass) {
   
+  # Ensure that the input `table` is actually a table object
+  tbl_validity_check(table = table)
+  
   column_validity_checks_ib_nb(
     table = table,
     column = {{ column }},
@@ -930,6 +936,9 @@ tbl_val_ib_excl_incl <- function(table,
                                  left,
                                  right,
                                  na_pass) {
+  
+  # Ensure that the input `table` is actually a table object
+  tbl_validity_check(table = table)
   
   column_validity_checks_ib_nb(
     table = table,
@@ -952,6 +961,9 @@ tbl_val_ib_incl_excl <- function(table,
                                  right,
                                  na_pass) {
   
+  # Ensure that the input `table` is actually a table object
+  tbl_validity_check(table = table)
+  
   column_validity_checks_ib_nb(
     table = table,
     column = {{ column }},
@@ -972,6 +984,9 @@ tbl_val_ib_excl_excl <- function(table,
                                  left,
                                  right,
                                  na_pass) {
+  
+  # Ensure that the input `table` is actually a table object
+  tbl_validity_check(table = table)
   
   column_validity_checks_ib_nb(
     table = table,
@@ -994,6 +1009,9 @@ tbl_val_nb_incl_incl <- function(table,
                                  right,
                                  na_pass) {
   
+  # Ensure that the input `table` is actually a table object
+  tbl_validity_check(table = table)
+  
   column_validity_checks_ib_nb(
     table = table,
     column = {{ column }},
@@ -1014,6 +1032,9 @@ tbl_val_nb_excl_incl <- function(table,
                                  left,
                                  right,
                                  na_pass) {
+  
+  # Ensure that the input `table` is actually a table object
+  tbl_validity_check(table = table)
   
   column_validity_checks_ib_nb(
     table = table,
@@ -1036,6 +1057,9 @@ tbl_val_nb_incl_excl <- function(table,
                                  right,
                                  na_pass) {
   
+  # Ensure that the input `table` is actually a table object
+  tbl_validity_check(table = table)
+  
   column_validity_checks_ib_nb(
     table = table,
     column = {{ column }},
@@ -1056,6 +1080,9 @@ tbl_val_nb_excl_excl <- function(table,
                                  left,
                                  right,
                                  na_pass) {
+  
+  # Ensure that the input `table` is actually a table object
+  tbl_validity_check(table = table)
   
   column_validity_checks_ib_nb(
     table = table,
@@ -1094,6 +1121,10 @@ interrogate_set <- function(agent,
                                column,
                                na_pass) {
       
+      # Ensure that the input `table` is actually a table object
+      tbl_validity_check(table = table)
+      
+      # Ensure that the `column` provided is valid
       column_validity_checks_column(table = table, column = {{ column }})
       
       table %>%
@@ -1125,6 +1156,10 @@ interrogate_set <- function(agent,
                                   column,
                                   na_pass) {
       
+      # Ensure that the input `table` is actually a table object
+      tbl_validity_check(table = table)
+      
+      # Ensure that the `column` provided is valid
       column_validity_checks_column(table = table, column = {{ column }})
       
       # Define function to get distinct values from a column in the
@@ -1193,6 +1228,10 @@ interrogate_set <- function(agent,
                                      column,
                                      na_pass) {
       
+      # Ensure that the input `table` is actually a table object
+      tbl_validity_check(table = table)
+      
+      # Ensure that the `column` provided is valid
       column_validity_checks_column(table = table, column = {{ column }})
       
       # Define function to get distinct values from a column in the
@@ -1251,6 +1290,10 @@ interrogate_set <- function(agent,
                                    column,
                                    na_pass) {
       
+      # Ensure that the input `table` is actually a table object
+      tbl_validity_check(table = table)
+      
+      # Ensure that the `column` provided is valid
       column_validity_checks_column(table = table, column = {{ column }})
       
       table %>%
@@ -1305,6 +1348,10 @@ interrogate_direction <- function(agent,
                                 na_pass,
                                 direction) {
     
+    # Ensure that the input `table` is actually a table object
+    tbl_validity_check(table = table)
+    
+    # Ensure that the `column` provided is valid
     column_validity_checks_column(table = table, column = {{ column }})
 
     tbl <- 
@@ -1426,15 +1473,21 @@ interrogate_regex <- function(agent,
                             regex,
                             na_pass) {
     
+    # Ensure that the input `table` is actually a table object
+    tbl_validity_check(table = table)
+    
+    # Ensure that the `column` provided is valid
     column_validity_checks_column(table = table, column = {{ column }})
     
     # nocov start
     
     if (tbl_type == "sqlite") {
       
-      stop("Regex-based validations are currently not supported on SQLite ",
-           "database tables",
-           call. = FALSE)
+      stop(
+        "Regex-based validations are currently not supported on SQLite ",
+        "database tables.",
+        call. = FALSE
+      )
     }
     
     if (tbl_type == "tbl_spark") {
@@ -1527,6 +1580,10 @@ interrogate_within_spec <- function(agent,
                                   spec,
                                   na_pass) {
     
+    # Ensure that the input `table` is actually a table object
+    tbl_validity_check(table = table)
+    
+    # Ensure that the `column` provided is valid
     column_validity_checks_column(table = table, column = {{ column }})
     
     # nocov start
@@ -1535,18 +1592,19 @@ interrogate_within_spec <- function(agent,
       
       stop(
         "Specification-based validations are currently not supported on ",
-        "SQLite database tables",
+        "SQLite database tables.",
         call. = FALSE
       )
     }
     
     if (inherits(table, "tbl_dbi") || inherits(table, "tbl_spark")) {
       
-      # Not possible: isbn, creditcard, & phone
+      # Not possible: `"isbn"`, `"creditcard"`, and `"phone"`
       if (spec %in% c("isbn", "creditcard", "phone")) {
+        
         stop(
           "Validations with the `\"", spec, "\"` specification are currently ",
-          "not supported on `tbl_dbi` or `tbl_spark` tables",
+          "not supported on `tbl_dbi` or `tbl_spark` tables.",
           call. = FALSE
         )
       }
@@ -1724,6 +1782,9 @@ interrogate_expr <- function(agent,
   tbl_val_expr <- function(table,
                            expr) {
     
+    # Ensure that the input `table` is actually a table object
+    tbl_validity_check(table = table)
+    
     expr <- expr[[1]]
 
     table %>% 
@@ -1746,6 +1807,10 @@ interrogate_null <- function(agent,
   tbl_val_null <- function(table,
                            column) {
     
+    # Ensure that the input `table` is actually a table object
+    tbl_validity_check(table = table)
+    
+    # Ensure that the `column` provided is valid
     column_validity_checks_column(table = table, column = {{ column }})
     
     table %>% dplyr::mutate(pb_is_good_ = is.na({{ column }}))
@@ -1766,6 +1831,10 @@ interrogate_not_null <- function(agent,
   tbl_val_not_null <- function(table,
                                column) {
     
+    # Ensure that the input `table` is actually a table object
+    tbl_validity_check(table = table)
+    
+    # Ensure that the `column` provided is valid
     column_validity_checks_column(table = table, column = {{ column }})
     
     table %>% dplyr::mutate(pb_is_good_ = !is.na({{ column }}))
@@ -1789,6 +1858,9 @@ interrogate_col_exists <- function(agent,
   tbl_col_exists <- function(table,
                              column,
                              column_names) {
+    
+    # Ensure that the input `table` is actually a table object
+    tbl_validity_check(table = table)
     
     dplyr::tibble(pb_is_good_ = as.character(column) %in% column_names)
   }
@@ -1816,6 +1888,10 @@ interrogate_col_type <- function(agent,
                          column,
                          assertion_type) {
     
+    # Ensure that the input `table` is actually a table object
+    tbl_validity_check(table = table)
+    
+    # Ensure that the `column` provided is valid
     column_validity_checks_column(table = table, column = {{ column }})
     
     column_class <-
@@ -1882,6 +1958,9 @@ interrogate_distinct <- function(agent,
                                 column_names,
                                 col_syms) {
     
+    # Ensure that the input `table` is actually a table object
+    tbl_validity_check(table = table)
+    
     table %>%
       dplyr::select({{ column_names }}) %>%
       dplyr::group_by(!!!col_syms) %>%
@@ -1891,11 +1970,14 @@ interrogate_distinct <- function(agent,
   
   # nocov start
   
-  # Create another variation of `tbl_rows_distinct_1()` that works for MySQL
+  # Create another variation of `tbl_rows_distinct()` that works for MySQL
   tbl_rows_distinct_mysql <- function(table,
                                       column_names,
                                       col_syms) {
 
+    # Ensure that the input `table` is actually a table object
+    tbl_validity_check(table = table)
+    
     unduplicated <- 
       table %>%
       dplyr::select({{ column_names }}) %>%
@@ -1987,6 +2069,9 @@ interrogate_col_schema_match <- function(agent,
                                    table_schema_x,
                                    table_schema_y) {
 
+    # Ensure that the input `table` is actually a table object
+    tbl_validity_check(table = table)
+    
     # nolint start
     
     # Extract options from `table_schema_y`
@@ -2082,6 +2167,17 @@ interrogate_col_schema_match <- function(agent,
   )
 }
 
+# Validity check for the table
+tbl_validity_check <- function(table) {
+  
+  if (!is_a_table_object(table)) {
+    stop(
+      "The 'table' in this validation step is not really a table object.",
+      call. = FALSE
+    )  
+  }  
+}
+
 # nolint start
 
 # Validity checks for the column and value 
@@ -2090,13 +2186,24 @@ column_validity_checks_column_value <- function(table,
                                                 value) {
   
   table_colnames <- colnames(table)
+  
   if (!(as.character(column) %in% table_colnames)) {
-    stop("The value for `column` doesn't correspond to a column name.")
+    
+    stop(
+      "The value for `column` doesn't correspond to a column name.",
+      call. = FALSE
+    )
   }
+  
   if (inherits(value, "name")) {
+    
     if (!(as.character(value) %in% table_colnames)) {
-      stop("The column supplied as the `value` doesn't correspond ",
-           "to a column name.")
+      
+      stop(
+        "The column supplied as the `value` doesn't correspond ",
+        "to a column name.",
+        call. = FALSE
+      )
     }
   }
 }
@@ -2108,8 +2215,13 @@ column_validity_checks_column <- function(table,
                                           column) {
   
   table_colnames <- colnames(table)
+  
   if (!(as.character(column) %in% table_colnames)) {
-    stop("The value for `column` doesn't correspond to a column name.")
+    
+    stop(
+      "The value for `column` doesn't correspond to a column name.",
+      call. = FALSE
+    )
   }
 }
 
@@ -2122,18 +2234,34 @@ column_validity_checks_ib_nb <- function(table,
   table_colnames <- colnames(table)
   
   if (!(as.character(column) %in% table_colnames)) {
-    stop("The value for `column` doesn't correspond to a column name.")
+    
+    stop(
+      "The value for `column` doesn't correspond to a column name.",
+      call. = FALSE
+    )
   }
+  
   if (inherits(left, "name")) {
+    
     if (!(as.character(left) %in% table_colnames)) {
-      stop("The column supplied as the `left` value doesn't correspond ",
-           "to a column name.")
+      
+      stop(
+        "The column supplied as the `left` value doesn't correspond ",
+        "to a column name.",
+        call. = FALSE
+      )
     }
   }
+  
   if (inherits(right, "name")) {
+    
     if (!(as.character(right) %in% table_colnames)) {
-      stop("The column supplied as the `right` value doesn't correspond ",
-           "to a column name.")
+      
+      stop(
+        "The column supplied as the `right` value doesn't correspond ",
+        "to a column name.",
+        call. = FALSE
+      )
     }
   }
 }

--- a/R/yaml_write.R
+++ b/R/yaml_write.R
@@ -452,8 +452,18 @@ as_vars_fn <- function(columns) {
 }
 
 as_list_preconditions <- function(preconditions) {
+  
   if (is.null(preconditions[[1]])) {
+    
     return(NULL)
+    
+  } else if (is.function(preconditions[[1]])) {
+    
+    return(
+      paste(deparse(preconditions[[1]]), collapse = "\n") %>%
+        gsub("function (x) \n{", "function(x) {", ., fixed = TRUE)
+    )
+    
   } else {
     return(as.character(preconditions))
   }

--- a/R/yaml_write.R
+++ b/R/yaml_write.R
@@ -226,7 +226,7 @@ yaml_write <- function(...,
       )
     }
     
-    return(invisible(NULL))
+    return(invisible(TRUE))
   }
   
   if ("agent" %in% object_types) {

--- a/R/yaml_write.R
+++ b/R/yaml_write.R
@@ -293,6 +293,7 @@ yaml_write <- function(...,
     filename <- file.path(path, filename)
   }
   
+  # Write the YAML to disk
   yaml::write_yaml(
     x = x,
     file = filename,
@@ -413,19 +414,28 @@ yaml_agent_string <- function(agent = NULL,
   
   if (is.null(agent) && is.null(filename)) {
     stop(
-      "An `agent` object or a `path` to a YAML file must be specified.",
+      "An `agent` object or a `filename` for a YAML file must be specified.",
       call. = FALSE
     )
   }
   
   if (!is.null(agent) && !is.null(filename)) {
-    stop("Only one of `agent` or `path` should be specified.", call. = FALSE)
+    stop(
+      "Only `agent` or `filename` should be specified (not both).",
+      call. = FALSE
+    )
   }
   
   if (!is.null(agent)) {
     
+    # Display the agent's YAML as a nicely formatted string by
+    # generating the YAML (`as_agent_yaml_list() %>% as.yaml()`) and
+    # then emitting it to the console via `message()`
     message(
-      as_agent_yaml_list(agent = agent, expanded = expanded) %>%
+      as_agent_yaml_list(
+        agent = agent,
+        expanded = expanded
+      ) %>%
         yaml::as.yaml(
           handlers = list(
             logical = function(x) {
@@ -443,6 +453,9 @@ yaml_agent_string <- function(agent = NULL,
       filename <- file.path(path, filename)
     }
     
+    # Display the agent's YAML as a nicely formatted string by
+    # reading the YAML file specified by `file` (and perhaps `path`)
+    # and then emitting it to the console via `message()`
     message(readLines(filename) %>% paste(collapse = "\n"))
   }
 }

--- a/man/col_vals_between.Rd
+++ b/man/col_vals_between.Rd
@@ -70,9 +70,11 @@ are inclusive.}
 test units? This is by default \code{FALSE}. Set to \code{TRUE} to give \code{NA}s a pass.}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/man/col_vals_decreasing.Rd
+++ b/man/col_vals_decreasing.Rd
@@ -65,9 +65,11 @@ has the effect of setting \code{allow_stationary} to \code{TRUE}.}
 test units? This is by default \code{FALSE}. Set to \code{TRUE} to give \code{NA}s a pass.}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/man/col_vals_equal.Rd
+++ b/man/col_vals_equal.Rd
@@ -54,9 +54,11 @@ what is specified here will pass validation.}
 test units? This is by default \code{FALSE}. Set to \code{TRUE} to give \code{NA}s a pass.}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/man/col_vals_expr.Rd
+++ b/man/col_vals_expr.Rd
@@ -32,9 +32,11 @@ form of a call made with the \code{expr()} function or as a one-sided \strong{R}
 formula (using a leading \code{~}).}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/man/col_vals_gt.Rd
+++ b/man/col_vals_gt.Rd
@@ -54,9 +54,11 @@ is specified here will pass validation.}
 test units? This is by default \code{FALSE}. Set to \code{TRUE} to give \code{NA}s a pass.}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/man/col_vals_gte.Rd
+++ b/man/col_vals_gte.Rd
@@ -55,9 +55,11 @@ equal to what is specified here will pass validation.}
 test units? This is by default \code{FALSE}. Set to \code{TRUE} to give \code{NA}s a pass.}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/man/col_vals_in_set.Rd
+++ b/man/col_vals_in_set.Rd
@@ -41,9 +41,11 @@ vector) to which this validation should be applied.}
 found within this \code{set} will be considered as passing.}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/man/col_vals_increasing.Rd
+++ b/man/col_vals_increasing.Rd
@@ -65,9 +65,11 @@ has the effect of setting \code{allow_stationary} to \code{TRUE}.}
 test units? This is by default \code{FALSE}. Set to \code{TRUE} to give \code{NA}s a pass.}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/man/col_vals_lt.Rd
+++ b/man/col_vals_lt.Rd
@@ -54,9 +54,11 @@ specified here will pass validation.}
 test units? This is by default \code{FALSE}. Set to \code{TRUE} to give \code{NA}s a pass.}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/man/col_vals_lte.Rd
+++ b/man/col_vals_lte.Rd
@@ -55,9 +55,11 @@ to what is specified here will pass validation.}
 test units? This is by default \code{FALSE}. Set to \code{TRUE} to give \code{NA}s a pass.}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/man/col_vals_make_set.Rd
+++ b/man/col_vals_make_set.Rd
@@ -47,9 +47,11 @@ vector) to which this validation should be applied.}
 unique values in the target column.}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/man/col_vals_make_subset.Rd
+++ b/man/col_vals_make_subset.Rd
@@ -47,9 +47,11 @@ vector) to which this validation should be applied.}
 values in the target column.}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/man/col_vals_not_between.Rd
+++ b/man/col_vals_not_between.Rd
@@ -67,9 +67,11 @@ are inclusive.}
 test units? This is by default \code{FALSE}. Set to \code{TRUE} to give \code{NA}s a pass.}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/man/col_vals_not_equal.Rd
+++ b/man/col_vals_not_equal.Rd
@@ -54,9 +54,11 @@ to what is specified here will pass validation.}
 test units? This is by default \code{FALSE}. Set to \code{TRUE} to give \code{NA}s a pass.}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/man/col_vals_not_in_set.Rd
+++ b/man/col_vals_not_in_set.Rd
@@ -47,9 +47,11 @@ vector) to which this validation should be applied.}
 found within this \code{set} will be considered as failing.}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/man/col_vals_not_null.Rd
+++ b/man/col_vals_not_null.Rd
@@ -31,9 +31,11 @@ created with \code{\link[=create_agent]{create_agent()}}.}
 vector) to which this validation should be applied.}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/man/col_vals_null.Rd
+++ b/man/col_vals_null.Rd
@@ -31,9 +31,11 @@ created with \code{\link[=create_agent]{create_agent()}}.}
 vector) to which this validation should be applied.}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/man/col_vals_regex.Rd
+++ b/man/col_vals_regex.Rd
@@ -54,9 +54,11 @@ validation.}
 test units? This is by default \code{FALSE}. Set to \code{TRUE} to give \code{NA}s a pass.}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/man/col_vals_within_spec.Rd
+++ b/man/col_vals_within_spec.Rd
@@ -53,9 +53,11 @@ vector) to which this validation should be applied.}
 test units? This is by default \code{FALSE}. Set to \code{TRUE} to give \code{NA}s a pass.}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/man/conjointly.Rd
+++ b/man/conjointly.Rd
@@ -48,9 +48,11 @@ example of this is \verb{~ col_vals_gte(., vars(a), 5.5), ~ col_vals_not_null(.,
 \item{.list}{Allows for the use of a list as an input alternative to \code{...}.}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/man/rows_distinct.Rd
+++ b/man/rows_distinct.Rd
@@ -36,9 +36,11 @@ created with \code{\link[=create_agent]{create_agent()}}.}
 vector) to which this validation should be applied.}
 
 \item{preconditions}{An optional expression for mutating the input table
-before proceeding with the validation. This is ideally as a one-sided R
-formula using a leading \code{~}. In the formula representation, the \code{.} serves
-as the input data table to be transformed (e.g., \code{~ . \%>\% dplyr::mutate(col = col + 10)}. See the \emph{Preconditions} section for more information.}
+before proceeding with the validation. This can either be provided as a
+one-sided R formula using a leading \code{~} (e.g.,
+\code{~ . \%>\% dplyr::mutate(col = col + 10)} or as a function (e.g.,
+\code{function(x) dplyr::mutate(x, col = col + 10)}. See the \emph{Preconditions}
+section for more information.}
 
 \item{segments}{An optional expression or set of expressions (held in a list)
 that serve to segment the target table by column values. Each expression

--- a/tests/testthat/test-yaml.R
+++ b/tests/testthat/test-yaml.R
@@ -250,6 +250,28 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
   )
   expect_equal(
     get_oneline_expr_str(
+      agent %>% 
+        col_vals_lt(
+          vars(a), 1, na_pass = TRUE,
+          preconditions = function(x) { x %>% dplyr::filter(a > 2) }
+        )
+    ),
+    "col_vals_lt(columns = vars(a),value = 1,na_pass = TRUE,preconditions = function(x) {x %>% dplyr::filter(a > 2)})"
+  )
+  expect_equal(
+    get_oneline_expr_str(
+      agent %>% 
+        col_vals_lt(
+          vars(a), 1, na_pass = TRUE,
+          preconditions = function(x) {
+            x %>% dplyr::filter(a > 2)
+          }
+        )
+    ),
+    "col_vals_lt(columns = vars(a),value = 1,na_pass = TRUE,preconditions = function(x) {x %>% dplyr::filter(a > 2)})"
+  )
+  expect_equal(
+    get_oneline_expr_str(
       agent %>%
         col_vals_lt(
           vars(a, c), 1,


### PR DESCRIPTION
The `preconditions` argument is used to modify the target table in a validation step (or multiple, should the step resolve to multiple). The work done to improve the functionality of using `preconditions` includes:

- checking that a table object is returned after evaluation
- improving YAML writing of any `preconditions` provided as a function
- updating the documentation associated with `preconditions`

Fixes: https://github.com/rich-iannone/pointblank/issues/317