### PR TITLE
Allow use of tidyselect stmts in `rows_distinct()` and `rows_complete()`

### DIFF
--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -2296,6 +2296,12 @@ interrogate_distinct <- function(
         unlist()
     }
     
+    if (length(column_names) == 1 && column_names == "NA") {
+      if (uses_tidyselect(expr_text = agent$validation_set$columns_expr[idx])) {
+        column_names <- character(0)
+      }
+    }
+    
   } else if (is.na(agent$validation_set$column[idx] %>% unlist())) {
     column_names <- get_all_cols(agent = agent)
   }
@@ -2311,6 +2317,7 @@ interrogate_distinct <- function(
     
     # Ensure that the input `table` is actually a table object
     tbl_validity_check(table = table)
+    column_validity_has_columns(columns = column_names)
     
     table %>%
       dplyr::select({{ column_names }}) %>%
@@ -2389,6 +2396,12 @@ interrogate_complete <- function(
         unlist()
     }
     
+    if (length(column_names) == 1 && column_names == "NA") {
+      if (uses_tidyselect(expr_text = agent$validation_set$columns_expr[idx])) {
+        column_names <- character(0)
+      }
+    }
+    
   } else if (is.na(agent$validation_set$column[idx] %>% unlist())) {
     column_names <- get_all_cols(agent = agent)
   }
