### PR TITLE
Improve the `set_tbl()` function

### DIFF
--- a/R/object_ops.R
+++ b/R/object_ops.R
@@ -752,23 +752,26 @@ export_report <- function(x,
 }
 
 
-#' Set a data table to an *agent* or *informant*
+#' Set a data table to an *agent*
 #' 
-#' @description 
-#' Setting a data table to an *agent* or *informant* with `set_tbl()` replaces
-#' any associated table (a data frame, a tibble, objects of class `tbl_dbi` or
-#' `tbl_spark`). If a data table is associated with an *agent* or *informant*
-#' through the `tbl` argument *and* the same object has a table-prep formula
-#' (settable in [create_agent()] and [create_informant()]'s `read_fn` argument
-#' or with [set_read_fn()]), the table-prep formula will take precedence. If
-#' this is undesirable, it be removed with the [remove_read_fn()] function. The
-#' association to a table can be removed with with [remove_tbl()].
+#' @description Setting a data table to an *agent* with `set_tbl()` replaces any
+#'   associated table (a data frame, a tibble, objects of class `tbl_dbi` or
+#'   `tbl_spark`). If a data table is associated with an *agent* through the
+#'   `tbl` argument *and* the same object has a table-prep formula (settable in
+#'   [create_agent()]'s `read_fn` argument or with [set_read_fn()]), the
+#'   table-prep formula will take precedence. If this is undesirable, it be
+#'   removed with the [remove_read_fn()] function. The association to a table
+#'   can be removed with with [remove_tbl()].
 #'
-#' @param x An *agent* object of class `ptblank_agent`, or, an *informant* of
-#'   class `ptblank_informant`.
+#' @param x An *agent* object of class `ptblank_agent`.
 #' @param tbl The input table for the `agent`. This can be a data frame, a
 #'   tibble, a `tbl_dbi` object, or a `tbl_spark` object. Any table already
-#'   associated with the *agent* or *informant* will be overwritten.
+#'   associated with the *agent* will be overwritten.
+#' @param tbl_name A optional name to assign to the new input table object. If
+#'   no value is provided, a name will be generated based on whatever
+#'   information is available.
+#' @param label An optional label for the validation plan. If no value is
+#'   provided then any existing label will be retained.
 #' 
 #' @examples
 #' # Set proportional failure thresholds
