### PR TITLE
Don't exclude trailing zeros

### DIFF
--- a/data-raw/00-reencode_text.R
+++ b/data-raw/00-reencode_text.R
@@ -30,7 +30,7 @@ reencode_utf8 <- function(x) {
       USE.NAMES = FALSE,
       FUN = function(x) {
         
-        bytes_nz <- x[x > 0]
+        bytes_nz <- x[min(which(x > 0)):length(x)]
 
         if (length(bytes_nz) > 2) {
           out <- paste("\\U", paste(as.hexmode(x), collapse = ""), sep = "")


### PR DESCRIPTION
I found another small issue with `reencode_utf8()` in the internationalization setup. The current implementation drops trailing zeros as well as leading zeros resulting in incorrect characters when they end in zeros.

```r
reencode_utf8("😀")
#> [1] "\\u01f6"
cat(stri_unescape_unicode("\\u01f6"))
#> Ƕ
```

After the fix, 😄 round trips correctly.


```r
reencode_utf8("😀")
#> [1] "\\U0001f600"
cat(stri_unescape_unicode("\\U0001f600"))
#> 😀
```

