### PR TITLE
Enhance tbl store by introducing substitution syntax and other things

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -751,6 +751,8 @@ print.tbl_store <- function(x, ...) {
   
   n_tbls <- length(tbl_names)
   
+  has_init_stmt <- !is.null(attr(x, which = "pb_init", exact = TRUE))
+  
   has_given_name <- 
     vapply(
       x,
@@ -789,6 +791,18 @@ print.tbl_store <- function(x, ...) {
     )
   }
   
+  if (has_init_stmt) {
+    
+    cli::cli_rule()
+    
+    init_stmt <- attr(x, which = "pb_init", exact = TRUE)
+    init_stmt <- capture_formula(init_stmt)[2]
+    
+    Sys.sleep(0.1)
+    
+    cli::cli_text(paste0("{.blue INIT} // ", init_stmt))
+  }
+  
   cli::cli_rule()
 }
 
@@ -807,6 +821,8 @@ knit_print.tbl_store <- function(x, ...) {
   tbl_names <- names(x)
   
   n_tbls <- length(tbl_names)
+  
+  has_init_stmt <- !is.null(attr(x, which = "pb_init", exact = TRUE))
   
   has_given_name <- 
     vapply(
@@ -841,6 +857,20 @@ knit_print.tbl_store <- function(x, ...) {
   
   top_rule <- "-- The `table_store` table-prep formulas"
   bottom_rule <- "----"
+  
+  if (has_init_stmt) {
+    
+    init_stmt <- attr(x, which = "pb_init", exact = TRUE)
+    init_stmt <- capture_formula(init_stmt)[2]
+    
+    Sys.sleep(0.1)
+    
+    tbl_store_lines <- 
+      paste(
+        tbl_store_lines,
+        paste0("\n", bottom_rule, "\nINIT // ", init_stmt)
+      )
+  }
   
   tbl_store_str <-
     glue::glue(

--- a/R/tbl_store.R
+++ b/R/tbl_store.R
@@ -124,14 +124,17 @@
 #' # R statement for generating the "tbl_store.yml" file
 #' tbl_store(
 #'   tbl_duckdb ~ db_tbl(small_table, dbname = ":memory:", dbtype = "duckdb"),
-#'   sml_table_high ~ small_table %>% dplyr::filter(f == "high")
+#'   sml_table_high ~ small_table %>% dplyr::filter(f == "high"),
+#'   .init = ~ library(tidyverse)
 #' ) %>%
 #'   yaml_write()
 #' 
 #' # YAML representation ("tbl_store.yml")
+#' type: tbl_store
 #' tbls:
 #'   tbl_duckdb: ~ db_tbl(small_table, dbname = ":memory:", dbtype = "duckdb")
 #'   sml_table_high: ~ small_table %>% dplyr::filter(f == "high")
+#' init: ~library(tidyverse)
 #' ```
 #' 
 #' This is useful when you want to get fresh pulls of prepared data from a

--- a/R/tbl_store.R
+++ b/R/tbl_store.R
@@ -39,6 +39,76 @@
 #' [tbl_source()] (e.g.,
 #' `create_agent(tbl = ~ tbl_source("<name>", <tbl_store>))`).
 #' 
+#' @section Syntax:
+#' The table store provides a way to get the tables we need fairly easily. Think
+#' of an identifier for the table you'd like and then provide the code necessary
+#' to obtain that table. Then repeat as many times as you like!
+#'
+#' Here we'll define two tables that can be materialized later: `tbl_duckdb` (an
+#' in-memory DuckDB database table with **pointblank**'s `small_table` dataset)
+#' and `sml_table_high` (a filtered version of `tbl_duckdb`):
+#' 
+#' ```
+#' tbls_1 <-
+#'   tbl_store(
+#'     tbl_duckdb ~ 
+#'       db_tbl(
+#'         pointblank::small_table,
+#'         dbname = ":memory:",
+#'         dbtype = "duckdb"
+#'       ),
+#'     sml_table_high ~ 
+#'       db_tbl(
+#'         pointblank::small_table,
+#'         dbname = ":memory:",
+#'         dbtype = "duckdb"
+#'       ) %>%
+#'       dplyr::filter(f == "high")
+#'   )
+#' ```
+#' 
+#' It's good to check that the tables can be obtained without error. We can do
+#' this with [tbl_get()]:
+#' 
+#' ```
+#' tbl_get("tbl_duckdb", store = tbls_1)
+#' tbl_get("sml_table_high", store = tbls_1)
+#' ```
+#' 
+#' We can shorten the `tbl_store()` statement with some syntax that
+#' **pointblank** provides. The `sml_table_high` table-prep is simply a
+#' transformation of `tbl_duckdb`, so, we can use `{{ tbl_duckdb }}` in place of
+#' the repeated statement. Additionally, we can provide a `library()` call to
+#' the `.init` argument of `tbl_store()` so that **dplyr** is available (thus
+#' allowing us to use `filter(...)` instead of `dplyr::filter(...)`). Here is
+#' the revised `tbl_store()` call:
+#' 
+#' ```
+#' tbls_2 <- 
+#'   tbl_store(
+#'     tbl_duckdb ~ 
+#'       db_tbl(
+#'         pointblank::small_table,
+#'         dbname = ":memory:",
+#'         dbtype = "duckdb"
+#'       ),
+#'     sml_table_high ~ 
+#'       {{ tbl_duckdb }} %>%
+#'       filter(f == "high"),
+#'     .init = ~ library(tidyverse)
+#'   )
+#' ```
+#' 
+#' Checking again with [tbl_get()] should provide the same tables as before:
+#' 
+#' ```
+#' tbl_get("tbl_duckdb", store = tbls_2)
+#' tbl_get("sml_table_high", store = tbls_2)
+#' ```
+#' 
+#' This is a great way to make table-prep more concise, readable, and less
+#' prone to errors.
+#' 
 #' @section YAML:
 #' A **pointblank** table store can be written to YAML with [yaml_write()] and
 #' the resulting YAML can be used in several ways. The ideal scenario is to have

--- a/R/tbl_store.R
+++ b/R/tbl_store.R
@@ -176,10 +176,11 @@
 #'   statement that obtains a table (i.e., the table-prep formula). If the LHS
 #'   is omitted then an identifier will be generated for you.
 #' @param .list Allows for the use of a list as an input alternative to `...`.
-#' @param .init Optionally provide statements (in a one-sided formula) that
-#'   should initially be executed when materializing *any* of tables in the
-#'   table store. This is useful for inclusion of `library()` calls that can
-#'   be beneficial for the table-prep formulas.
+#' @param .init We can optionally provide an initialization statement (in a
+#'   one-sided formula) that should be executed whenever *any* of tables in the
+#'   table store are obtained. This is useful, for instance, for including a
+#'   `library()` call that can be executed before any table-prep formulas in
+#'   `...`.
 #' 
 #' @return A `tbl_store` object that contains table-prep formulas.
 #' 

--- a/R/tbl_store.R
+++ b/R/tbl_store.R
@@ -461,7 +461,7 @@ tbl_source <- function(tbl,
   tbl_entry <- 
     tbl_store(
       .list = list(
-        as.formula(
+        stats::as.formula(
           paste0(names(store)[this_entry_idx], " ", tbl_entry_str)
         )
       )

--- a/R/tbl_store.R
+++ b/R/tbl_store.R
@@ -19,22 +19,25 @@
 
 #' Define a store of tables with table-prep formulas: a table store
 #' 
-#' @description 
+#' @description
 #' It can be useful to set up all the data sources you need and just draw from
 #' them when necessary. This upfront configuration with `tbl_store()` lets us
 #' define the methods for obtaining tabular data from mixed sources (e.g.,
-#' database tables, tables generated from flat files, etc.) and provide names
-#' for these data preparation procedures. Then we have a convenient way to
-#' access the materialized tables with [tbl_get()], or, the table-prep formulas
-#' with [tbl_source()]. Table-prep formulas can be as simple as getting a table
-#' from a location, or, it can involve as much mutation as is necessary (imagine
-#' procuring several mutated variations of the same source table, generating a
-#' table from multiple sources, or pre-filtering a database table according to
-#' the system time). Another nice aspect of organizing table-prep formulas in a
-#' single object is supplying it to the `tbl` argument of [create_agent()] or
-#' [create_informant()] via `$` notation (e.g, `create_agent(tbl =
-#' <tbl_store>$<name>)`) or with [tbl_source()] (e.g., `create_agent(tbl = ~
-#' tbl_source("<name>", <tbl_store>))`).
+#' database tables, tables generated from flat files, etc.) and provide
+#' identifiers for these data preparation procedures.
+#' 
+#' What results from this work is a convenient way to materialize tables with
+#' [tbl_get()]. We can also get any table-prep formula from the table store
+#' with [tbl_source()]. The content of a table-prep formulas can involve reading
+#' a table from a location, or, it can involve data transformation. One can
+#' imagine scenarios where we might (1) procure several mutated variations of
+#' the same source table, (2) generate a table using disparate data sources, or
+#' (3) filter the rows of a database table according to the system time. Another
+#' nice aspect of organizing table-prep formulas in a single object is supplying
+#' it to the `tbl` argument of [create_agent()] or [create_informant()] via `$`
+#' notation (e.g, `create_agent(tbl = <tbl_store>$<name>)`) or with
+#' [tbl_source()] (e.g.,
+#' `create_agent(tbl = ~ tbl_source("<name>", <tbl_store>))`).
 #' 
 #' @section YAML:
 #' A **pointblank** table store can be written to YAML with [yaml_write()] and
@@ -96,12 +99,14 @@
 #' 
 #' @param ... Expressions that contain table-prep formulas and table names for
 #'   data retrieval. Two-sided formulas (e.g, `<LHS> ~ <RHS>`) are to be used,
-#'   where the left-hand side is a given name and the right-hand is the portion
-#'   that is is used to obtain the table.
+#'   where the left-hand side is an identifier and the right-hand contains a
+#'   statement that obtains a table (i.e., the table-prep formula). If the LHS
+#'   is omitted then an identifier will be generated for you.
 #' @param .list Allows for the use of a list as an input alternative to `...`.
 #' @param .init Optionally provide statements (in a one-sided formula) that
 #'   should initially be executed when materializing *any* of tables in the
-#'   table store.
+#'   table store. This is useful for inclusion of `library()` calls that can
+#'   be beneficial for the table-prep formulas.
 #' 
 #' @return A `tbl_store` object that contains table-prep formulas.
 #' 

--- a/R/tbl_store.R
+++ b/R/tbl_store.R
@@ -678,12 +678,19 @@ yaml_read_tbl_store <- function(filename) {
   
   statements <- paste(table_names, table_formulas)
   
+  # If there is an init statement, obtain that
+  if ("init" %in% names(y)) {
+    init <- y$init
+  } else {
+    init <- NULL
+  }
+  
   # Generate the expression string
   expr_str <-
     paste0(
       "tbl_store(\n",
-      paste(paste0("  ", statements), collapse = ",\n"), "\n",
-      ")"
+      paste(paste0("  ", statements), collapse = ",\n"),
+      if (is.null(init)) "\n)" else paste0(",\n  .init = ", init, "\n)")
     )
 
   tbl_store <- 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1066,16 +1066,25 @@ tidy_gsub <- function(x,
   gsub(pattern, replacement, x, fixed = fixed)
 }
 
-capture_formula <- function(formula, separate = TRUE) {
+capture_formula <- function(formula,
+                            separate = TRUE,
+                            remove_whitespace = TRUE,
+                            oneline = TRUE) {
   
   # TODO: add option to use `htmltools::htmlEscape()`
   
   attributes(formula) <- NULL
   
-  output <- utils::capture.output(formula) %>% 
-    gsub("^\\s+", "", .) %>%
-    paste(collapse = "")
-
+  output <- utils::capture.output(formula)
+  
+  if (remove_whitespace) {
+    output <- gsub("^\\s+", "", output)
+  }
+  
+  if (oneline) {
+    output <- paste(output, collapse = "")
+  }
+  
   if (separate) {
     if (grepl("^~", output)) {
       output <- c(NA_character_, output)

--- a/R/yaml_write.R
+++ b/R/yaml_write.R
@@ -1308,8 +1308,22 @@ as_tbl_store_yaml_list <- function(tbl_store) {
   
   lst_tbls <- list(tbls = tbl_list)
   
+  if (!is.null(attr(tbl_store, which = "pb_init", exact = TRUE))) {
+    
+    init_stmt <- attr(tbl_store, which = "pb_init", exact = TRUE)
+    init_stmt <- capture_formula(init_stmt)[2]
+    
+    Sys.sleep(0.1)
+    
+    lst_init <- list(init = init_stmt)
+    
+  } else {
+    lst_init <- NULL
+  }
+  
   c(
     type = "tbl_store",           # YAML type: `tbl_store`
-    lst_tbls                      # table store list of table-prep formulas
+    lst_tbls,                     # table store list of table-prep formulas
+    lst_init                      # initialization statement
   )
 }

--- a/man/tbl_store.Rd
+++ b/man/tbl_store.Rd
@@ -15,10 +15,11 @@ is omitted then an identifier will be generated for you.}
 
 \item{.list}{Allows for the use of a list as an input alternative to \code{...}.}
 
-\item{.init}{Optionally provide statements (in a one-sided formula) that
-should initially be executed when materializing \emph{any} of tables in the
-table store. This is useful for inclusion of \code{library()} calls that can
-be beneficial for the table-prep formulas.}
+\item{.init}{We can optionally provide an initialization statement (in a
+one-sided formula) that should be executed whenever \emph{any} of tables in the
+table store are obtained. This is useful, for instance, for including a
+\code{library()} call that can be executed before any table-prep formulas in
+\code{...}.}
 }
 \value{
 A \code{tbl_store} object that contains table-prep formulas.
@@ -116,14 +117,17 @@ written to YAML (if no filename is given then the YAML is written to
 \code{"tbl_store.yml"}).\preformatted{# R statement for generating the "tbl_store.yml" file
 tbl_store(
   tbl_duckdb ~ db_tbl(small_table, dbname = ":memory:", dbtype = "duckdb"),
-  sml_table_high ~ small_table \%>\% dplyr::filter(f == "high")
+  sml_table_high ~ small_table \%>\% dplyr::filter(f == "high"),
+  .init = ~ library(tidyverse)
 ) \%>\%
   yaml_write()
 
 # YAML representation ("tbl_store.yml")
+type: tbl_store
 tbls:
   tbl_duckdb: ~ db_tbl(small_table, dbname = ":memory:", dbtype = "duckdb")
   sml_table_high: ~ small_table \%>\% dplyr::filter(f == "high")
+init: ~library(tidyverse)
 }
 
 This is useful when you want to get fresh pulls of prepared data from a

--- a/man/tbl_store.Rd
+++ b/man/tbl_store.Rd
@@ -9,14 +9,16 @@ tbl_store(..., .list = list2(...), .init = NULL)
 \arguments{
 \item{...}{Expressions that contain table-prep formulas and table names for
 data retrieval. Two-sided formulas (e.g, \verb{<LHS> ~ <RHS>}) are to be used,
-where the left-hand side is a given name and the right-hand is the portion
-that is is used to obtain the table.}
+where the left-hand side is an identifier and the right-hand contains a
+statement that obtains a table (i.e., the table-prep formula). If the LHS
+is omitted then an identifier will be generated for you.}
 
 \item{.list}{Allows for the use of a list as an input alternative to \code{...}.}
 
 \item{.init}{Optionally provide statements (in a one-sided formula) that
 should initially be executed when materializing \emph{any} of tables in the
-table store.}
+table store. This is useful for inclusion of \code{library()} calls that can
+be beneficial for the table-prep formulas.}
 }
 \value{
 A \code{tbl_store} object that contains table-prep formulas.
@@ -25,16 +27,21 @@ A \code{tbl_store} object that contains table-prep formulas.
 It can be useful to set up all the data sources you need and just draw from
 them when necessary. This upfront configuration with \code{tbl_store()} lets us
 define the methods for obtaining tabular data from mixed sources (e.g.,
-database tables, tables generated from flat files, etc.) and provide names
-for these data preparation procedures. Then we have a convenient way to
-access the materialized tables with \code{\link[=tbl_get]{tbl_get()}}, or, the table-prep formulas
-with \code{\link[=tbl_source]{tbl_source()}}. Table-prep formulas can be as simple as getting a table
-from a location, or, it can involve as much mutation as is necessary (imagine
-procuring several mutated variations of the same source table, generating a
-table from multiple sources, or pre-filtering a database table according to
-the system time). Another nice aspect of organizing table-prep formulas in a
-single object is supplying it to the \code{tbl} argument of \code{\link[=create_agent]{create_agent()}} or
-\code{\link[=create_informant]{create_informant()}} via \code{$} notation (e.g, \verb{create_agent(tbl = <tbl_store>$<name>)}) or with \code{\link[=tbl_source]{tbl_source()}} (e.g., \verb{create_agent(tbl = ~ tbl_source("<name>", <tbl_store>))}).
+database tables, tables generated from flat files, etc.) and provide
+identifiers for these data preparation procedures.
+
+What results from this work is a convenient way to materialize tables with
+\code{\link[=tbl_get]{tbl_get()}}. We can also get any table-prep formula from the table store
+with \code{\link[=tbl_source]{tbl_source()}}. The content of a table-prep formulas can involve reading
+a table from a location, or, it can involve data transformation. One can
+imagine scenarios where we might (1) procure several mutated variations of
+the same source table, (2) generate a table using disparate data sources, or
+(3) filter the rows of a database table according to the system time. Another
+nice aspect of organizing table-prep formulas in a single object is supplying
+it to the \code{tbl} argument of \code{\link[=create_agent]{create_agent()}} or \code{\link[=create_informant]{create_informant()}} via \code{$}
+notation (e.g, \verb{create_agent(tbl = <tbl_store>$<name>)}) or with
+\code{\link[=tbl_source]{tbl_source()}} (e.g.,
+\verb{create_agent(tbl = ~ tbl_source("<name>", <tbl_store>))}).
 }
 \section{YAML}{
 

--- a/man/tbl_store.Rd
+++ b/man/tbl_store.Rd
@@ -43,6 +43,66 @@ notation (e.g, \verb{create_agent(tbl = <tbl_store>$<name>)}) or with
 \code{\link[=tbl_source]{tbl_source()}} (e.g.,
 \verb{create_agent(tbl = ~ tbl_source("<name>", <tbl_store>))}).
 }
+\section{Syntax}{
+
+The table store provides a way to get the tables we need fairly easily. Think
+of an identifier for the table you'd like and then provide the code necessary
+to obtain that table. Then repeat as many times as you like!
+
+Here we'll define two tables that can be materialized later: \code{tbl_duckdb} (an
+in-memory DuckDB database table with \strong{pointblank}'s \code{small_table} dataset)
+and \code{sml_table_high} (a filtered version of \code{tbl_duckdb}):\preformatted{tbls_1 <-
+  tbl_store(
+    tbl_duckdb ~ 
+      db_tbl(
+        pointblank::small_table,
+        dbname = ":memory:",
+        dbtype = "duckdb"
+      ),
+    sml_table_high ~ 
+      db_tbl(
+        pointblank::small_table,
+        dbname = ":memory:",
+        dbtype = "duckdb"
+      ) \%>\%
+      dplyr::filter(f == "high")
+  )
+}
+
+It's good to check that the tables can be obtained without error. We can do
+this with \code{\link[=tbl_get]{tbl_get()}}:\preformatted{tbl_get("tbl_duckdb", store = tbls_1)
+tbl_get("sml_table_high", store = tbls_1)
+}
+
+We can shorten the \code{tbl_store()} statement with some syntax that
+\strong{pointblank} provides. The \code{sml_table_high} table-prep is simply a
+transformation of \code{tbl_duckdb}, so, we can use \code{{{ tbl_duckdb }}} in place of
+the repeated statement. Additionally, we can provide a \code{library()} call to
+the \code{.init} argument of \code{tbl_store()} so that \strong{dplyr} is available (thus
+allowing us to use \code{filter(...)} instead of \code{dplyr::filter(...)}). Here is
+the revised \code{tbl_store()} call:\preformatted{tbls_2 <- 
+  tbl_store(
+    tbl_duckdb ~ 
+      db_tbl(
+        pointblank::small_table,
+        dbname = ":memory:",
+        dbtype = "duckdb"
+      ),
+    sml_table_high ~ 
+      \{\{ tbl_duckdb \}\} \%>\%
+      filter(f == "high"),
+    .init = ~ library(tidyverse)
+  )
+}
+
+Checking again with \code{\link[=tbl_get]{tbl_get()}} should provide the same tables as before:\preformatted{tbl_get("tbl_duckdb", store = tbls_2)
+tbl_get("sml_table_high", store = tbls_2)
+}
+
+This is a great way to make table-prep more concise, readable, and less
+prone to errors.
+}
+
 \section{YAML}{
 
 A \strong{pointblank} table store can be written to YAML with \code{\link[=yaml_write]{yaml_write()}} and

--- a/man/tbl_store.Rd
+++ b/man/tbl_store.Rd
@@ -4,7 +4,7 @@
 \alias{tbl_store}
 \title{Define a store of tables with table-prep formulas: a table store}
 \usage{
-tbl_store(..., .list = list2(...))
+tbl_store(..., .list = list2(...), .init = NULL)
 }
 \arguments{
 \item{...}{Expressions that contain table-prep formulas and table names for
@@ -13,6 +13,10 @@ where the left-hand side is a given name and the right-hand is the portion
 that is is used to obtain the table.}
 
 \item{.list}{Allows for the use of a list as an input alternative to \code{...}.}
+
+\item{.init}{Optionally provide statements (in a one-sided formula) that
+should initially be executed when materializing \emph{any} of tables in the
+table store.}
 }
 \value{
 A \code{tbl_store} object that contains table-prep formulas.


### PR DESCRIPTION
This PR is for generally enhancing the table store feature. Additional syntax will make it easier to include table-prep stmts in other table-prep stmts. Also, other components of a table store will make it easy to run statements before any table prep should occur.

Fixes: https://github.com/rich-iannone/pointblank/issues/391