@@ -2404,6 +2417,7 @@ interrogate_complete <- function(
     
     # Ensure that the input `table` is actually a table object
     tbl_validity_check(table = table)
+    column_validity_has_columns(columns = column_names)
     
     if (is_tbl_dbi(table) || is_tbl_spark(table)) {
       
@@ -2802,6 +2816,17 @@ column_validity_checks_column_value <- function(
 }
 
 # nolint end
+
+# Validity check for presence of columns
+column_validity_has_columns <- function(columns) {
+  
+  if (length(columns) < 1) {
+    stop(
+      "The column selection statement that was used yielded no columns.",
+      call. = FALSE
+    )
+  }
+}
 
 # Validity check for the column
 column_validity_checks_column <- function(

--- a/R/rows_complete.R
+++ b/R/rows_complete.R
@@ -270,11 +270,19 @@ rows_complete <- function(
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
   
-  # Resolve the columns based on the expression
-  if (!is.null(rlang::eval_tidy(columns)) && !is.null(columns)) {
-    columns <- resolve_columns(x = x, var_expr = columns, preconditions)
+  if (uses_tidyselect(expr_text = columns_expr)) {
+    
+    # Resolve the columns based on the expression
+    columns <- resolve_columns(x = x, var_expr = columns, preconditions = NULL)
+    
   } else {
-    columns <- NULL
+    
+    # Resolve the columns based on the expression
+    if (!is.null(rlang::eval_tidy(columns)) && !is.null(columns)) {
+      columns <- resolve_columns(x = x, var_expr = columns, preconditions)
+    } else {
+      columns <- NULL
+    }
   }
   
   # Resolve segments into list

--- a/R/rows_distinct.R
+++ b/R/rows_distinct.R
@@ -271,11 +271,19 @@ rows_distinct <- function(
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
   
-  # Resolve the columns based on the expression
-  if (!is.null(rlang::eval_tidy(columns)) && !is.null(columns)) {
-    columns <- resolve_columns(x = x, var_expr = columns, preconditions)
+  if (uses_tidyselect(expr_text = columns_expr)) {
+    
+    # Resolve the columns based on the expression
+    columns <- resolve_columns(x = x, var_expr = columns, preconditions = NULL)
+    
   } else {
-    columns <- NULL
+    
+    # Resolve the columns based on the expression
+    if (!is.null(rlang::eval_tidy(columns)) && !is.null(columns)) {
+      columns <- resolve_columns(x = x, var_expr = columns, preconditions)
+    } else {
+      columns <- NULL
+    }
   }
   
   # Resolve segments into list

--- a/R/utils.R
+++ b/R/utils.R
@@ -147,6 +147,13 @@ exported_tidyselect_fns <- function() {
   c("starts_with", "ends_with", "contains", "matches", "everything")
 }
 
+uses_tidyselect <- function(expr_text) {
+  grepl(
+    "^starts_with\\(|^ends_with\\(|^contains\\(|^matches\\(|^everything\\(",
+    expr_text
+  )
+}
+
 get_assertion_type_at_idx <- function(agent, idx) {
   agent$validation_set[[idx, "assertion_type"]]
 }

--- a/tests/testthat/test-interrogate_with_agent.R
+++ b/tests/testthat/test-interrogate_with_agent.R
@@ -840,6 +840,116 @@ test_that("Interrogating for valid row values", {
   expect_equivalent(validation$validation_set$f_failed, 0.15385)
   expect_equivalent(nrow(validation$validation_set), 1)
   
+  # Use the `rows_distinct()` function to create
+  # a validation step for columns queried with a
+  # tidyselect statement, then `interrogate()`
+  validation <-
+    create_agent(tbl = small_table) %>%
+    rows_distinct(columns = starts_with(c("date", "a"))) %>%
+    interrogate()
+  
+  # Expect certain values in `validation$validation_set`
+  expect_equivalent(validation$tbl_name, "small_table")
+  expect_equivalent(validation$validation_set$assertion_type, "rows_distinct")
+  expect_equivalent(validation$validation_set$column %>% unlist(), "date_time, date, a")
+  expect_true(is.null(validation$validation_set[["values"]][[1]]))
+  expect_false(validation$validation_set$all_passed)
+  expect_equivalent(validation$validation_set$n, 13)
+  expect_equivalent(validation$validation_set$n_passed, 11)
+  expect_equivalent(validation$validation_set$n_failed, 2)
+  expect_equivalent(validation$validation_set$f_passed, 0.84615)
+  expect_equivalent(validation$validation_set$f_failed, 0.15385)
+  expect_equivalent(nrow(validation$validation_set), 1)
+  
+  #
+  # rows_complete()
+  #
+  
+  # Use the `rows_complete()` function to create
+  # a validation step, then, `interrogate()`
+  validation <-
+    create_agent(tbl = small_table) %>%
+    rows_complete() %>%
+    interrogate()
+  
+  # Expect certain values in `validation$validation_set`
+  expect_equivalent(validation$tbl_name, "small_table")
+  expect_equivalent(validation$validation_set$assertion_type, "rows_complete")
+  expect_true(is.na(validation$validation_set$column %>% unlist()))
+  expect_true(is.null(validation$validation_set[["values"]][[1]]))
+  expect_false(validation$validation_set$all_passed)
+  expect_equivalent(validation$validation_set$n, 13)
+  expect_equivalent(validation$validation_set$n_passed, 11)
+  expect_equivalent(validation$validation_set$n_failed, 2)
+  expect_equivalent(validation$validation_set$f_passed, 0.84615)
+  expect_equivalent(validation$validation_set$f_failed, 0.15385)
+  expect_equivalent(nrow(validation$validation_set), 1)
+  
+  # Use the `rows_complete()` function to create
+  # a validation step (with a precondition), then,
+  # `interrogate()`
+  validation <-
+    create_agent(tbl = small_table) %>%
+    rows_complete(
+      preconditions = ~ . %>% dplyr::filter(date < "2016-01-06")
+    ) %>%
+    interrogate()
+  
+  # Expect certain values in `validation$validation_set`
+  expect_equivalent(validation$tbl_name, "small_table")
+  expect_equivalent(validation$validation_set$assertion_type, "rows_complete")
+  expect_true(is.na(validation$validation_set$column %>% unlist()))
+  expect_true(is.null(validation$validation_set[["values"]][[1]]))
+  expect_true(validation$validation_set$all_passed)
+  expect_equivalent(validation$validation_set$n, 3)
+  expect_equivalent(validation$validation_set$n_passed, 3)
+  expect_equivalent(validation$validation_set$n_failed, 0)
+  expect_equivalent(validation$validation_set$f_passed, 1)
+  expect_equivalent(validation$validation_set$f_failed, 0)
+  expect_equivalent(nrow(validation$validation_set), 1)
+  
+  # Use the `rows_complete()` function to create
+  # a validation step for selected columns, then,
+  # `interrogate()`
+  validation <-
+    create_agent(tbl = small_table) %>%
+    rows_complete(columns = vars(date_time, a)) %>%
+    interrogate()
+  
+  # Expect certain values in `validation$validation_set`
+  expect_equivalent(validation$tbl_name, "small_table")
+  expect_equivalent(validation$validation_set$assertion_type, "rows_complete")
+  expect_equivalent(validation$validation_set$column %>% unlist(), "date_time, a")
+  expect_true(is.null(validation$validation_set[["values"]][[1]]))
+  expect_true(validation$validation_set$all_passed)
+  expect_equivalent(validation$validation_set$n, 13)
+  expect_equivalent(validation$validation_set$n_passed, 13)
+  expect_equivalent(validation$validation_set$n_failed, 0)
+  expect_equivalent(validation$validation_set$f_passed, 1)
+  expect_equivalent(validation$validation_set$f_failed, 0)
+  expect_equivalent(nrow(validation$validation_set), 1)
+  
+  # Use the `rows_complete()` function to create
+  # a validation step for columns queried with a
+  # tidyselect statement, then `interrogate()`
+  validation <-
+    create_agent(tbl = small_table) %>%
+    rows_complete(columns = starts_with(c("date", "a"))) %>%
+    interrogate()
+  
+  # Expect certain values in `validation$validation_set`
+  expect_equivalent(validation$tbl_name, "small_table")
+  expect_equivalent(validation$validation_set$assertion_type, "rows_complete")
+  expect_equivalent(validation$validation_set$column %>% unlist(), "date_time, date, a")
+  expect_true(is.null(validation$validation_set[["values"]][[1]]))
+  expect_true(validation$validation_set$all_passed)
+  expect_equivalent(validation$validation_set$n, 13)
+  expect_equivalent(validation$validation_set$n_passed, 13)
+  expect_equivalent(validation$validation_set$n_failed, 0)
+  expect_equivalent(validation$validation_set$f_passed, 1)
+  expect_equivalent(validation$validation_set$f_failed, 0)
+  expect_equivalent(nrow(validation$validation_set), 1)
+  
   #
   # col_vals_in_set()
   #


### PR DESCRIPTION
This change allows for the use of select helpers in the `columns` arg of `rows_distinct()` and `rows_complete()`.

Fixes: https://github.com/rich-iannone/pointblank/issues/414