### PR TITLE
Bugfix for expectation functions handling multiple columns

### DIFF
--- a/R/col_exists.R
+++ b/R/col_exists.R
@@ -279,7 +279,7 @@ expect_col_exists <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -287,6 +287,25 @@ expect_col_exists <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -298,7 +317,7 @@ expect_col_exists <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
+  column_text <- prep_column_text(vs$column[[fail_idx]])
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_is_character.R
+++ b/R/col_is_character.R
@@ -270,7 +270,7 @@ expect_col_is_character <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -278,6 +278,25 @@ expect_col_is_character <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -289,7 +308,7 @@ expect_col_is_character <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
+  column_text <- prep_column_text(vs$column[[fail_idx]])
   col_type <- "character"
   
   testthat::expect(

--- a/R/col_is_date.R
+++ b/R/col_is_date.R
@@ -273,7 +273,7 @@ expect_col_is_date <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -281,6 +281,25 @@ expect_col_is_date <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -292,7 +311,7 @@ expect_col_is_date <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
+  column_text <- prep_column_text(vs$column[[fail_idx]])
   col_type <- "Date"
   
   testthat::expect(

--- a/R/col_is_factor.R
+++ b/R/col_is_factor.R
@@ -275,7 +275,7 @@ expect_col_is_factor <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -283,6 +283,25 @@ expect_col_is_factor <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -294,7 +313,7 @@ expect_col_is_factor <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
+  column_text <- prep_column_text(vs$column[[fail_idx]])
   col_type <- "factor"
   
   testthat::expect(

--- a/R/col_is_integer.R
+++ b/R/col_is_integer.R
@@ -271,7 +271,7 @@ expect_col_is_integer <- function(object,
     interrogate() %>% 
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -279,6 +279,25 @@ expect_col_is_integer <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -290,7 +309,7 @@ expect_col_is_integer <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
+  column_text <- prep_column_text(vs$column[[fail_idx]])
   col_type <- "integer"
   
   testthat::expect(

--- a/R/col_is_logical.R
+++ b/R/col_is_logical.R
@@ -274,7 +274,7 @@ expect_col_is_logical <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -282,6 +282,25 @@ expect_col_is_logical <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -293,7 +312,7 @@ expect_col_is_logical <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
+  column_text <- prep_column_text(vs$column[[fail_idx]])
   col_type <- "logical"
   
   testthat::expect(

--- a/R/col_is_numeric.R
+++ b/R/col_is_numeric.R
@@ -274,7 +274,7 @@ expect_col_is_numeric <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -282,6 +282,25 @@ expect_col_is_numeric <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -293,7 +312,7 @@ expect_col_is_numeric <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
+  column_text <- prep_column_text(vs$column[[fail_idx]])
   col_type <- "numeric"
   
   testthat::expect(

--- a/R/col_is_posix.R
+++ b/R/col_is_posix.R
@@ -273,7 +273,7 @@ expect_col_is_posix <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -281,6 +281,25 @@ expect_col_is_posix <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -292,7 +311,7 @@ expect_col_is_posix <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
+  column_text <- prep_column_text(vs$column[[fail_idx]])
   col_type <- "POSIXct"
   
   testthat::expect(

--- a/R/col_vals_between.R
+++ b/R/col_vals_between.R
@@ -443,7 +443,7 @@ expect_col_vals_between <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -451,6 +451,25 @@ expect_col_vals_between <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -462,11 +481,11 @@ expect_col_vals_between <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
+  column_text <- prep_column_text(vs$column[[fail_idx]])
   value_1 <- 
-    prep_values_text(values = vs$values[[1]][[1]], limit = 3, lang = "en")
+    prep_values_text(values = vs$values[[fail_idx]][[1]], limit = 3, lang = "en")
   value_2 <- 
-    prep_values_text(values = vs$values[[1]][[2]], limit = 3, lang = "en")
+    prep_values_text(values = vs$values[[fail_idx]][[2]], limit = 3, lang = "en")
 
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_between.R
+++ b/R/col_vals_between.R
@@ -483,9 +483,13 @@ expect_col_vals_between <- function(object,
   
   column_text <- prep_column_text(vs$column[[fail_idx]])
   value_1 <- 
-    prep_values_text(values = vs$values[[fail_idx]][[1]], limit = 3, lang = "en")
+    prep_values_text(
+      values = vs$values[[fail_idx]][[1]], limit = 3, lang = "en"
+    )
   value_2 <- 
-    prep_values_text(values = vs$values[[fail_idx]][[2]], limit = 3, lang = "en")
+    prep_values_text(
+      values = vs$values[[fail_idx]][[2]], limit = 3, lang = "en"
+    )
 
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_decreasing.R
+++ b/R/col_vals_decreasing.R
@@ -344,7 +344,7 @@ expect_col_vals_decreasing <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -352,6 +352,25 @@ expect_col_vals_decreasing <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -363,7 +382,7 @@ expect_col_vals_decreasing <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
+  column_text <- prep_column_text(vs$column[[fail_idx]])
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_equal.R
+++ b/R/col_vals_equal.R
@@ -383,7 +383,7 @@ expect_col_vals_equal <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -391,6 +391,25 @@ expect_col_vals_equal <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -402,9 +421,9 @@ expect_col_vals_equal <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
+  column_text <- prep_column_text(vs$column[[fail_idx]])
   operator <- "=="
-  values_text <- prep_values_text(values = vs$values, limit = 3, lang = "en")
+  values_text <- prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_equal.R
+++ b/R/col_vals_equal.R
@@ -423,7 +423,8 @@ expect_col_vals_equal <- function(object,
   
   column_text <- prep_column_text(vs$column[[fail_idx]])
   operator <- "=="
-  values_text <- prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
+  values_text <- 
+    prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_gt.R
+++ b/R/col_vals_gt.R
@@ -494,7 +494,8 @@ expect_col_vals_gt <- function(object,
   
   column_text <- prep_column_text(vs$column[[fail_idx]])
   operator <- ">"
-  values_text <- prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
+  values_text <- 
+    prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_gt.R
+++ b/R/col_vals_gt.R
@@ -454,7 +454,7 @@ expect_col_vals_gt <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -462,6 +462,25 @@ expect_col_vals_gt <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -473,9 +492,9 @@ expect_col_vals_gt <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
+  column_text <- prep_column_text(vs$column[[fail_idx]])
   operator <- ">"
-  values_text <- prep_values_text(values = vs$values, limit = 3, lang = "en")
+  values_text <- prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_gte.R
+++ b/R/col_vals_gte.R
@@ -386,7 +386,7 @@ expect_col_vals_gte <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -394,6 +394,25 @@ expect_col_vals_gte <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -405,9 +424,9 @@ expect_col_vals_gte <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
+  column_text <- prep_column_text(vs$column[[fail_idx]])
   operator <- ">="
-  values_text <- prep_values_text(values = vs$values, limit = 3, lang = "en")
+  values_text <- prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_gte.R
+++ b/R/col_vals_gte.R
@@ -426,7 +426,8 @@ expect_col_vals_gte <- function(object,
   
   column_text <- prep_column_text(vs$column[[fail_idx]])
   operator <- ">="
-  values_text <- prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
+  values_text <- 
+    prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_in_set.R
+++ b/R/col_vals_in_set.R
@@ -373,7 +373,7 @@ expect_col_vals_in_set <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -381,6 +381,25 @@ expect_col_vals_in_set <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -392,8 +411,9 @@ expect_col_vals_in_set <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
-  values_text <- prep_values_text(values = vs$values, limit = 3, lang = "en")
+  column_text <- prep_column_text(vs$column[[fail_idx]])
+  values_text <- 
+    prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_lt.R
+++ b/R/col_vals_lt.R
@@ -384,7 +384,7 @@ expect_col_vals_lt <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -392,6 +392,25 @@ expect_col_vals_lt <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -403,9 +422,9 @@ expect_col_vals_lt <- function(object,
     
   act <- testthat::quasi_label(enquo(x), arg = "object")
 
-  column_text <- prep_column_text(vs$column[[1]])
+  column_text <- prep_column_text(vs$column[[fail_idx]])
   operator <- "<"
-  values_text <- prep_values_text(values = vs$values, limit = 3, lang = "en")
+  values_text <- prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_lt.R
+++ b/R/col_vals_lt.R
@@ -424,7 +424,8 @@ expect_col_vals_lt <- function(object,
 
   column_text <- prep_column_text(vs$column[[fail_idx]])
   operator <- "<"
-  values_text <- prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
+  values_text <- 
+    prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_lte.R
+++ b/R/col_vals_lte.R
@@ -427,7 +427,8 @@ expect_col_vals_lte <- function(object,
   
   column_text <- prep_column_text(vs$column[[fail_idx]])
   operator <- "<="
-  values_text <- prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
+  values_text <- 
+    prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_lte.R
+++ b/R/col_vals_lte.R
@@ -387,7 +387,7 @@ expect_col_vals_lte <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -395,6 +395,25 @@ expect_col_vals_lte <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -406,9 +425,9 @@ expect_col_vals_lte <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
+  column_text <- prep_column_text(vs$column[[fail_idx]])
   operator <- "<="
-  values_text <- prep_values_text(values = vs$values, limit = 3, lang = "en")
+  values_text <- prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_make_set.R
+++ b/R/col_vals_make_set.R
@@ -376,7 +376,7 @@ expect_col_vals_make_set <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -384,6 +384,25 @@ expect_col_vals_make_set <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -395,8 +414,9 @@ expect_col_vals_make_set <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
-  values_text <- prep_values_text(values = vs$values, limit = 3, lang = "en")
+  column_text <- prep_column_text(vs$column[[fail_idx]])
+  values_text <- 
+    prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_make_subset.R
+++ b/R/col_vals_make_subset.R
@@ -373,7 +373,7 @@ expect_col_vals_make_subset <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -381,6 +381,25 @@ expect_col_vals_make_subset <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -392,8 +411,9 @@ expect_col_vals_make_subset <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
-  values_text <- prep_values_text(values = vs$values, limit = 3, lang = "en")
+  column_text <- prep_column_text(vs$column[[fail_idx]])
+  values_text <- 
+    prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_not_between.R
+++ b/R/col_vals_not_between.R
@@ -481,9 +481,13 @@ expect_col_vals_not_between <- function(object,
   
   column_text <- prep_column_text(vs$column[[fail_idx]])
   value_1 <- 
-    prep_values_text(values = vs$values[[fail_idx]][[1]], limit = 3, lang = "en")
+    prep_values_text(
+      values = vs$values[[fail_idx]][[1]], limit = 3, lang = "en"
+    )
   value_2 <- 
-    prep_values_text(values = vs$values[[fail_idx]][[2]], limit = 3, lang = "en")
+    prep_values_text(
+      values = vs$values[[fail_idx]][[2]], limit = 3, lang = "en"
+    )
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_not_between.R
+++ b/R/col_vals_not_between.R
@@ -441,7 +441,7 @@ expect_col_vals_not_between <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -449,6 +449,25 @@ expect_col_vals_not_between <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -460,11 +479,11 @@ expect_col_vals_not_between <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
+  column_text <- prep_column_text(vs$column[[fail_idx]])
   value_1 <- 
-    prep_values_text(values = vs$values[[1]][[1]], limit = 3, lang = "en")
+    prep_values_text(values = vs$values[[fail_idx]][[1]], limit = 3, lang = "en")
   value_2 <- 
-    prep_values_text(values = vs$values[[1]][[2]], limit = 3, lang = "en")
+    prep_values_text(values = vs$values[[fail_idx]][[2]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_not_equal.R
+++ b/R/col_vals_not_equal.R
@@ -424,7 +424,8 @@ expect_col_vals_not_equal <- function(object,
   
   column_text <- prep_column_text(vs$column[[fail_idx]])
   operator <- "!="
-  values_text <- prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
+  values_text <- 
+    prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_not_equal.R
+++ b/R/col_vals_not_equal.R
@@ -384,7 +384,7 @@ expect_col_vals_not_equal <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -392,6 +392,25 @@ expect_col_vals_not_equal <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -403,9 +422,9 @@ expect_col_vals_not_equal <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
+  column_text <- prep_column_text(vs$column[[fail_idx]])
   operator <- "!="
-  values_text <- prep_values_text(values = vs$values, limit = 3, lang = "en")
+  values_text <- prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_not_in_set.R
+++ b/R/col_vals_not_in_set.R
@@ -373,7 +373,7 @@ expect_col_vals_not_in_set <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -381,6 +381,25 @@ expect_col_vals_not_in_set <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -392,8 +411,9 @@ expect_col_vals_not_in_set <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
-  values_text <- prep_values_text(values = vs$values, limit = 3, lang = "en")
+  column_text <- prep_column_text(vs$column[[fail_idx]])
+  values_text <- 
+    prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_not_null.R
+++ b/R/col_vals_not_null.R
@@ -361,7 +361,7 @@ expect_col_vals_not_null <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -369,6 +369,25 @@ expect_col_vals_not_null <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+  
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -380,7 +399,7 @@ expect_col_vals_not_null <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
+  column_text <- prep_column_text(vs$column[[fail_idx]])
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_null.R
+++ b/R/col_vals_null.R
@@ -360,7 +360,7 @@ expect_col_vals_null <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -368,6 +368,25 @@ expect_col_vals_null <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -379,7 +398,7 @@ expect_col_vals_null <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
+  column_text <- prep_column_text(vs$column[[fail_idx]])
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_regex.R
+++ b/R/col_vals_regex.R
@@ -383,7 +383,7 @@ expect_col_vals_regex <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -391,6 +391,25 @@ expect_col_vals_regex <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -402,8 +421,8 @@ expect_col_vals_regex <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
-  values_text <- prep_values_text(values = vs$values, limit = 3, lang = "en")
+  column_text <- prep_column_text(vs$column[[fail_idx]])
+  values_text <- prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_regex.R
+++ b/R/col_vals_regex.R
@@ -422,7 +422,8 @@ expect_col_vals_regex <- function(object,
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
   column_text <- prep_column_text(vs$column[[fail_idx]])
-  values_text <- prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
+  values_text <- 
+    prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_within_spec.R
+++ b/R/col_vals_within_spec.R
@@ -479,7 +479,8 @@ expect_col_vals_within_spec <- function(object,
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
   column_text <- prep_column_text(vs$column[[fail_idx]])
-  values_text <- prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
+  values_text <- 
+    prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/R/col_vals_within_spec.R
+++ b/R/col_vals_within_spec.R
@@ -440,7 +440,7 @@ expect_col_vals_within_spec <- function(object,
     interrogate() %>%
     .$validation_set
   
-  x <- vs$notify %>% all()
+  x <- vs$notify
   
   threshold_type <- get_threshold_type(threshold = threshold)
   
@@ -448,6 +448,25 @@ expect_col_vals_within_spec <- function(object,
     failed_amount <- vs$f_failed
   } else {
     failed_amount <- vs$n_failed
+  }
+  
+  # If several validations were performed serially (due to supplying
+  # multiple columns)
+  if (length(x) > 1 && any(x)) {
+    
+    # Get the index (step) of the first failure instance
+    fail_idx <- which(x)[1]
+    
+    # Get the correct, single `failed_amount` for the first
+    # failure instance
+    failed_amount <- failed_amount[fail_idx]
+    
+    # Redefine `x` as a single TRUE value
+    x <- TRUE
+    
+  } else {
+    x <- any(x)
+    fail_idx <- 1
   }
   
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
@@ -459,8 +478,8 @@ expect_col_vals_within_spec <- function(object,
   
   act <- testthat::quasi_label(enquo(x), arg = "object")
   
-  column_text <- prep_column_text(vs$column[[1]])
-  values_text <- prep_values_text(values = vs$values, limit = 3, lang = "en")
+  column_text <- prep_column_text(vs$column[[fail_idx]])
+  values_text <- prep_values_text(values = vs$values[[fail_idx]], limit = 3, lang = "en")
   
   testthat::expect(
     ok = identical(!as.vector(act$val), TRUE),

--- a/tests/testthat/test-expectation_fns.R
+++ b/tests/testthat/test-expectation_fns.R
@@ -92,6 +92,17 @@ test_that("pointblank expectation function produce the correct results", {
     "failure level \\(1\\) >= failure threshold \\(1\\)"
   )
   
+  eval_batch_expect_fns(
+    expect_fn = expect_col_vals_lt,
+    tbl_test =
+      tibble::tibble(
+        x = c(5, 6, 10),   # failing
+        y = c(2, 3, 7),    # passing
+        z = c(-3, 0, 6.7)  # passing
+      ),
+    value = 10
+  )
+  
   #
   # expect_col_vals_lte()
   #
@@ -111,6 +122,17 @@ test_that("pointblank expectation function produce the correct results", {
   expect_failure(
     expect_col_vals_lte(tbl, columns = vars(a), value = 7),
     "failure level \\(1\\) >= failure threshold \\(1\\)"
+  )
+  
+  eval_batch_expect_fns(
+    expect_fn = expect_col_vals_lte,
+    tbl_test =
+      tibble::tibble(
+        x = c(5, 6, 10.5), # failing
+        y = c(2, 3, 7),    # passing
+        z = c(-3, 0, 6.7)  # passing
+      ),
+    value = 10
   )
   
   #
@@ -134,6 +156,17 @@ test_that("pointblank expectation function produce the correct results", {
     "failure level \\(3\\) >= failure threshold \\(1\\)"
   )
   
+  eval_batch_expect_fns(
+    expect_fn = expect_col_vals_equal,
+    tbl_test =
+      tibble::tibble(
+        x = c(5, 5, 6), # failing
+        y = c(5, 5, 5), # passing
+        z = c(5, 5, 5)  # passing
+      ),
+    value = 5
+  )
+  
   #
   # expect_col_vals_not_equal()
   #
@@ -153,6 +186,17 @@ test_that("pointblank expectation function produce the correct results", {
   expect_failure(
     expect_col_vals_not_equal(tbl_not_equal_c_3, columns = vars(c), value = 7),
     "failure level \\(2\\) >= failure threshold \\(1\\)"
+  )
+  
+  eval_batch_expect_fns(
+    expect_fn = expect_col_vals_not_equal,
+    tbl_test =
+      tibble::tibble(
+        x = c(8, 5, 6), # failing
+        y = c(1, 2, 4), # passing
+        z = c(6, 2, 8)  # passing
+      ),
+    value = 5
   )
   
   #
@@ -178,6 +222,17 @@ test_that("pointblank expectation function produce the correct results", {
     "failure level \\(2\\) >= failure threshold \\(1\\)"
   )
   
+  eval_batch_expect_fns(
+    expect_fn = expect_col_vals_gte,
+    tbl_test =
+      tibble::tibble(
+        x = c(4, 1.5, 8.3),  # failing
+        y = c(2, 3, 7),      # passing
+        z = c(3, 4, 6.7)     # passing
+      ),
+    value = 2
+  )
+  
   #
   # expect_col_vals_gt()
   #
@@ -199,6 +254,17 @@ test_that("pointblank expectation function produce the correct results", {
   expect_failure(
     expect_col_vals_gt(tbl, columns = vars(c), value = 0),
     "failure level \\(2\\) >= failure threshold \\(1\\)"
+  )
+  
+  eval_batch_expect_fns(
+    expect_fn = expect_col_vals_gt,
+    tbl_test =
+      tibble::tibble(
+        x = c(4, 2, 8.3),  # failing
+        y = c(2.5, 3, 7),  # passing
+        z = c(3, 4, 6.7)   # passing
+      ),
+    value = 2
   )
   
   #
@@ -225,6 +291,18 @@ test_that("pointblank expectation function produce the correct results", {
     "failure level \\(11\\) >= failure threshold \\(1\\)"
   )
   
+  eval_batch_expect_fns(
+    expect_fn = expect_col_vals_between,
+    tbl_test =
+      tibble::tibble(
+        x = c(4, 6, 7),     # failing
+        y = c(4, 5, 6),     # passing
+        z = c(4.5, 5, 5.9)  # passing
+      ),
+    left = 4,
+    right = 6
+  )
+  
   #
   # expect_col_vals_not_between()
   #
@@ -247,6 +325,18 @@ test_that("pointblank expectation function produce the correct results", {
   expect_failure(
     expect_col_vals_not_between(tbl, columns = vars(c), left = 20, right = 30),
     "failure level \\(2\\) >= failure threshold \\(1\\)"
+  )
+  
+  eval_batch_expect_fns(
+    expect_fn = expect_col_vals_not_between,
+    tbl_test =
+      tibble::tibble(
+        x = c(3, 5, 7),  # failing
+        y = c(1, 2, 3),  # passing
+        z = c(7, 8, 9)   # passing
+      ),
+    left = 4,
+    right = 6
   )
   
   #
@@ -493,6 +583,17 @@ test_that("pointblank expectation function produce the correct results", {
     "failure level \\(13\\) >= failure threshold \\(1\\)"
   )
   
+  eval_batch_expect_fns(
+    expect_fn = expect_col_vals_regex,
+    tbl_test =
+      tibble::tibble(
+        x = c("bean", "bane", "wean"), # failing
+        y = c("sea", "eat", "tea"), # passing
+        z = c("unchallangeable", "levelheadedness", "reauthorization")  # passing
+      ),
+    regex = "ea"
+  )
+  
   #
   # expect_col_vals_within_spec()
   #
@@ -510,6 +611,17 @@ test_that("pointblank expectation function produce the correct results", {
   expect_failure(
     expect_col_vals_within_spec(specifications, vars(zip_codes), spec = "zip"),
     "failure level \\(3\\) >= failure threshold \\(1\\)"
+  )
+  
+  eval_batch_expect_fns(
+    expect_fn = expect_col_vals_within_spec,
+    tbl_test =
+      tibble::tibble(
+        x = c("test@test.com", "great@test.com", "no!@test.com"), # failing
+        y = c("mail+mail@example.com", "atest@test.net", "hi@e.test.com"), # passing
+        z = c("01234567890@numbers-in-local.net", "mail.email@test.com", "good@test.com")  # passing
+      ),
+    spec = "email"
   )
   
   #

--- a/tests/testthat/test-expectation_fns.R
+++ b/tests/testthat/test-expectation_fns.R
@@ -412,6 +412,16 @@ test_that("pointblank expectation function produce the correct results", {
     "failure level \\(2\\) >= failure threshold \\(1\\)"
   )
   
+  eval_batch_expect_fns(
+    expect_fn = expect_col_vals_not_null,
+    tbl_test =
+      tibble::tibble(
+        x = c(1, 2, NA), # failing
+        y = c(4, 5, 6),  # passing
+        z = c(7, 8, 9)   # passing
+      )
+  )
+  
   #
   # expect_col_vals_regex()
   #

--- a/tests/testthat/test-expectation_fns.R
+++ b/tests/testthat/test-expectation_fns.R
@@ -905,31 +905,6 @@ test_that("pointblank expectation function produce the correct results", {
   )
   
   #
-  # expect_col_is_posix()
-  #
-  
-  expect_col_is_posix(tbl, columns = vars(date_time))
-  
-  expect_failure(expect_col_is_posix(tbl, columns = vars(date)))
-  expect_failure(expect_col_is_posix(tbl, columns = vars(a)))
-  expect_failure(expect_col_is_posix(tbl, columns = vars(b)))
-  expect_failure(expect_col_is_posix(tbl, columns = vars(d)))
-  expect_failure(expect_col_is_posix(tbl, columns = vars(e)))
-  expect_failure(expect_col_is_posix(tbl, columns = vars(f)))
-  expect_failure(expect_col_is_posix(tbl, columns = vars(g)))
-  expect_success(expect_col_is_posix(tbl, columns = vars(g), threshold = 2))
-  
-  expect_error(expect_col_is_posix(tbl, columns = vars(g)), class = "expectation_failure")
-  
-  expect_failure(expect_col_is_posix(tbl, columns = vars(g), threshold = 1), failed_beyond_absolute)
-  expect_failure(expect_col_is_posix(tbl, columns = vars(g), threshold = 0.01), failed_beyond_proportional)
-  
-  expect_failure(
-    expect_col_is_posix(tbl, columns = vars(g)),
-    "failure level \\(1\\) >= failure threshold \\(1\\)"
-  )
-  
-  #
   # expect_col_is_logical()
   #
   
@@ -952,6 +927,16 @@ test_that("pointblank expectation function produce the correct results", {
   expect_failure(
     expect_col_is_logical(tbl, columns = vars(g)),
     "failure level \\(1\\) >= failure threshold \\(1\\)"
+  )
+  
+  eval_batch_expect_fns(
+    expect_fn = expect_col_is_logical,
+    tbl_test =
+      tibble::tibble(
+        x = c(1, 0, 1),            # failing
+        y = c(TRUE, FALSE, TRUE),  # passing
+        z = c(TRUE, NA, FALSE)     # passing
+      )
   )
   
   #
@@ -979,6 +964,51 @@ test_that("pointblank expectation function produce the correct results", {
     "failure level \\(1\\) >= failure threshold \\(1\\)"
   )
   
+  eval_batch_expect_fns(
+    expect_fn = expect_col_is_date,
+    tbl_test =
+      tibble::tibble(
+        x = tbl$date_time[1:3],  # failing
+        y = tbl$date[1:3],       # passing
+        z = tbl$date[4:6]        # passing
+      )
+  )
+  
+  #
+  # expect_col_is_posix()
+  #
+  
+  expect_col_is_posix(tbl, columns = vars(date_time))
+  
+  expect_failure(expect_col_is_posix(tbl, columns = vars(date)))
+  expect_failure(expect_col_is_posix(tbl, columns = vars(a)))
+  expect_failure(expect_col_is_posix(tbl, columns = vars(b)))
+  expect_failure(expect_col_is_posix(tbl, columns = vars(d)))
+  expect_failure(expect_col_is_posix(tbl, columns = vars(e)))
+  expect_failure(expect_col_is_posix(tbl, columns = vars(f)))
+  expect_failure(expect_col_is_posix(tbl, columns = vars(g)))
+  expect_success(expect_col_is_posix(tbl, columns = vars(g), threshold = 2))
+  
+  expect_error(expect_col_is_posix(tbl, columns = vars(g)), class = "expectation_failure")
+  
+  expect_failure(expect_col_is_posix(tbl, columns = vars(g), threshold = 1), failed_beyond_absolute)
+  expect_failure(expect_col_is_posix(tbl, columns = vars(g), threshold = 0.01), failed_beyond_proportional)
+  
+  expect_failure(
+    expect_col_is_posix(tbl, columns = vars(g)),
+    "failure level \\(1\\) >= failure threshold \\(1\\)"
+  )
+  
+  eval_batch_expect_fns(
+    expect_fn = expect_col_is_posix,
+    tbl_test =
+      tibble::tibble(
+        x = tbl$date[1:3],       # failing
+        y = tbl$date_time[1:3],  # passing
+        z = tbl$date_time[4:6]   # passing
+      )
+  )
+  
   #
   # expect_col_is_factor()
   #
@@ -1002,6 +1032,16 @@ test_that("pointblank expectation function produce the correct results", {
   expect_failure(
     expect_col_is_factor(tbl, columns = vars(f)),
     "failure level \\(1\\) >= failure threshold \\(1\\)"
+  )
+  
+  eval_batch_expect_fns(
+    expect_fn = expect_col_is_factor,
+    tbl_test =
+      tibble::tibble(
+        x = tbl$f[1:3],  # failing
+        y = tbl$g[1:3],  # passing
+        z = tbl$g[4:6]   # passing
+      )
   )
   
   #
@@ -1029,6 +1069,16 @@ test_that("pointblank expectation function produce the correct results", {
   expect_failure(
     expect_col_exists(tbl, columns = vars(h)),
     "failure level \\(1\\) >= failure threshold \\(1\\)"
+  )
+  
+  eval_batch_expect_fns(
+    expect_fn = expect_col_exists,
+    tbl_test =
+      tibble::tibble(
+        a = c("1", "2", "3"),  # failing
+        y = c(1.2, 2.3, 3.4),  # passing
+        z = c(1.1, 2.2, 3.3)   # passing
+      )
   )
   
   #

--- a/tests/testthat/test-expectation_fns.R
+++ b/tests/testthat/test-expectation_fns.R
@@ -362,6 +362,17 @@ test_that("pointblank expectation function produce the correct results", {
     "failure level \\(5\\) >= failure threshold \\(1\\)"
   )
   
+  eval_batch_expect_fns(
+    expect_fn = expect_col_vals_in_set,
+    tbl_test =
+      tibble::tibble(
+        x = c(4, 4, 7),  # failing
+        y = c(4, 4, 5),  # passing
+        z = c(6, 5, 4)   # passing
+      ),
+    set = c(4, 5, 6)
+  )
+  
   #
   # expect_col_vals_not_in_set()
   #
@@ -383,6 +394,17 @@ test_that("pointblank expectation function produce the correct results", {
   expect_failure(
     expect_col_vals_not_in_set(tbl, columns = vars(b), set = tbl$b),
     "failure level \\(13\\) >= failure threshold \\(1\\)"
+  )
+  
+  eval_batch_expect_fns(
+    expect_fn = expect_col_vals_not_in_set,
+    tbl_test =
+      tibble::tibble(
+        x = c(1, 2, 6),  # failing
+        y = c(1, 2, 3),  # passing
+        z = c(7, 8, 9)   # passing
+      ),
+    set = c(4, 5, 6)
   )
   
   #

--- a/tests/testthat/test-expectation_fns.R
+++ b/tests/testthat/test-expectation_fns.R
@@ -32,17 +32,39 @@ tbl_not_equal_c_3 <- tbl %>% dplyr::filter(c != 3)
 tbl_c_null <- tbl %>% dplyr::filter(is.na(c))
 tbl_c_not_null <- tbl %>% dplyr::filter(!is.na(c))
 
-eval_batch_expect_fns <- function(expect_fn, tbl_test) {
+eval_batch_expect_fns <- function(expect_fn, tbl_test, ...) {
   
-  expect_failure(expect_fn(tbl_test, columns = "x"))
-  expect_success(expect_fn(tbl_test, columns = "y"))
-  expect_success(expect_fn(tbl_test, columns = "z"))
-  expect_failure(expect_fn(tbl_test, columns = c("x", "y")))
-  expect_failure(expect_fn(tbl_test, columns = c("y", "x")))
-  expect_failure(expect_fn(tbl_test, columns = c("x", "z")))
-  expect_failure(expect_fn(tbl_test, columns = c("x", "y", "z")))
-  expect_success(expect_fn(tbl_test, columns = c("y", "z")))
-  expect_success(expect_fn(tbl_test, columns = c("z", "y")))
+  args <- list(...)
+  
+  cols_ <-
+    list(
+      "x",
+      "y",
+      "z",
+      c("x", "y"),
+      c("y", "x"),
+      c("x", "z"),
+      c("x", "y", "z"),
+      c("y", "z"),
+      c("z", "y")
+    )
+  
+  fail_succeed <-
+    list(
+      expect_failure,
+      expect_success,
+      expect_success,
+      expect_failure,
+      expect_failure,
+      expect_failure,
+      expect_failure,
+      expect_success,
+      expect_success
+    )
+  
+  for (i in seq_along(cols_)) {
+    fail_succeed[[i]](do.call(expect_fn, c(list(object = tbl_test), list(columns = cols_[[i]]), args)))
+  }
 }
 
 test_that("pointblank expectation function produce the correct results", {

--- a/tests/testthat/test-expectation_fns.R
+++ b/tests/testthat/test-expectation_fns.R
@@ -345,6 +345,16 @@ test_that("pointblank expectation function produce the correct results", {
     "failure level \\(1\\) >= failure threshold \\(1\\)"
   )
   
+  eval_batch_expect_fns(
+    expect_fn = expect_col_vals_increasing,
+    tbl_test =
+      tibble::tibble(
+        x = c(2, 3, 2), # failing
+        y = c(1, 3, 9), # passing
+        z = c(6, 7, 8)  # passing
+      )
+  )
+  
   #
   # expect_col_vals_decreasing()
   #

--- a/tests/testthat/test-expectation_fns.R
+++ b/tests/testthat/test-expectation_fns.R
@@ -372,6 +372,16 @@ test_that("pointblank expectation function produce the correct results", {
     "failure level \\(1\\) >= failure threshold \\(1\\)"
   )
   
+  eval_batch_expect_fns(
+    expect_fn = expect_col_vals_decreasing,
+    tbl_test =
+      tibble::tibble(
+        x = c(1, 2, 3), # failing
+        y = c(9, 3, 1), # passing
+        z = c(8, 7, 6)  # passing
+      )
+  )
+  
   #
   # expect_col_vals_null()
   #

--- a/tests/testthat/test-expectation_fns.R
+++ b/tests/testthat/test-expectation_fns.R
@@ -32,6 +32,19 @@ tbl_not_equal_c_3 <- tbl %>% dplyr::filter(c != 3)
 tbl_c_null <- tbl %>% dplyr::filter(is.na(c))
 tbl_c_not_null <- tbl %>% dplyr::filter(!is.na(c))
 
+eval_batch_expect_fns <- function(expect_fn, tbl_test) {
+  
+  expect_failure(expect_fn(tbl_test, columns = "x"))
+  expect_success(expect_fn(tbl_test, columns = "y"))
+  expect_success(expect_fn(tbl_test, columns = "z"))
+  expect_failure(expect_fn(tbl_test, columns = c("x", "y")))
+  expect_failure(expect_fn(tbl_test, columns = c("y", "x")))
+  expect_failure(expect_fn(tbl_test, columns = c("x", "z")))
+  expect_failure(expect_fn(tbl_test, columns = c("x", "y", "z")))
+  expect_success(expect_fn(tbl_test, columns = c("y", "z")))
+  expect_success(expect_fn(tbl_test, columns = c("z", "y")))
+}
+
 test_that("pointblank expectation function produce the correct results", {
 
   failed_beyond_absolute <- ".*validation failed beyond the absolute threshold level.*"

--- a/tests/testthat/test-expectation_fns.R
+++ b/tests/testthat/test-expectation_fns.R
@@ -392,6 +392,16 @@ test_that("pointblank expectation function produce the correct results", {
     "failure level \\(11\\) >= failure threshold \\(1\\)"
   )
   
+  eval_batch_expect_fns(
+    expect_fn = expect_col_vals_null,
+    tbl_test =
+      tibble::tibble(
+        x = c(1, NA, NA),  # failing
+        y = c(NA, NA, NA), # passing
+        z = c(NA, NA, NA)  # passing
+      )
+  )
+  
   #
   # expect_col_vals_not_null()
   #

--- a/tests/testthat/test-expectation_fns.R
+++ b/tests/testthat/test-expectation_fns.R
@@ -429,6 +429,17 @@ test_that("pointblank expectation function produce the correct results", {
     "failure level \\(1\\) >= failure threshold \\(1\\)"
   )
   
+  eval_batch_expect_fns(
+    expect_fn = expect_col_vals_make_set,
+    tbl_test =
+      tibble::tibble(
+        x = c(1, 2, 2),  # failing
+        y = c(1, 2, 3),  # passing
+        z = c(3, 2, 1)   # passing
+      ),
+    set = c(1, 2, 3)
+  )
+  
   #
   # expect_col_vals_make_subset()
   #
@@ -450,6 +461,17 @@ test_that("pointblank expectation function produce the correct results", {
   expect_failure(
     expect_col_vals_make_subset(tbl, columns = vars(e), set = ""),
     "failure level \\(1\\) >= failure threshold \\(1\\)"
+  )
+  
+  eval_batch_expect_fns(
+    expect_fn = expect_col_vals_make_subset,
+    tbl_test =
+      tibble::tibble(
+        x = c(1, 3, 3),  # failing
+        y = c(1, 2, 3),  # passing
+        z = c(3, 2, 1)   # passing
+      ),
+    set = c(1, 2)
   )
   
   #
@@ -801,6 +823,16 @@ test_that("pointblank expectation function produce the correct results", {
     "failure level \\(1\\) >= failure threshold \\(1\\)"
   )
   
+  eval_batch_expect_fns(
+    expect_fn = expect_col_is_character,
+    tbl_test =
+      tibble::tibble(
+        x = c(1, 2, 3),               # failing
+        y = c("1", "2", "3"),         # passing
+        z = c("one", "two", "three")  # passing
+      )
+  )
+  
   #
   # expect_col_is_numeric()
   #
@@ -827,6 +859,16 @@ test_that("pointblank expectation function produce the correct results", {
     "failure level \\(1\\) >= failure threshold \\(1\\)"
   )
   
+  eval_batch_expect_fns(
+    expect_fn = expect_col_is_numeric,
+    tbl_test =
+      tibble::tibble(
+        x = c("1", "2", "3"),  # failing
+        y = c(1.2, 2.3, 3.4),  # passing
+        z = c(1.1, 2.2, 3.3)   # passing
+      )
+  )
+  
   #
   # expect_col_is_integer()
   #
@@ -850,6 +892,16 @@ test_that("pointblank expectation function produce the correct results", {
   expect_failure(
     expect_col_is_integer(tbl, columns = vars(g)),
     "failure level \\(1\\) >= failure threshold \\(1\\)"
+  )
+  
+  eval_batch_expect_fns(
+    expect_fn = expect_col_is_integer,
+    tbl_test =
+      tibble::tibble(
+        x = c(1.1, 2.2, 3.3),  # failing
+        y = c(1L, 2L, 3L),     # passing
+        z = c(4L, 5L, 6L)      # passing
+      )
   )
   
   #


### PR DESCRIPTION
In cases where `expect_*()` functions may handle multiple columns, we need to correctly stop at the first failure and provide the correct reporting for that. Multiple columns really means multiple steps in serial, and previously this was handled incorrectly.

Fixes: #334 