@@ -817,26 +820,22 @@ export_report <- function(x,
 #' 
 #' @export
 set_tbl <- function(x,
-                    tbl) {
+                    tbl,
+                    tbl_name = NULL,
+                    label = NULL) {
   
   # Set the table on the `$tbl` list element
   x$tbl <- tbl
   
   if (is_ptblank_agent(x)) {
     
-    # TODO: only attempt to set a `tbl_name` if it is NULL
-    
-    # Get the name of the table and set it to
-    # the `$tbl_name` list element
-    tbl_name <- deparse(match.call()$tbl)
-    if (tbl_name == ".") {
-      tbl_name <- "table"
+    if (!is.null(tbl_name)) {
+      x$tbl_name <- tbl_name
     }
     
-    x$tbl_name <- tbl_name
-  }
-  
-  if (is_ptblank_informant(x)) {
+    if (!is.null(label)) {
+      x$label <- label
+    }
     
     # Obtain basic information on the table and
     # set the relevant list elements
@@ -856,20 +855,17 @@ set_tbl <- function(x,
   invisible(x)
 }
 
-#' Remove a data table associated with an *agent* or *informant*
+#' Remove a data table associated with an *agent*
 #' 
-#' @description 
-#' Removing an *agent* or *informant*'s association to a data table can be done
-#' with the `remove_tbl()` function. This can be useful to ensure that the table
-#' data isn't unintentionally written to disk. It is usually best to avoid
-#' directly associating a table to an *agent* or *informant* through the `tbl`
-#' argument, instead opting for setting a table-prep formula (via
-#' [create_agent()] and [create_informant()]'s `read_fn` argument, or, with
-#' [set_read_fn()]). If necessary, the association to a table can be set again
-#' with [set_tbl()].
+#' @description Removing an *agent*'s association to a data table can be done
+#'   with the `remove_tbl()` function. This can be useful to ensure that the
+#'   table data isn't unintentionally written to disk. It is usually best to
+#'   avoid directly associating a table to an *agent* through the `tbl`
+#'   argument, instead opting for setting a table-prep formula (via
+#'   [create_agent()]'s `read_fn` argument, or, with [set_read_fn()]). If
+#'   necessary, the association to a table can be set again with [set_tbl()].
 #' 
-#' @param x An *agent* object of class `ptblank_agent`, or, an *informant* of
-#'   class `ptblank_informant`.
+#' @param x An *agent* object of class `ptblank_agent`.
 #' 
 #' @examples
 #' # Set proportional failure thresholds

--- a/R/object_ops.R
+++ b/R/object_ops.R
@@ -836,7 +836,7 @@ set_tbl <- function(x,
     x$tbl_name <- tbl_name
   }
   
-  if (is_ptblank_agent(x)) {
+  if (is_ptblank_informant(x)) {
     
     # Obtain basic information on the table and
     # set the relevant list elements

--- a/man/remove_tbl.Rd
+++ b/man/remove_tbl.Rd
@@ -2,23 +2,21 @@
 % Please edit documentation in R/object_ops.R
 \name{remove_tbl}
 \alias{remove_tbl}
-\title{Remove a data table associated with an \emph{agent} or \emph{informant}}
+\title{Remove a data table associated with an \emph{agent}}
 \usage{
 remove_tbl(x)
 }
 \arguments{
-\item{x}{An \emph{agent} object of class \code{ptblank_agent}, or, an \emph{informant} of
-class \code{ptblank_informant}.}
+\item{x}{An \emph{agent} object of class \code{ptblank_agent}.}
 }
 \description{
-Removing an \emph{agent} or \emph{informant}'s association to a data table can be done
-with the \code{remove_tbl()} function. This can be useful to ensure that the table
-data isn't unintentionally written to disk. It is usually best to avoid
-directly associating a table to an \emph{agent} or \emph{informant} through the \code{tbl}
+Removing an \emph{agent}'s association to a data table can be done
+with the \code{remove_tbl()} function. This can be useful to ensure that the
+table data isn't unintentionally written to disk. It is usually best to
+avoid directly associating a table to an \emph{agent} through the \code{tbl}
 argument, instead opting for setting a table-prep formula (via
-\code{\link[=create_agent]{create_agent()}} and \code{\link[=create_informant]{create_informant()}}'s \code{read_fn} argument, or, with
-\code{\link[=set_read_fn]{set_read_fn()}}). If necessary, the association to a table can be set again
-with \code{\link[=set_tbl]{set_tbl()}}.
+\code{\link[=create_agent]{create_agent()}}'s \code{read_fn} argument, or, with \code{\link[=set_read_fn]{set_read_fn()}}). If
+necessary, the association to a table can be set again with \code{\link[=set_tbl]{set_tbl()}}.
 }
 \section{Function ID}{
 

--- a/man/set_tbl.Rd
+++ b/man/set_tbl.Rd
@@ -2,27 +2,33 @@
 % Please edit documentation in R/object_ops.R
 \name{set_tbl}
 \alias{set_tbl}
-\title{Set a data table to an \emph{agent} or \emph{informant}}
+\title{Set a data table to an \emph{agent}}
 \usage{
-set_tbl(x, tbl)
+set_tbl(x, tbl, tbl_name = NULL, label = NULL)
 }
 \arguments{
-\item{x}{An \emph{agent} object of class \code{ptblank_agent}, or, an \emph{informant} of
-class \code{ptblank_informant}.}
+\item{x}{An \emph{agent} object of class \code{ptblank_agent}.}
 
 \item{tbl}{The input table for the \code{agent}. This can be a data frame, a
 tibble, a \code{tbl_dbi} object, or a \code{tbl_spark} object. Any table already
-associated with the \emph{agent} or \emph{informant} will be overwritten.}
+associated with the \emph{agent} will be overwritten.}
+
+\item{tbl_name}{A optional name to assign to the new input table object. If
+no value is provided, a name will be generated based on whatever
+information is available.}
+
+\item{label}{An optional label for the validation plan. If no value is
+provided then any existing label will be retained.}
 }
 \description{
-Setting a data table to an \emph{agent} or \emph{informant} with \code{set_tbl()} replaces
-any associated table (a data frame, a tibble, objects of class \code{tbl_dbi} or
-\code{tbl_spark}). If a data table is associated with an \emph{agent} or \emph{informant}
-through the \code{tbl} argument \emph{and} the same object has a table-prep formula
-(settable in \code{\link[=create_agent]{create_agent()}} and \code{\link[=create_informant]{create_informant()}}'s \code{read_fn} argument
-or with \code{\link[=set_read_fn]{set_read_fn()}}), the table-prep formula will take precedence. If
-this is undesirable, it be removed with the \code{\link[=remove_read_fn]{remove_read_fn()}} function. The
-association to a table can be removed with with \code{\link[=remove_tbl]{remove_tbl()}}.
+Setting a data table to an \emph{agent} with \code{set_tbl()} replaces any
+associated table (a data frame, a tibble, objects of class \code{tbl_dbi} or
+\code{tbl_spark}). If a data table is associated with an \emph{agent} through the
+\code{tbl} argument \emph{and} the same object has a table-prep formula (settable in
+\code{\link[=create_agent]{create_agent()}}'s \code{read_fn} argument or with \code{\link[=set_read_fn]{set_read_fn()}}), the
+table-prep formula will take precedence. If this is undesirable, it be
+removed with the \code{\link[=remove_read_fn]{remove_read_fn()}} function. The association to a table
+can be removed with with \code{\link[=remove_tbl]{remove_tbl()}}.
 }
 \section{Function ID}{
 

--- a/tests/testthat/test-object_ops.R
+++ b/tests/testthat/test-object_ops.R
@@ -148,8 +148,8 @@ test_that("The `x_write_disk()` and `x_read_disk()` functions works as expected"
   # Expect the new `tbl` data to be in the agent object
   expect_s3_class(agent_test_4$tbl, "tbl_df")
   
-  # Expect the `tbl_name` to be `small_table`
-  expect_equal(agent_test_4$tbl_name, "small_table")
+  # Expect the `tbl_name` to remain as `small_table_sqlite()`
+  expect_equal(agent_test_4$tbl_name, "small_table_sqlite()")
   
   # Expect the `db_tbl_name` to be NA
   expect_equal(agent_test_4$db_tbl_name, NA_character_)
@@ -173,8 +173,8 @@ test_that("The `x_write_disk()` and `x_read_disk()` functions works as expected"
   # Expect the new `tbl` data to be in the agent object
   expect_s3_class(agent_test_4$tbl, "tbl_df")
   
-  # Expect the `tbl_name` to be `table`
-  expect_equal(agent_test_4$tbl_name, "table")
+  # Expect the `tbl_name` to still be `small_table_sqlite()`
+  expect_equal(agent_test_4$tbl_name, "small_table_sqlite()")
   
   # Expect the `db_tbl_name` to be NA
   expect_equal(agent_test_4$db_tbl_name, NA_character_)
@@ -203,4 +203,42 @@ test_that("The `x_write_disk()` and `x_read_disk()` functions works as expected"
   
   # Don't expect the `read_fn` element to be in the agent object
   expect_null(agent_test_4$read_fn)
+})
+
+test_that("The `set_tbl()` function works as expected", {
+  
+  #
+  # Tests with an agent
+  #
+  
+  # Create an agent and supply it with the `specifications` table
+  agent <- create_agent(tbl = specifications)
+  
+  expect_null(agent$read_fn)
+  expect_equal(agent$tbl_name, "specifications")
+  expect_match(agent$label, "\\[.*?\\]")
+  expect_equal(agent$col_names, colnames(specifications))
+  
+  # Replace the table in the agent with `game_revenue`
+  agent_replace_1 <- agent %>% set_tbl(tbl = game_revenue)
+  
+  expect_null(agent_replace_1$read_fn)
+  expect_equal(agent_replace_1$tbl_name, "specifications")
+  expect_equal(agent_replace_1$label, agent$label)
+  expect_equal(agent_replace_1$col_names, colnames(game_revenue))
+  
+  # Replace the table in the agent with `game_revenue` and change the
+  # table name and label
+  agent_replace_2 <- 
+    agent %>% 
+    set_tbl(
+      tbl = game_revenue,
+      tbl_name = "game_revenue",
+      label = "Checking the game revenue table."
+    )
+  
+  expect_null(agent_replace_2$read_fn)
+  expect_equal(agent_replace_2$tbl_name, "game_revenue")
+  expect_match(agent_replace_2$label, "Checking the game revenue table.")
+  expect_equal(agent_replace_2$col_names, colnames(game_revenue))
 })


### PR DESCRIPTION
This PR improves the `set_tbl()` function by allowing the optional change of `tbl_name` and `label` for an agent (often useful when switching out a table).

Fixes: #368 