### PR TITLE
Enhance the `all_passed()` function

### DIFF
--- a/R/all_passed.R
+++ b/R/all_passed.R
@@ -93,7 +93,20 @@ all_passed <- function(agent,
   # with an agent having no validation steps, the return value
   # should be NA
   if (length(all_passed_vec) < 1) {
-    return(NA)
+    
+    if (is.null(i)) {
+      
+      return(NA)
+      
+    } else {
+      
+      # Stop function if any value is provided for `i`
+      stop(
+        "You cannot provide a value for `i` when the agent ",
+        "contains no validation steps.",
+        call. = FALSE
+      )
+    }
   }
   
   # If a vector is provided to `i` then subset the `all_passed_vec`

--- a/R/get_data_extracts.R
+++ b/R/get_data_extracts.R
@@ -47,8 +47,8 @@
 #'   out and any sample rows from non-passing validations could potentially be
 #'   available in the object.
 #' @param i The validation step number, which is assigned to each validation
-#'   step in the order of definition. If `NULL` (the default), all data extract
-#'   tables will be provided in a list object.
+#'   step by **pointblank** in the order of definition. If `NULL` (the default),
+#'   all data extract tables will be provided in a list object.
 #' 
 #' @return A list of tables if `i` is not provided, or, a standalone table if
 #'   `i` is given.

--- a/man/all_passed.Rd
+++ b/man/all_passed.Rd
@@ -4,10 +4,15 @@
 \alias{all_passed}
 \title{Did all of the validations fully \emph{pass}?}
 \usage{
-all_passed(agent)
+all_passed(agent, i = NULL)
 }
 \arguments{
 \item{agent}{An agent object of class \code{ptblank_agent}.}
+
+\item{i}{A vector of validation step numbers. These values are assigned to
+each validation step by \strong{pointblank} in the order of definition. If
+\code{NULL} (the default), all validation steps will be used for the evaluation
+of complete \emph{passing}.}
 }
 \value{
 A logical value.

--- a/man/get_data_extracts.Rd
+++ b/man/get_data_extracts.Rd
@@ -13,8 +13,8 @@ out and any sample rows from non-passing validations could potentially be
 available in the object.}
 
 \item{i}{The validation step number, which is assigned to each validation
-step in the order of definition. If \code{NULL} (the default), all data extract
-tables will be provided in a list object.}
+step by \strong{pointblank} in the order of definition. If \code{NULL} (the default),
+all data extract tables will be provided in a list object.}
 }
 \value{
 A list of tables if \code{i} is not provided, or, a standalone table if


### PR DESCRIPTION
These changes to `all_passed()` make it such that failed steps (that return an evaluation error, perhaps because of a missing column) result in `FALSE`. Also, the `i` argument has been added to `all_passed()` to optionally get a subset of validation steps before evaluation.

Fixes #342 
Fixes #343 