### PR TITLE
A complete tidyselect integration for the `columns` argument in validation functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,9 @@ Authors@R: c(
     person("Richard", "Iannone", , "rich@posit.co", c("aut", "cre"),
            comment = c(ORCID = "0000-0003-3925-190X")),
     person("Mauricio", "Vargas", , "mavargas11@uc.cl", c("aut"),
-           comment = c(ORCID = "0000-0003-1017-7574"))
+           comment = c(ORCID = "0000-0003-1017-7574")),
+    person("June", "Choe", , "jchoe001@gmail.com", c("aut"),
+           comment = c(ORCID = "0000-0002-0701-921X"))
     )
 License: MIT + file LICENSE
 URL: https://rstudio.github.io/pointblank/, https://github.com/rstudio/pointblank

--- a/R/col_exists.R
+++ b/R/col_exists.R
@@ -234,17 +234,14 @@ col_exists <- function(
     rlang::as_label(rlang::quo(!!enquo(columns))) %>%
     gsub("^\"|\"$", "", .)
   
-  # Normalize the `columns` expression
-  if (inherits(columns, "quosures")) {
-    
-    columns <- 
-      vapply(
-        columns,
-        FUN.VALUE = character(1),
-        USE.NAMES = FALSE,
-        FUN = function(x) as.character(rlang::get_expr(x))
-      )
+  # Capture the `columns` expression
+  columns <- rlang::enquo(columns)
+  if (rlang::quo_is_null(columns)) {
+    columns <- rlang::quo(tidyselect::everything())
   }
+  
+  # Resolve the columns based on the expression
+  columns <- resolve_columns(x = x, var_expr = columns, preconditions = NULL)
 
   if (is_a_table_object(x)) {
     

--- a/R/col_exists.R
+++ b/R/col_exists.R
@@ -289,7 +289,7 @@ col_exists <- function(
         assertion_type = "col_exists",
         i_o = i_o,
         columns_expr = columns_expr,
-        column = tidyselect::all_of(columns[i]),
+        column = columns[i],
         preconditions = NULL,
         actions = covert_actions(actions, agent),
         step_id = step_id[i],

--- a/R/col_exists.R
+++ b/R/col_exists.R
@@ -251,7 +251,7 @@ col_exists <- function(
     secret_agent <- 
       create_agent(x, label = "::QUIET::") %>%
       col_exists(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         actions = prime_actions(actions),
         label = label,
         brief = brief,
@@ -289,7 +289,7 @@ col_exists <- function(
         assertion_type = "col_exists",
         i_o = i_o,
         columns_expr = columns_expr,
-        column = columns[i],
+        column = tidyselect::all_of(columns[i]),
         preconditions = NULL,
         actions = covert_actions(actions, agent),
         step_id = step_id[i],

--- a/R/col_exists.R
+++ b/R/col_exists.R
@@ -241,7 +241,11 @@ col_exists <- function(
   }
   
   # Resolve the columns based on the expression
-  columns <- resolve_columns(x = x, var_expr = columns, preconditions = NULL)
+  ## Only for `col_exists()`: error gracefully if column not found
+  columns <- tryCatch(
+    expr = resolve_columns(x = x, var_expr = columns, preconditions = NULL),
+    error = function(cnd) cnd$i %||% NA_character_
+  )
 
   if (is_a_table_object(x)) {
     

--- a/R/col_is_character.R
+++ b/R/col_is_character.R
@@ -282,7 +282,7 @@ col_is_character <- function(
         assertion_type = "col_is_character",
         i_o = i_o,
         columns_expr = columns_expr,
-        column = tidyselect::all_of(columns[i]),
+        column = columns[i],
         preconditions = NULL,
         actions = covert_actions(actions, agent),
         step_id = step_id[i],

--- a/R/col_is_character.R
+++ b/R/col_is_character.R
@@ -242,7 +242,7 @@ col_is_character <- function(
     secret_agent <- 
       create_agent(x, label = "::QUIET::") %>%
       col_is_character(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         label = label,
         brief = brief,
         actions = prime_actions(actions),
@@ -282,7 +282,7 @@ col_is_character <- function(
         assertion_type = "col_is_character",
         i_o = i_o,
         columns_expr = columns_expr,
-        column = columns[i],
+        column = tidyselect::all_of(columns[i]),
         preconditions = NULL,
         actions = covert_actions(actions, agent),
         step_id = step_id[i],

--- a/R/col_is_date.R
+++ b/R/col_is_date.R
@@ -274,7 +274,7 @@ col_is_date <- function(
         assertion_type = "col_is_date",
         i_o = i_o,
         columns_expr = columns_expr,
-        column = tidyselect::all_of(columns[i]),
+        column = columns[i],
         preconditions = NULL,
         actions = covert_actions(actions, agent),
         step_id = step_id[i],

--- a/R/col_is_date.R
+++ b/R/col_is_date.R
@@ -234,7 +234,7 @@ col_is_date <- function(
     secret_agent <- 
       create_agent(x, label = "::QUIET::") %>%
       col_is_date(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         label = label,
         brief = brief,
         actions = prime_actions(actions),
@@ -274,7 +274,7 @@ col_is_date <- function(
         assertion_type = "col_is_date",
         i_o = i_o,
         columns_expr = columns_expr,
-        column = columns[i],
+        column = tidyselect::all_of(columns[i]),
         preconditions = NULL,
         actions = covert_actions(actions, agent),
         step_id = step_id[i],

--- a/R/col_is_factor.R
+++ b/R/col_is_factor.R
@@ -240,7 +240,7 @@ col_is_factor <- function(
     secret_agent <- 
       create_agent(x, label = "::QUIET::") %>%
       col_is_factor(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         label = label,
         brief = brief,
         actions = prime_actions(actions),
@@ -280,7 +280,7 @@ col_is_factor <- function(
         assertion_type = "col_is_factor",
         i_o = i_o,
         columns_expr = columns_expr,
-        column = columns[i],
+        column = tidyselect::all_of(columns[i]),
         preconditions = NULL,
         actions = covert_actions(actions, agent),
         step_id = step_id[i],

--- a/R/col_is_factor.R
+++ b/R/col_is_factor.R
@@ -280,7 +280,7 @@ col_is_factor <- function(
         assertion_type = "col_is_factor",
         i_o = i_o,
         columns_expr = columns_expr,
-        column = tidyselect::all_of(columns[i]),
+        column = columns[i],
         preconditions = NULL,
         actions = covert_actions(actions, agent),
         step_id = step_id[i],

--- a/R/col_is_integer.R
+++ b/R/col_is_integer.R
@@ -278,7 +278,7 @@ col_is_integer <- function(
         assertion_type = "col_is_integer",
         i_o = i_o,
         columns_expr = columns_expr,
-        column = tidyselect::all_of(columns[i]),
+        column = columns[i],
         preconditions = NULL,
         actions = covert_actions(actions, agent),
         step_id = step_id[i],

--- a/R/col_is_integer.R
+++ b/R/col_is_integer.R
@@ -238,7 +238,7 @@ col_is_integer <- function(
     secret_agent <- 
       create_agent(x, label = "::QUIET::") %>%
       col_is_integer(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         label = label,
         brief = brief,
         actions = prime_actions(actions),
@@ -278,7 +278,7 @@ col_is_integer <- function(
         assertion_type = "col_is_integer",
         i_o = i_o,
         columns_expr = columns_expr,
-        column = columns[i],
+        column = tidyselect::all_of(columns[i]),
         preconditions = NULL,
         actions = covert_actions(actions, agent),
         step_id = step_id[i],

--- a/R/col_is_logical.R
+++ b/R/col_is_logical.R
@@ -235,7 +235,7 @@ col_is_logical <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_is_logical(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         label = label,
         brief = brief,
         actions = prime_actions(actions),
@@ -275,7 +275,7 @@ col_is_logical <- function(
         assertion_type = "col_is_logical",
         i_o = i_o,
         columns_expr = columns_expr,
-        column = columns[i],
+        column = tidyselect::all_of(columns[i]),
         preconditions = NULL,
         actions = covert_actions(actions, agent),
         step_id = step_id[i],

--- a/R/col_is_logical.R
+++ b/R/col_is_logical.R
@@ -275,7 +275,7 @@ col_is_logical <- function(
         assertion_type = "col_is_logical",
         i_o = i_o,
         columns_expr = columns_expr,
-        column = tidyselect::all_of(columns[i]),
+        column = columns[i],
         preconditions = NULL,
         actions = covert_actions(actions, agent),
         step_id = step_id[i],

--- a/R/col_is_numeric.R
+++ b/R/col_is_numeric.R
@@ -235,7 +235,7 @@ col_is_numeric <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_is_numeric(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         label = label,
         brief = brief,
         actions = prime_actions(actions),
@@ -275,7 +275,7 @@ col_is_numeric <- function(
         assertion_type = "col_is_numeric",
         i_o = i_o,
         columns_expr = columns_expr,
-        column = columns[i],
+        column = tidyselect::all_of(columns[i]),
         preconditions = NULL,
         actions = covert_actions(actions, agent),
         step_id = step_id[i],

--- a/R/col_is_numeric.R
+++ b/R/col_is_numeric.R
@@ -275,7 +275,7 @@ col_is_numeric <- function(
         assertion_type = "col_is_numeric",
         i_o = i_o,
         columns_expr = columns_expr,
-        column = tidyselect::all_of(columns[i]),
+        column = columns[i],
         preconditions = NULL,
         actions = covert_actions(actions, agent),
         step_id = step_id[i],

--- a/R/col_is_posix.R
+++ b/R/col_is_posix.R
@@ -235,7 +235,7 @@ col_is_posix <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_is_posix(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         label = label,
         brief = brief,
         actions = prime_actions(actions),
@@ -275,7 +275,7 @@ col_is_posix <- function(
         assertion_type = "col_is_posix",
         i_o = i_o,
         columns_expr = columns_expr,
-        column = columns[i],
+        column = tidyselect::all_of(columns[i]),
         preconditions = NULL,
         actions = covert_actions(actions, agent),
         step_id = step_id[i],

--- a/R/col_is_posix.R
+++ b/R/col_is_posix.R
@@ -275,7 +275,7 @@ col_is_posix <- function(
         assertion_type = "col_is_posix",
         i_o = i_o,
         columns_expr = columns_expr,
-        column = tidyselect::all_of(columns[i]),
+        column = columns[i],
         preconditions = NULL,
         actions = covert_actions(actions, agent),
         step_id = step_id[i],

--- a/R/col_vals_between.R
+++ b/R/col_vals_between.R
@@ -393,7 +393,7 @@ col_vals_between <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_vals_between(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         left = left,
         right = right,
         inclusive = inclusive,
@@ -448,7 +448,7 @@ col_vals_between <- function(
           assertion_type = "col_vals_between",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = columns[i],
+          column = tidyselect::all_of(columns[i]),
           values = c(left, right),
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_between.R
+++ b/R/col_vals_between.R
@@ -448,7 +448,7 @@ col_vals_between <- function(
           assertion_type = "col_vals_between",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = tidyselect::all_of(columns[i]),
+          column = columns[i],
           values = c(left, right),
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_decreasing.R
+++ b/R/col_vals_decreasing.R
@@ -379,7 +379,7 @@ col_vals_decreasing <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_vals_decreasing(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         allow_stationary = allow_stationary,
         increasing_tol = increasing_tol,
         na_pass = na_pass,
@@ -433,7 +433,7 @@ col_vals_decreasing <- function(
           assertion_type = "col_vals_decreasing",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = columns[i],
+          column = tidyselect::all_of(columns[i]),
           values = stat_tol,
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_decreasing.R
+++ b/R/col_vals_decreasing.R
@@ -433,7 +433,7 @@ col_vals_decreasing <- function(
           assertion_type = "col_vals_decreasing",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = tidyselect::all_of(columns[i]),
+          column = columns[i],
           values = stat_tol,
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_equal.R
+++ b/R/col_vals_equal.R
@@ -385,7 +385,7 @@ col_vals_equal <- function(
           assertion_type = "col_vals_equal",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = tidyselect::all_of(columns[i]),
+          column = columns[i],
           values = value,
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_equal.R
+++ b/R/col_vals_equal.R
@@ -332,7 +332,7 @@ col_vals_equal <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_vals_equal(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         value = value,
         na_pass = na_pass,
         preconditions = preconditions,
@@ -385,7 +385,7 @@ col_vals_equal <- function(
           assertion_type = "col_vals_equal",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = columns[i],
+          column = tidyselect::all_of(columns[i]),
           values = value,
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_gt.R
+++ b/R/col_vals_gt.R
@@ -452,7 +452,7 @@ col_vals_gt <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_vals_gt(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         value = value,
         na_pass = na_pass,
         preconditions = preconditions,
@@ -505,7 +505,7 @@ col_vals_gt <- function(
           assertion_type = "col_vals_gt",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = columns[i],
+          column = tidyselect::all_of(columns[i]),
           values = value,
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_gt.R
+++ b/R/col_vals_gt.R
@@ -505,7 +505,7 @@ col_vals_gt <- function(
           assertion_type = "col_vals_gt",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = tidyselect::all_of(columns[i]),
+          column = columns[i],
           values = value,
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_gte.R
+++ b/R/col_vals_gte.R
@@ -384,7 +384,7 @@ col_vals_gte <- function(
           assertion_type = "col_vals_gte",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = tidyselect::all_of(columns[i]),
+          column = columns[i],
           values = value,
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_gte.R
+++ b/R/col_vals_gte.R
@@ -331,7 +331,7 @@ col_vals_gte <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_vals_gte(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         value = value,
         na_pass = na_pass,
         preconditions = preconditions,
@@ -384,7 +384,7 @@ col_vals_gte <- function(
           assertion_type = "col_vals_gte",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = columns[i],
+          column = tidyselect::all_of(columns[i]),
           values = value,
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_in_set.R
+++ b/R/col_vals_in_set.R
@@ -325,7 +325,7 @@ col_vals_in_set <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_vals_in_set(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         set = set,
         preconditions = preconditions,
         segments = segments,
@@ -377,7 +377,7 @@ col_vals_in_set <- function(
           assertion_type = "col_vals_in_set",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = columns[i],
+          column = tidyselect::all_of(columns[i]),
           values = set,
           preconditions = preconditions,
           seg_expr = segments,

--- a/R/col_vals_in_set.R
+++ b/R/col_vals_in_set.R
@@ -377,7 +377,7 @@ col_vals_in_set <- function(
           assertion_type = "col_vals_in_set",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = tidyselect::all_of(columns[i]),
+          column = columns[i],
           values = set,
           preconditions = preconditions,
           seg_expr = segments,

--- a/R/col_vals_increasing.R
+++ b/R/col_vals_increasing.R
@@ -421,7 +421,7 @@ col_vals_increasing <- function(
           assertion_type = "col_vals_increasing",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = tidyselect::all_of(columns[i]),
+          column = columns[i],
           values = stat_tol,
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_increasing.R
+++ b/R/col_vals_increasing.R
@@ -367,7 +367,7 @@ col_vals_increasing <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_vals_increasing(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         allow_stationary = allow_stationary,
         decreasing_tol = decreasing_tol,
         na_pass = na_pass,
@@ -421,7 +421,7 @@ col_vals_increasing <- function(
           assertion_type = "col_vals_increasing",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = columns[i],
+          column = tidyselect::all_of(columns[i]),
           values = stat_tol,
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_lt.R
+++ b/R/col_vals_lt.R
@@ -386,7 +386,7 @@ col_vals_lt <- function(
           assertion_type = "col_vals_lt",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = tidyselect::all_of(columns[i]),
+          column = columns[i],
           values = value,
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_lt.R
+++ b/R/col_vals_lt.R
@@ -333,7 +333,7 @@ col_vals_lt <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_vals_lt(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         value = value,
         na_pass = na_pass,
         preconditions = preconditions,
@@ -386,7 +386,7 @@ col_vals_lt <- function(
           assertion_type = "col_vals_lt",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = columns[i],
+          column = tidyselect::all_of(columns[i]),
           values = value,
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_lte.R
+++ b/R/col_vals_lte.R
@@ -334,7 +334,7 @@ col_vals_lte <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_vals_lte(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         value = value,
         na_pass = na_pass,
         preconditions = preconditions,
@@ -387,7 +387,7 @@ col_vals_lte <- function(
           assertion_type = "col_vals_lte",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = columns[i],
+          column = tidyselect::all_of(columns[i]),
           values = value,
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_lte.R
+++ b/R/col_vals_lte.R
@@ -387,7 +387,7 @@ col_vals_lte <- function(
           assertion_type = "col_vals_lte",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = tidyselect::all_of(columns[i]),
+          column = columns[i],
           values = value,
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_make_set.R
+++ b/R/col_vals_make_set.R
@@ -327,7 +327,7 @@ col_vals_make_set <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_vals_make_set(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         set = set,
         preconditions = preconditions,
         segments = segments,
@@ -379,7 +379,7 @@ col_vals_make_set <- function(
           assertion_type = "col_vals_make_set",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = columns[i],
+          column = tidyselect::all_of(columns[i]),
           values = set,
           preconditions = preconditions,
           seg_expr = segments,

--- a/R/col_vals_make_set.R
+++ b/R/col_vals_make_set.R
@@ -379,7 +379,7 @@ col_vals_make_set <- function(
           assertion_type = "col_vals_make_set",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = tidyselect::all_of(columns[i]),
+          column = columns[i],
           values = set,
           preconditions = preconditions,
           seg_expr = segments,

--- a/R/col_vals_make_subset.R
+++ b/R/col_vals_make_subset.R
@@ -376,7 +376,7 @@ col_vals_make_subset <- function(
           assertion_type = "col_vals_make_subset",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = tidyselect::all_of(columns[i]),
+          column = columns[i],
           values = set,
           preconditions = preconditions,
           seg_expr = segments,

--- a/R/col_vals_make_subset.R
+++ b/R/col_vals_make_subset.R
@@ -324,7 +324,7 @@ col_vals_make_subset <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_vals_make_subset(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         set = set,
         preconditions = preconditions,
         segments = segments,
@@ -376,7 +376,7 @@ col_vals_make_subset <- function(
           assertion_type = "col_vals_make_subset",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = columns[i],
+          column = tidyselect::all_of(columns[i]),
           values = set,
           preconditions = preconditions,
           seg_expr = segments,

--- a/R/col_vals_not_between.R
+++ b/R/col_vals_not_between.R
@@ -451,7 +451,7 @@ col_vals_not_between <- function(
           assertion_type = "col_vals_not_between",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = tidyselect::all_of(columns[i]),
+          column = columns[i],
           values = c(left, right),
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_not_between.R
+++ b/R/col_vals_not_between.R
@@ -396,7 +396,7 @@ col_vals_not_between <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_vals_not_between(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         left = left,
         right = right,
         inclusive = inclusive,
@@ -451,7 +451,7 @@ col_vals_not_between <- function(
           assertion_type = "col_vals_not_between",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = columns[i],
+          column = tidyselect::all_of(columns[i]),
           values = c(left, right),
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_not_equal.R
+++ b/R/col_vals_not_equal.R
@@ -384,7 +384,7 @@ col_vals_not_equal <- function(
           assertion_type = "col_vals_not_equal",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = tidyselect::all_of(columns[i]),
+          column = columns[i],
           values = value,
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_not_equal.R
+++ b/R/col_vals_not_equal.R
@@ -331,7 +331,7 @@ col_vals_not_equal <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_vals_not_equal(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         value = value,
         na_pass = na_pass,
         preconditions = preconditions,
@@ -384,7 +384,7 @@ col_vals_not_equal <- function(
           assertion_type = "col_vals_not_equal",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = columns[i],
+          column = tidyselect::all_of(columns[i]),
           values = value,
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_not_in_set.R
+++ b/R/col_vals_not_in_set.R
@@ -321,7 +321,7 @@ col_vals_not_in_set <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_vals_not_in_set(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         set = set,
         preconditions = preconditions,
         segments = segments,
@@ -373,7 +373,7 @@ col_vals_not_in_set <- function(
           assertion_type = "col_vals_not_in_set",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = columns[i],
+          column = tidyselect::all_of(columns[i]),
           values = set,
           preconditions = preconditions,
           seg_expr = segments,

--- a/R/col_vals_not_in_set.R
+++ b/R/col_vals_not_in_set.R
@@ -373,7 +373,7 @@ col_vals_not_in_set <- function(
           assertion_type = "col_vals_not_in_set",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = tidyselect::all_of(columns[i]),
+          column = columns[i],
           values = set,
           preconditions = preconditions,
           seg_expr = segments,

--- a/R/col_vals_not_null.R
+++ b/R/col_vals_not_null.R
@@ -363,7 +363,7 @@ col_vals_not_null <- function(
           assertion_type = "col_vals_not_null",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = tidyselect::all_of(columns[i]),
+          column = columns[i],
           preconditions = preconditions,
           seg_expr = segments,
           seg_col = seg_col,

--- a/R/col_vals_not_null.R
+++ b/R/col_vals_not_null.R
@@ -312,7 +312,7 @@ col_vals_not_null <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_vals_not_null(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         preconditions = preconditions,
         segments = segments,
         label = label,
@@ -363,7 +363,7 @@ col_vals_not_null <- function(
           assertion_type = "col_vals_not_null",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = columns[i],
+          column = tidyselect::all_of(columns[i]),
           preconditions = preconditions,
           seg_expr = segments,
           seg_col = seg_col,

--- a/R/col_vals_null.R
+++ b/R/col_vals_null.R
@@ -362,7 +362,7 @@ col_vals_null <- function(
           assertion_type = "col_vals_null",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = tidyselect::all_of(columns[i]),
+          column = columns[i],
           preconditions = preconditions,
           seg_expr = segments,
           seg_col = seg_col,

--- a/R/col_vals_null.R
+++ b/R/col_vals_null.R
@@ -311,7 +311,7 @@ col_vals_null <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_vals_null(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         preconditions = preconditions,
         segments = segments,
         label = label,
@@ -362,7 +362,7 @@ col_vals_null <- function(
           assertion_type = "col_vals_null",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = columns[i],
+          column = tidyselect::all_of(columns[i]),
           preconditions = preconditions,
           seg_expr = segments,
           seg_col = seg_col,

--- a/R/col_vals_regex.R
+++ b/R/col_vals_regex.R
@@ -378,7 +378,7 @@ col_vals_regex <- function(
           assertion_type = "col_vals_regex",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = tidyselect::all_of(columns[i]),
+          column = columns[i],
           values = regex,
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_regex.R
+++ b/R/col_vals_regex.R
@@ -325,7 +325,7 @@ col_vals_regex <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_vals_regex(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         regex = regex,
         na_pass = na_pass,
         preconditions = preconditions,
@@ -378,7 +378,7 @@ col_vals_regex <- function(
           assertion_type = "col_vals_regex",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = columns[i],
+          column = tidyselect::all_of(columns[i]),
           values = regex,
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_within_spec.R
+++ b/R/col_vals_within_spec.R
@@ -443,7 +443,7 @@ col_vals_within_spec <- function(
           assertion_type = "col_vals_within_spec",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = tidyselect::all_of(columns[i]),
+          column = columns[i],
           values = spec,
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/col_vals_within_spec.R
+++ b/R/col_vals_within_spec.R
@@ -390,7 +390,7 @@ col_vals_within_spec <- function(
     secret_agent <-
       create_agent(x, label = "::QUIET::") %>%
       col_vals_within_spec(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         spec = spec,
         na_pass = na_pass,
         preconditions = preconditions,
@@ -443,7 +443,7 @@ col_vals_within_spec <- function(
           assertion_type = "col_vals_within_spec",
           i_o = i_o,
           columns_expr = columns_expr,
-          column = columns[i],
+          column = tidyselect::all_of(columns[i]),
           values = spec,
           na_pass = na_pass,
           preconditions = preconditions,

--- a/R/rows_complete.R
+++ b/R/rows_complete.R
@@ -278,21 +278,12 @@ rows_complete <- function(
   
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
-  
-  if (uses_tidyselect(expr_text = columns_expr)) {
-    
-    # Resolve the columns based on the expression
-    columns <- resolve_columns(x = x, var_expr = columns, preconditions = NULL)
-    
-  } else {
-    
-    # Resolve the columns based on the expression
-    if (!is.null(rlang::eval_tidy(columns)) && !is.null(columns)) {
-      columns <- resolve_columns(x = x, var_expr = columns, preconditions)
-    } else {
-      columns <- NULL
-    }
+  if (rlang::quo_is_null(columns)) {
+    columns <- rlang::quo(tidyselect::everything())
   }
+  
+  # Resolve the columns based on the expression
+  columns <- resolve_columns(x = x, var_expr = columns, preconditions = NULL)
   
   # Resolve segments into list
   segments_list <-

--- a/R/rows_complete.R
+++ b/R/rows_complete.R
@@ -298,7 +298,7 @@ rows_complete <- function(
     secret_agent <- 
       create_agent(x, label = "::QUIET::") %>%
       rows_complete(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         preconditions = preconditions,
         segments = segments,
         label = label,

--- a/R/rows_distinct.R
+++ b/R/rows_distinct.R
@@ -280,20 +280,8 @@ rows_distinct <- function(
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
   
-  if (uses_tidyselect(expr_text = columns_expr)) {
-    
-    # Resolve the columns based on the expression
-    columns <- resolve_columns(x = x, var_expr = columns, preconditions = NULL)
-    
-  } else {
-    
-    # Resolve the columns based on the expression
-    if (!is.null(rlang::eval_tidy(columns)) && !is.null(columns)) {
-      columns <- resolve_columns(x = x, var_expr = columns, preconditions)
-    } else {
-      columns <- NULL
-    }
-  }
+  # Resolve the columns based on the expression
+  columns <- resolve_columns(x = x, var_expr = columns, preconditions = NULL)
   
   # Resolve segments into list
   segments_list <-

--- a/R/rows_distinct.R
+++ b/R/rows_distinct.R
@@ -279,8 +279,8 @@ rows_distinct <- function(
   
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
-  if (is.null(rlang::quo_get_expr(columns))) {
-    columns <- rlang::new_quosure(rlang::expr(tidyselect::everything()))
+  if (rlang::quo_is_null(columns)) {
+    columns <- rlang::quo(tidyselect::everything())
   }
   
   # Resolve the columns based on the expression

--- a/R/rows_distinct.R
+++ b/R/rows_distinct.R
@@ -296,7 +296,7 @@ rows_distinct <- function(
     secret_agent <- 
       create_agent(x, label = "::QUIET::") %>%
       rows_distinct(
-        columns = columns,
+        columns = tidyselect::all_of(columns),
         preconditions = preconditions,
         segments = segments,
         label = label,

--- a/R/rows_distinct.R
+++ b/R/rows_distinct.R
@@ -279,6 +279,9 @@ rows_distinct <- function(
   
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  if (is.null(rlang::quo_get_expr(columns))) {
+    columns <- rlang::new_quosure(rlang::expr(tidyselect::everything()))
+  }
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions = NULL)

--- a/R/scan_data.R
+++ b/R/scan_data.R
@@ -1041,7 +1041,7 @@ probe_columns_numeric <- function(
     locale
 ) {
   
-  data_column <- dplyr::select(data, {{ column }})
+  data_column <- dplyr::select(data, tidyselect::any_of(column))
   
   column_description_gt <- 
     get_column_description_gt(
@@ -1133,7 +1133,7 @@ probe_columns_character <- function(
     locale
 ) {
   
-  data_column <- data %>% dplyr::select({{ column }})
+  data_column <- data %>% dplyr::select(tidyselect::any_of(column))
   
   column_description_gt <- 
     get_column_description_gt(
@@ -1184,7 +1184,7 @@ probe_columns_logical <- function(
     locale
 ) {
   
-  data_column <- data %>% dplyr::select({{ column }})
+  data_column <- data %>% dplyr::select(tidyselect::any_of(column))
   
   column_description_gt <- 
     get_column_description_gt(
@@ -1211,7 +1211,7 @@ probe_columns_factor <- function(
     locale
 ) {
   
-  data_column <- data %>% dplyr::select({{ column }})
+  data_column <- data %>% dplyr::select(tidyselect::any_of(column))
   
   column_description_gt <- 
     get_column_description_gt(
@@ -1238,7 +1238,7 @@ probe_columns_date <- function(
     locale
 ) {
   
-  data_column <- data %>% dplyr::select({{ column }})
+  data_column <- data %>% dplyr::select(tidyselect::any_of(column))
   
   column_description_gt <- 
     get_column_description_gt(
@@ -1265,7 +1265,7 @@ probe_columns_posix <- function(
     locale
 ) {
   
-  data_column <- data %>% dplyr::select({{ column }})
+  data_column <- data %>% dplyr::select(tidyselect::any_of(column))
   
   column_description_gt <- 
     get_column_description_gt(
@@ -1290,7 +1290,7 @@ probe_columns_other <- function(
     n_rows
 ) {
   
-  data_column <- data %>% dplyr::select({{ column }})
+  data_column <- data %>% dplyr::select(tidyselect::any_of(column))
   
   column_classes <- paste(class(data_column), collapse = ", ")
   

--- a/R/table_transformers.R
+++ b/R/table_transformers.R
@@ -161,7 +161,7 @@ tt_summary_stats <- function(tbl) {
     
     if (r_col_types[i] %in% c("integer", "numeric")) {
       
-      data_col <- dplyr::select(tbl, col_names[i])
+      data_col <- dplyr::select(tbl, tidyselect::all_of(col_names[i]))
       
       # nocov start
       
@@ -286,7 +286,7 @@ tt_string_info <- function(tbl) {
     
     if (r_col_types[i] == "character") {
       
-      data_col <- dplyr::select(tbl, col_names[i])
+      data_col <- dplyr::select(tbl, tidyselect::all_of(col_names[i]))
       
       suppressWarnings({
         info_list <- get_table_column_nchar_stats(data_column = data_col)
@@ -585,7 +585,7 @@ tt_time_shift <- function(
         tbl %>%
         dplyr::mutate(
           dplyr::across(
-            .cols = time_columns,
+            .cols = tidyselect::all_of(time_columns),
             .fns = ~ lubridate::days(n_days) + .
           )
         )
@@ -596,7 +596,7 @@ tt_time_shift <- function(
         tbl %>%
         dplyr::mutate(
           dplyr::across(
-            .cols = time_columns,
+            .cols = tidyselect::all_of(time_columns),
             .fns = ~ time_shift + .
           )
         )
@@ -645,7 +645,7 @@ tt_time_shift <- function(
           tbl %>%
           dplyr::mutate(
             dplyr::across(
-              .cols = time_columns,
+              .cols = tidyselect::all_of(time_columns),
               .fns = ~ fn_time(time_value * direction_val) + .)
           )
       }

--- a/R/table_transformers.R
+++ b/R/table_transformers.R
@@ -1058,9 +1058,9 @@ get_tt_param <- function(
     # Obtain the value from the `tbl` through a `select()`, `filter()`, `pull()`
     param_value <-
       tbl %>%
-      dplyr::select(.param., .env$column) %>%
+      dplyr::select(.param., tidyselect::all_of(column)) %>%
       dplyr::filter(.param. == .env$param) %>%
-      dplyr::pull(.env$column)
+      dplyr::pull(tidyselect::all_of(column))
     
   } else if (tt_type == "tbl_dims") {
     

--- a/R/utils.R
+++ b/R/utils.R
@@ -225,10 +225,15 @@ resolve_columns <- function(x, var_expr, preconditions, ..., call = rlang::calle
     return(character(NA_character_))
   }
   
-  # Extract tbl and apply preconditions
-  tbl <- if (is_ptblank_agent(x)) get_tbl_object(x) else x
+  # Extract tbl
+  tbl <- if (is_ptblank_agent(x)) {
+    get_tbl_object(x)
+  } else if (is_a_table_object(x)) {
+    x
+  }
+  # Apply preconditions
   if (!is.null(preconditions)) {
-    tbl <- apply_preconditions(tbl = x, preconditions = preconditions)
+    tbl <- apply_preconditions(tbl = tbl, preconditions = preconditions)
   }
   
   # Revised column selection logic

--- a/R/utils.R
+++ b/R/utils.R
@@ -237,11 +237,9 @@ resolve_columns <- function(x, var_expr, preconditions, ..., call = rlang::calle
   # Revised column selection logic
   ## Special case `vars()`-style enquo-ing and implement backwards compatibility
   if (rlang::is_call(col_expr, "vars")) {
-    col_syms <- rlang::call_args(col_expr)
-    # Turn it into `c(...)` expression and forward to tidyselect
-    col_c_expr <- rlang::call2("c", !!!col_syms)
-    column <- tidyselect::eval_select(col_c_expr, tbl, error_call = call)
-    column <- names(column)
+    cols <- rlang::call_args(col_expr)
+    # Deparse into character vector
+    column <- vapply(cols, rlang::as_name, character(1), USE.NAMES = FALSE)
   } else {
     ## Else, proceed with the assumption that user supplied a {tidyselect} expression
     column <- tidyselect::eval_select(col_expr, tbl, error_call = call)

--- a/R/utils.R
+++ b/R/utils.R
@@ -235,7 +235,8 @@ resolve_columns <- function(x, var_expr, preconditions) {
       rlang::cnd_signal(out)
     } else {
       # Else (if building up validations): return columns attempted to subset
-      out$i
+      # or NA if none
+      out$i %||% NA_character_
     }
   } else {
     out

--- a/R/utils.R
+++ b/R/utils.R
@@ -231,9 +231,6 @@ resolve_columns <- function(x, var_expr, preconditions, ..., call = rlang::calle
     tbl <- apply_preconditions(tbl = x, preconditions = preconditions)
   }
   
-  # For simplicity, get the expression out of the quosure
-  col_expr <- rlang::quo_get_expr(var_expr)
-  
   # Revised column selection logic
   ## Special case `vars()`-style enquo-ing and implement backwards compatibility
   if (rlang::is_call(col_expr, "vars")) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -345,7 +345,7 @@ resolve_segments <- function(x, seg_expr, preconditions) {
         
         col_seg_vals <- 
           tbl %>%
-          dplyr::select(.env$column_name) %>%
+          dplyr::select(tidyselect::all_of(column_name)) %>%
           dplyr::distinct() %>%
           dplyr::pull()
         

--- a/R/utils.R
+++ b/R/utils.R
@@ -221,7 +221,7 @@ materialize_table <- function(tbl, check = TRUE) {
 resolve_columns <- function(x, var_expr, preconditions, ..., call = rlang::caller_env()) {
   
   # Return an empty character vector if the expr is NULL
-  if (is.null(var_expr)) {
+  if (is.null(rlang::quo_get_expr(var_expr))) {
     return(character(NA_character_))
   }
   
@@ -251,13 +251,11 @@ resolve_columns <- function(x, var_expr, preconditions, ..., call = rlang::calle
       column <- tidyselect::eval_select(col_c_expr, tbl, error_call = call)
       column <- names(column)
     }
-    # column <- vapply(cols, rlang::as_name, character(1), USE.NAMES = FALSE)
   } else {
     ## Else, proceed with the assumption that user supplied a {tidyselect} expression
     column <- tidyselect::eval_select(var_expr, tbl, error_call = call)
     column <- names(column)
   }
-  # Just the names of the tidy-selected columns
   
   if (length(column) < 1) {
     column <- NA_character_

--- a/R/utils.R
+++ b/R/utils.R
@@ -221,7 +221,7 @@ materialize_table <- function(tbl, check = TRUE) {
 resolve_columns <- function(x, var_expr, preconditions, ..., call = rlang::caller_env()) {
   
   # Return an empty character vector if the expr is NULL
-  if (is.null(rlang::quo_get_expr(var_expr))) {
+  if (rlang::quo_is_null(var_expr)) {
     return(character(NA_character_))
   }
   

--- a/R/utils.R
+++ b/R/utils.R
@@ -233,13 +233,13 @@ resolve_columns <- function(x, var_expr, preconditions, ..., call = rlang::calle
   
   # Revised column selection logic
   ## Special case `vars()`-style enquo-ing and implement backwards compatibility
-  if (rlang::is_call(col_expr, "vars")) {
-    cols <- rlang::call_args(col_expr)
+  if (rlang::is_call(rlang::quo_get_expr(var_expr), "vars")) {
+    cols <- rlang::call_args(var_expr)
     # Deparse into character vector
     column <- vapply(cols, rlang::as_name, character(1), USE.NAMES = FALSE)
   } else {
     ## Else, proceed with the assumption that user supplied a {tidyselect} expression
-    column <- tidyselect::eval_select(col_expr, tbl, error_call = call)
+    column <- tidyselect::eval_select(var_expr, tbl, error_call = call)
     column <- names(column)
   }
   

--- a/R/utils.R
+++ b/R/utils.R
@@ -218,7 +218,8 @@ materialize_table <- function(tbl, check = TRUE) {
   tbl
 }
 
-resolve_columns <- function(x, var_expr, preconditions, ..., call = rlang::caller_env()) {
+resolve_columns <- function(x, var_expr, preconditions, ...,
+                            call = rlang::caller_env()) {
   
   # Return an empty character vector if the expr is NULL
   if (rlang::quo_is_null(var_expr)) {
@@ -237,14 +238,15 @@ resolve_columns <- function(x, var_expr, preconditions, ..., call = rlang::calle
   }
   
   # Revised column selection logic
-  ## Special case `vars()`-style enquo-ing and implement backwards compatibility
+  ## Special case `vars()`-expression for backwards compatibility
   if (rlang::quo_is_call(var_expr, "vars")) {
     cols <- rlang::call_args(var_expr)
     # Ensure elements are symbols
     col_syms <- rlang::syms(cols)
     if (rlang::is_empty(tbl)) {
-      # Special-case `serially()` - just deparse elements and don't test for existence
-      column <- vapply(col_syms, rlang::as_name, character(1), USE.NAMES = FALSE)
+      # Special-case `serially()` - just deparse elements and bypass tidyselect
+      column <- vapply(col_syms, rlang::as_name, character(1),
+                       USE.NAMES = FALSE)
     } else {
       # Convert to the idiomatic `c()`-expr
       col_c_expr <- rlang::call2("c", !!!col_syms)
@@ -252,7 +254,7 @@ resolve_columns <- function(x, var_expr, preconditions, ..., call = rlang::calle
       column <- names(column)
     }
   } else {
-    ## Else, proceed with the assumption that user supplied a {tidyselect} expression
+    ## Else, assume that the user supplied a valid tidyselect expression
     column <- tidyselect::eval_select(var_expr, tbl, error_call = call)
     column <- names(column)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -238,9 +238,9 @@ resolve_columns <- function(x, var_expr, preconditions, ..., call = rlang::calle
   
   # Revised column selection logic
   ## Special case `vars()`-style enquo-ing and implement backwards compatibility
-  if (rlang::is_call(rlang::quo_get_expr(var_expr), "vars")) {
+  if (rlang::quo_is_call(var_expr, "vars")) {
     cols <- rlang::call_args(var_expr)
-    # Deparse into character vector
+    # Ensure elements are symbols
     col_syms <- rlang::syms(cols)
     if (rlang::is_empty(tbl)) {
       # Special-case `serially()` - just deparse elements and don't test for existence

--- a/R/utils.R
+++ b/R/utils.R
@@ -902,7 +902,7 @@ get_tbl_information_dbi <- function(tbl) {
           DBI::dbDataType(
             tbl_connection,
             tbl %>%
-              dplyr::select(x) %>%
+              dplyr::select(tidyselect::all_of(x)) %>%
               utils::head(1) %>%
               dplyr::collect() %>%
               dplyr::pull(x)

--- a/R/utils.R
+++ b/R/utils.R
@@ -246,9 +246,9 @@ resolve_columns <- function(x, var_expr, preconditions) {
 
 resolve_columns_internal <- function(x, var_expr, preconditions) {
   
-  # Return an empty character vector if the expr is NULL
+  # Return NA if the expr is NULL
   if (rlang::quo_is_null(var_expr)) {
-    return(character(NA_character_))
+    return(NA_character_)
   }
   
   # Extract tbl

--- a/R/utils.R
+++ b/R/utils.R
@@ -224,6 +224,8 @@ is_secret_agent <- function(x) {
 
 resolve_columns <- function(x, var_expr, preconditions) {
   
+  force(x) # To avoid `restarting interrupted promise evaluation` warnings
+  
   out <- tryCatch(
     expr = resolve_columns_internal(x, var_expr, preconditions),
     error = function(cnd) cnd
@@ -234,8 +236,7 @@ resolve_columns <- function(x, var_expr, preconditions) {
     if (is_a_table_object(x) || is_secret_agent(x)) {
       rlang::cnd_signal(out)
     } else {
-      # Else (if building up validations): return columns attempted to subset
-      # or NA if none
+      # Else (mid-planning): return columns attempted to subset or NA if empty
       out$i %||% NA_character_
     }
   } else {

--- a/tests/testthat/test-create_validation_steps.R
+++ b/tests/testthat/test-create_validation_steps.R
@@ -1036,7 +1036,7 @@ test_that("Creating a `rows_distinct()` step is possible", {
   expect_equivalent(validation$tbl_name, "small_table")
   expect_equivalent(validation$col_names, c("date_time", "date", "a", "b", "c", "d", "e", "f"))
   expect_equivalent(validation$validation_set$assertion_type, "rows_distinct")
-  expect_true(is.na(validation$validation_set$column %>% .[[1]] %>% .[[1]]))
+  expect_equivalent(validation$validation_set$column %>% unlist(), "date_time, date, a, b, c, d, e, f")
   expect_true(is.null(validation$validation_set[["values"]][[1]]))
   expect_true(is.na(validation$validation_set$all_passed))
   expect_true(is.na(validation$validation_set$n))

--- a/tests/testthat/test-expectation_fns.R
+++ b/tests/testthat/test-expectation_fns.R
@@ -1624,7 +1624,8 @@ test_that("pointblank expectation function produce the correct results", {
 
 test_that("expect errors to be expressed by pointblank under some conditions", {
   
-  no_col_msg <- "The value for `column` doesn't correspond to a column name."
+  # no_col_msg <- "The value for `column` doesn't correspond to a column name."
+  no_col_msg <- "column"
   
   # Errors caught and expressed when a column doesn't exist
   expect_error(expect_col_vals_lt(tbl, columns = vars(z), value = 0), regexp = no_col_msg)

--- a/tests/testthat/test-interrogate_with_agent.R
+++ b/tests/testthat/test-interrogate_with_agent.R
@@ -873,7 +873,7 @@ test_that("Interrogating for valid row values", {
   # Expect certain values in `validation$validation_set`
   expect_equivalent(validation$tbl_name, "small_table")
   expect_equivalent(validation$validation_set$assertion_type, "rows_complete")
-  expect_true(is.na(validation$validation_set$column %>% unlist()))
+  expect_equivalent(validation$validation_set$column %>% unlist(), "date_time, date, a, b, c, d, e, f")
   expect_true(is.null(validation$validation_set[["values"]][[1]]))
   expect_false(validation$validation_set$all_passed)
   expect_equivalent(validation$validation_set$n, 13)
@@ -896,7 +896,7 @@ test_that("Interrogating for valid row values", {
   # Expect certain values in `validation$validation_set`
   expect_equivalent(validation$tbl_name, "small_table")
   expect_equivalent(validation$validation_set$assertion_type, "rows_complete")
-  expect_true(is.na(validation$validation_set$column %>% unlist()))
+  expect_equivalent(validation$validation_set$column %>% unlist(), "date_time, date, a, b, c, d, e, f")
   expect_true(is.null(validation$validation_set[["values"]][[1]]))
   expect_true(validation$validation_set$all_passed)
   expect_equivalent(validation$validation_set$n, 3)

--- a/tests/testthat/test-interrogate_with_agent.R
+++ b/tests/testthat/test-interrogate_with_agent.R
@@ -784,7 +784,7 @@ test_that("Interrogating for valid row values", {
   # Expect certain values in `validation$validation_set`
   expect_equivalent(validation$tbl_name, "small_table")
   expect_equivalent(validation$validation_set$assertion_type, "rows_distinct")
-  expect_true(is.na(validation$validation_set$column %>% unlist()))
+  expect_equivalent(validation$validation_set$column %>% unlist(), "date_time, date, a, b, c, d, e, f")
   expect_true(is.null(validation$validation_set[["values"]][[1]]))
   expect_false(validation$validation_set$all_passed)
   expect_equivalent(validation$validation_set$n, 13)
@@ -807,7 +807,7 @@ test_that("Interrogating for valid row values", {
   # Expect certain values in `validation$validation_set`
   expect_equivalent(validation$tbl_name, "small_table")
   expect_equivalent(validation$validation_set$assertion_type, "rows_distinct")
-  expect_true(is.na(validation$validation_set$column %>% unlist()))
+  expect_equivalent(validation$validation_set$column %>% unlist(), "date_time, date, a, b, c, d, e, f")
   expect_true(is.null(validation$validation_set[["values"]][[1]]))
   expect_true(validation$validation_set$all_passed)
   expect_equivalent(validation$validation_set$n, 11)

--- a/tests/testthat/test-interrogate_with_agent_db.R
+++ b/tests/testthat/test-interrogate_with_agent_db.R
@@ -485,7 +485,7 @@ test_that("Interrogating for valid row values", {
   # Expect certain values in `validation$validation_set`
   expect_equivalent(validation$tbl_name, "small_table")
   expect_equivalent(validation$validation_set$assertion_type, "rows_distinct")
-  expect_true(is.na(validation$validation_set$column %>% unlist()))
+  expect_equivalent(validation$validation_set$column %>% unlist(), "date_time, date, a, b, c, d, e, f")
   expect_true(is.null(validation$validation_set[["values"]][[1]]))
   expect_false(validation$validation_set$all_passed)
   expect_equivalent(validation$validation_set$n, 13)
@@ -510,7 +510,7 @@ test_that("Interrogating for valid row values", {
   # Expect certain values in `validation$validation_set`
   expect_equivalent(validation$tbl_name, "small_table")
   expect_equivalent(validation$validation_set$assertion_type, "rows_distinct")
-  expect_true(is.na(validation$validation_set$column %>% unlist()))
+  expect_equivalent(validation$validation_set$column %>% unlist(), "date_time, date, a, b, c, d, e, f")
   expect_true(is.null(validation$validation_set[["values"]][[1]]))
   expect_true(validation$validation_set$all_passed)
   expect_equivalent(validation$validation_set$n, 11)

--- a/tests/testthat/test-test_fns.R
+++ b/tests/testthat/test-test_fns.R
@@ -787,7 +787,8 @@ test_that("pointblank expectation functions produce the correct results", {
 
 test_that("expect errors to be expressed by pointblank under some conditions", {
   
-  no_col_msg <- "The value for `column` doesn't correspond to a column name."
+  # no_col_msg <- "The value for `column` doesn't correspond to a column name."
+  no_col_msg <- "column"
   
   # Errors caught and expressed when a column doesn't exist
   expect_error(test_col_vals_lt(tbl, columns = vars(z), value = 0), regexp = no_col_msg)

--- a/tests/testthat/test-tidyselect_fails_safely.R
+++ b/tests/testthat/test-tidyselect_fails_safely.R
@@ -74,6 +74,23 @@ test_that("(tidy-)selecting 0 columns = skip the validation step at interrogatio
   
 })
 
+test_that("tidyselecting 0 columns for rows_* functions = error at interrogation", {
+  
+  expect_no_error(a_rows_distinct <- agent %>% rows_distinct(starts_with("z")) %>% interrogate())
+  expect_no_error(a_rows_complete <- agent %>% rows_distinct(starts_with("z")) %>% interrogate())
+  expect_true(a_rows_distinct$validation_set$eval_error)
+  expect_true(a_rows_complete$validation_set$eval_error)
+  
+  # TODO: 0-column selection from tidyselect helpers *not* caught by `uses_tidyselect()`
+  #       will still have same behavior but show different eval error message
+  #       (errors from `select()` and not from `column_validity_has_columns()` as above)
+  expect_no_error(a_rows_distinct2 <- agent %>% rows_distinct(any_of("z")) %>% interrogate())
+  expect_no_error(a_rows_complete2 <- agent %>% rows_distinct(any_of("z")) %>% interrogate())
+  expect_true(a_rows_distinct2$validation_set$eval_error)
+  expect_true(a_rows_complete2$validation_set$eval_error)
+  
+})
+
 test_that("tidyselect errors *are* immediate for assertion/expectation/test", {
   
   mismatch_msg <- "Can't subset columns that don't exist."

--- a/tests/testthat/test-tidyselect_fails_safely.R
+++ b/tests/testthat/test-tidyselect_fails_safely.R
@@ -10,10 +10,10 @@ test_that("tidyselect errors signaled at report, not during development of valid
   expect_s3_class(a4 <- agent %>% col_vals_not_null(all_of(nonexistent_col)), "ptblank_agent")
   
   # Failure signaled via report
-  expect_message(expect_no_error(a1 %>% interrogate()), "ERROR")
-  expect_message(expect_no_error(a2 %>% interrogate()), "ERROR")
-  expect_message(expect_no_error(a3 %>% interrogate()), "ERROR")
-  expect_message(expect_no_error(a4 %>% interrogate()), "ERROR")
+  expect_false(a1 %>% interrogate() %>% all_passed())
+  expect_false(a2 %>% interrogate() %>% all_passed())
+  expect_false(a3 %>% interrogate() %>% all_passed())
+  expect_false(a4 %>% interrogate() %>% all_passed())
   
   # Stress testing
   expect_no_error(agent %>% col_vals_not_null(stop()))
@@ -52,23 +52,25 @@ test_that("fail state correctly registered in the report for tidyselect errors",
 
 test_that("(tidy-)selecting 0 columns = skip the validation step at interrogation", {
   
+  eval_inactive <- function(x) !x$validation_set$eval_active
+  
   # Old behavior for vars()/NULL/<missing> preserved:
   ## 1) No immediate error for zero columns selected
   expect_s3_class(a5 <- agent %>% col_vals_not_null(vars()), "ptblank_agent")
   expect_s3_class(a6 <- agent %>% col_vals_not_null(NULL), "ptblank_agent")
   expect_s3_class(a7 <- agent %>% col_vals_not_null(), "ptblank_agent")
   ## 2) # Treated as inactive in the report
-  expect_message(expect_no_error(a5 %>% interrogate()), "Skipping")
-  expect_message(expect_no_error(a6 %>% interrogate()), "Skipping")
-  expect_message(expect_no_error(a7 %>% interrogate()), "Skipping")
+  expect_true(a5 %>% interrogate() %>% eval_inactive())
+  expect_true(a6 %>% interrogate() %>% eval_inactive())
+  expect_true(a7 %>% interrogate() %>% eval_inactive())
   
   # Same behavior of 0-column selection replicated in tidyselect patterns
   expect_length(small_table %>% dplyr::select(any_of("z")), 0)
   expect_length(small_table %>% dplyr::select(c()), 0)
   expect_s3_class(a8 <- agent %>% col_vals_not_null(any_of("z")), "ptblank_agent")
   expect_s3_class(a9 <- agent %>% col_vals_not_null(c()), "ptblank_agent")
-  expect_message(expect_no_error(a8 %>% interrogate()), "Skipping")
-  expect_message(expect_no_error(a9 %>% interrogate()), "Skipping")
+  expect_true(a8 %>% interrogate() %>% eval_inactive())
+  expect_true(a9 %>% interrogate() %>% eval_inactive())
   
 })
 

--- a/tests/testthat/test-tidyselect_integration.R
+++ b/tests/testthat/test-tidyselect_integration.R
@@ -1,0 +1,48 @@
+test_that("Full range of tidyselect features available in column selection", {
+  
+  tbl <- tibble(x = 1:2, y = 1:2, yy = 1:2, nonunique = 1)
+  
+  # Single symbol
+  expect_success(expect_rows_distinct(tbl, x))
+  expect_failure(expect_rows_distinct(tbl, nonunique))
+  
+  # Backward-compatibility with `vars()` syntax
+  expect_success(expect_rows_distinct(tbl, vars(x)))
+  expect_success(expect_rows_distinct(tbl, vars(x, nonunique)))
+  expect_failure(expect_rows_distinct(tbl, vars(nonunique)))
+  
+  # Preferred {tidyselect}-style `c()` syntax
+  expect_success(expect_rows_distinct(tbl, c(x)))
+  expect_success(expect_rows_distinct(tbl, c(x, nonunique)))
+  expect_failure(expect_rows_distinct(tbl, c(nonunique)))
+  
+  # {tidyselect} functions
+  expect_success(expect_rows_distinct(tbl, all_of("x")))
+  expect_success(expect_rows_distinct(tbl, all_of(c("x", "nonunique"))))
+  expect_failure(expect_rows_distinct(tbl, all_of("nonunique")))
+  
+  # NEW: {tidyselect} integer indexing
+  expect_success(expect_rows_distinct(tbl, 1))
+  expect_success(expect_rows_distinct(tbl, c(1, 4)))
+  expect_failure(expect_rows_distinct(tbl, 4))
+  
+  # NEW: {tidyselect} negative indexing
+  expect_success(expect_rows_distinct(tbl, -(2:4)))
+  expect_success(expect_rows_distinct(tbl, -(2:3)))
+  expect_failure(expect_rows_distinct(tbl, -(1:3)))
+  
+  # NEW: {tidyselect} functions in complex expressions
+  exist_col <- "y"
+  expect_success(expect_rows_distinct(tbl, c(x, all_of(exist_col))))
+  nonexist_col <- "z"
+  expect_error(expect_rows_distinct(tbl, c(x, all_of(nonexist_col))))
+  expect_success(expect_rows_distinct(tbl, c(x, any_of(nonexist_col))))
+  
+  # DEPRECATION: Supplying a character vector variable still works, but signals deprecation:
+  options(lifecycle_verbosity = "warning")
+  expect_success(expect_warning(
+    expect_rows_distinct(tbl, exist_col),
+    "Using an external vector in selections was deprecated in tidyselect 1.1.0."
+  ))
+  
+})

--- a/tests/testthat/test-tidyselect_integration.R
+++ b/tests/testthat/test-tidyselect_integration.R
@@ -1,6 +1,6 @@
 test_that("Full range of tidyselect features available in column selection", {
   
-  tbl <- data.frame(x = 1:2, y = 1:2, yy = 1:2, nonunique = 1)
+  tbl <- data.frame(x = 1:2, y = 1:2, yy = 1:2, nonunique = "A")
   
   # Single symbol
   expect_success(expect_rows_distinct(tbl, x))
@@ -30,6 +30,11 @@ test_that("Full range of tidyselect features available in column selection", {
   expect_success(expect_rows_distinct(tbl, -(2:4)))
   expect_success(expect_rows_distinct(tbl, -(2:3)))
   expect_failure(expect_rows_distinct(tbl, -(1:3)))
+  
+  # NEW: {tidyselect} `where()` predicate:
+  expect_success(expect_rows_distinct(tbl, !tidyselect::where(is.character)))
+  expect_success(expect_rows_distinct(tbl, tidyselect::where(is.numeric)))
+  expect_failure(expect_rows_distinct(tbl, tidyselect::where(is.character)))
   
   # NEW: {tidyselect} functions in complex expressions
   exist_col <- "y"

--- a/tests/testthat/test-tidyselect_integration.R
+++ b/tests/testthat/test-tidyselect_integration.R
@@ -45,4 +45,9 @@ test_that("Full range of tidyselect features available in column selection", {
     "Using an external vector in selections was deprecated in tidyselect 1.1.0."
   ))
   
+  # For `rows_distinct()` specifically, NULL = "select everything" behavior implemented in tidyselect:
+  expect_success(expect_rows_distinct(tbl, ))
+  tbl_only_nonunique <- tbl[,"nonunique", drop = FALSE]
+  expect_failure(expect_rows_distinct(tbl_only_nonunique, ))
+  
 })

--- a/tests/testthat/test-tidyselect_integration.R
+++ b/tests/testthat/test-tidyselect_integration.R
@@ -52,7 +52,6 @@ test_that("Full range of tidyselect features available in column selection", {
   
 })
 
-
 test_that("'NULL = select everything' behavior in rows_*() validation functions", {
 
   # For `rows_*()` functions specifically, empty/NULL = "select everything" behavior:
@@ -89,4 +88,37 @@ test_that("'NULL = select everything' behavior in rows_*() validation functions"
       unique()
   }, toString(colnames(small_table)))
     
+})
+
+# tidyselect coverage for `col_exists()`
+test_that("'NULL = select everything' behavior in rows_*() validation functions", {
+  
+  # Reprex from (#433)
+  df <- tibble::tibble(
+    id.x = 1:3,
+    id.y = 1:3,
+    stuff = 1:3
+  )
+  expect_success({
+    df %>% 
+      expect_col_exists(
+        columns = vars(ends_with(".x"))
+      )
+  })
+  expect_equal({
+    df %>% 
+      col_exists(
+        columns = vars(ends_with(".x"))
+      )
+  }, df)
+  
+  # Multiple column selection produces multiple steps
+  expect_no_error({
+    df_interrogated <- df %>% 
+      create_agent() %>% 
+      col_exists(starts_with("id")) %>% 
+      interrogate()
+  })
+  expect_equal(nrow(df_interrogated$validation_set), 2L)
+  
 })

--- a/tests/testthat/test-tidyselect_integration.R
+++ b/tests/testthat/test-tidyselect_integration.R
@@ -1,6 +1,6 @@
 test_that("Full range of tidyselect features available in column selection", {
   
-  tbl <- data.frame(x = 1:2, y = 1:2, yy = 1:2, nonunique = "A")
+  tbl <- data.frame(x = 1:2, y = 1:2, nonunique = "A")
   
   # Single symbol
   expect_success(expect_rows_distinct(tbl, x))
@@ -23,13 +23,13 @@ test_that("Full range of tidyselect features available in column selection", {
   
   # NEW: {tidyselect} integer indexing
   expect_success(expect_rows_distinct(tbl, 1))
-  expect_success(expect_rows_distinct(tbl, c(1, 4)))
-  expect_failure(expect_rows_distinct(tbl, 4))
+  expect_success(expect_rows_distinct(tbl, c(1, 3)))
+  expect_failure(expect_rows_distinct(tbl, 3))
   
   # NEW: {tidyselect} negative indexing
-  expect_success(expect_rows_distinct(tbl, -(2:4)))
   expect_success(expect_rows_distinct(tbl, -(2:3)))
-  expect_failure(expect_rows_distinct(tbl, -(1:3)))
+  expect_success(expect_rows_distinct(tbl, -2))
+  expect_failure(expect_rows_distinct(tbl, -(1:2)))
   
   # NEW: {tidyselect} `where()` predicate:
   expect_success(expect_rows_distinct(tbl, !tidyselect::where(is.character)))
@@ -43,16 +43,50 @@ test_that("Full range of tidyselect features available in column selection", {
   expect_error(expect_rows_distinct(tbl, c(x, tidyselect::all_of(nonexist_col))))
   expect_success(expect_rows_distinct(tbl, c(x, tidyselect::any_of(nonexist_col))))
   
-  # DEPRECATION: Supplying a character vector variable still works, but signals deprecation:
-  options(lifecycle_verbosity = "warning")
+  # Supplying a character vector variable still works, but signals deprecation:
+  rlang::local_options(lifecycle_verbosity = "warning")
   expect_success(expect_warning(
     expect_rows_distinct(tbl, exist_col),
     "Using an external vector in selections was deprecated in tidyselect 1.1.0."
   ))
   
-  # For `rows_distinct()` specifically, NULL = "select everything" behavior implemented in tidyselect:
-  expect_success(expect_rows_distinct(tbl, ))
-  tbl_only_nonunique <- tbl[,"nonunique", drop = FALSE]
-  expect_failure(expect_rows_distinct(tbl_only_nonunique, ))
+})
+
+
+test_that("'NULL = select everything' behavior in rows_*() validation functions", {
+
+  # For `rows_*()` functions specifically, empty/NULL = "select everything" behavior:
+  expect_success(expect_rows_distinct(data.frame(x = 1, y = 2)))
+  expect_success(expect_rows_complete(data.frame(x = 1, y = 2)))
+  expect_failure(expect_rows_distinct(data.frame(x = c(1, 1))))
+  expect_failure(expect_rows_complete(data.frame(x = c(1, NA))))
+  expect_success(expect_rows_distinct(data.frame(x = 1, y = 2), columns = NULL))
+  expect_success(expect_rows_complete(data.frame(x = 1, y = 2), columns = NULL))
+  expect_failure(expect_rows_distinct(data.frame(x = c(1, 1)), columns = NULL))
+  expect_failure(expect_rows_complete(data.frame(x = c(1, NA)), columns = NULL))
   
+  # Report shows all column names with empty `columns` argument
+  expect_equal({
+    small_table %>%
+      create_agent() %>% 
+      rows_distinct() %>% 
+      rows_complete() %>% 
+      interrogate() %>% 
+      {.$validation_set$column} %>% 
+      unlist() %>% 
+      unique()
+  }, toString(colnames(small_table)))
+  
+  # Report shows all column names with explicit NULL `columns` argument
+  expect_equal({
+    small_table %>%
+      create_agent() %>% 
+      rows_distinct(columns = NULL) %>% 
+      rows_complete(columns = NULL) %>% 
+      interrogate() %>% 
+      {.$validation_set$column} %>% 
+      unlist() %>% 
+      unique()
+  }, toString(colnames(small_table)))
+    
 })

--- a/tests/testthat/test-tidyselect_integration.R
+++ b/tests/testthat/test-tidyselect_integration.R
@@ -1,6 +1,6 @@
 test_that("Full range of tidyselect features available in column selection", {
   
-  tbl <- tibble(x = 1:2, y = 1:2, yy = 1:2, nonunique = 1)
+  tbl <- data.frame(x = 1:2, y = 1:2, yy = 1:2, nonunique = 1)
   
   # Single symbol
   expect_success(expect_rows_distinct(tbl, x))
@@ -17,9 +17,9 @@ test_that("Full range of tidyselect features available in column selection", {
   expect_failure(expect_rows_distinct(tbl, c(nonunique)))
   
   # {tidyselect} functions
-  expect_success(expect_rows_distinct(tbl, all_of("x")))
-  expect_success(expect_rows_distinct(tbl, all_of(c("x", "nonunique"))))
-  expect_failure(expect_rows_distinct(tbl, all_of("nonunique")))
+  expect_success(expect_rows_distinct(tbl, tidyselect::all_of("x")))
+  expect_success(expect_rows_distinct(tbl, tidyselect::all_of(c("x", "nonunique"))))
+  expect_failure(expect_rows_distinct(tbl, tidyselect::all_of("nonunique")))
   
   # NEW: {tidyselect} integer indexing
   expect_success(expect_rows_distinct(tbl, 1))
@@ -33,10 +33,10 @@ test_that("Full range of tidyselect features available in column selection", {
   
   # NEW: {tidyselect} functions in complex expressions
   exist_col <- "y"
-  expect_success(expect_rows_distinct(tbl, c(x, all_of(exist_col))))
+  expect_success(expect_rows_distinct(tbl, c(x, tidyselect::all_of(exist_col))))
   nonexist_col <- "z"
-  expect_error(expect_rows_distinct(tbl, c(x, all_of(nonexist_col))))
-  expect_success(expect_rows_distinct(tbl, c(x, any_of(nonexist_col))))
+  expect_error(expect_rows_distinct(tbl, c(x, tidyselect::all_of(nonexist_col))))
+  expect_success(expect_rows_distinct(tbl, c(x, tidyselect::any_of(nonexist_col))))
   
   # DEPRECATION: Supplying a character vector variable still works, but signals deprecation:
   options(lifecycle_verbosity = "warning")

--- a/tests/testthat/test-yaml.R
+++ b/tests/testthat/test-yaml.R
@@ -800,7 +800,7 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
   
   expect_equal(
     get_oneline_expr_str(agent %>% rows_distinct()),
-    "rows_distinct()"
+    "rows_distinct(columns = vars(date_time, date, a, b, c, d, e, f))"
   )
   expect_equal(
     get_oneline_expr_str(agent %>% rows_distinct(columns = vars(a, b))),


### PR DESCRIPTION
Hi Rich -

Making my way over from your R/Pharma pointblank workshop yesterday - thanks for the great package! I've actually been accumulating some thoughts about a complete tidyselect integration for pointblank, and the workshop nudged me to wrap up my thoughts into a PR.

# Intro

My understanding of the column selection logic as it currently exists is that the `columns` argument of user-facing validations functions is always `enquo()`-ed, and forwarded to (at least) three different implementations:

1) If input is a `vars()` call, deparse the elements and return the column names in a character vector.

2) If input is a call to one of the supported {tidyselect} functions in `exported_tidyselect_fns`, forward the quosure to `eval_select()`.

3) For all other cases, the input (sometimes character vector, sometimes a symbol) is forwarded to `vars_select()` as quosure and defused there.

This PR tries to unify these various behaviors under `tidyselect::eval_select()` (mostly by rewriting the `resolve_columns()` internal function). The proposal is to make all user-supplied expressions to `columns` pass through {tidyselect}, as much as possible.

# Problems

There are (or were, if I did this right) four points of friction for a complete `{tidyselect}`-backend refactoring:
1) Both users and developers of pointblank can freely switch between passing *expressions* vs. *character vectors* to the column argument without being explicit about which one we're intending. The PRO is that the function is smart and it "just works", which is convenient. The CON is that it requires/causes the kind of fractured implementation of the selection logic that I described above. The solution is to *expect* the argument to always be captured/quoted by default, unless it's specifically marked for ordinary evaluation. `dplyr::select()` has already paved way for this by introducing `all_of()`. So anytime in the source code we do something like `columns = columns` and expect the `columns` argument to be ordinarily evaluated as a character vector, this PR ensures that the input is wrapped in `all_of()` to let `eval_select()` handle it:

2) The way we currently implement `vars()` will become somewhat of an off-label usage in a `{tidyselect}` context. There's no way to make this straightforwardly work, so I just special case this for backwards compatibility. Luckily, `{tidyselect}` already offers this capability with `c()`, so the PR simply intercepts the `vars()` expression and replaces `vars` with `c` before sending it off to `eval_select()`.
3) `eval_select()` is strict about resolving column selections - it throws an error if the selection is invalid. In our case, this is a doubled edged sword (see also the error in tests at the bottom of this PR). On the one hand, we get the really informative tidyverse-style error messages it generates for free, instead of the generic message that pointblank currently throws. On the other hand, the dataframe that `resolve_columns()` receives is sometimes empty, with no columns (ex: in the case of `serially()`). In the PR, I decided to just special case empty data - the `vars()` expression in that case is simply deparsed into a character vector, bypassing tidyselect entirely (leaving it up to pointblank to catch any column selection errors downstream).
4) Some validation functions (ex: `col_exists()`) simply deparse the user-supplied column expression immediately without doing anything more with it. These should get re-routed to `resolve_columns()` for consistency (of having all user-facing column selection logic be powered by `{tidyselect}`).

The first three actually turned out to be pretty trivial to address, as far as refactoring is concerned - It took a re-write of the `resolve_columns()` function + wrapping the input to `columns` in `all_of()` whenever we're passing a character vector, forcing the source code to be intentional about it. The fourth friction point requires editing the body of individual validation functions, so I'm holding them off for now.

# Example

To demonstrate what the PR enables, here it is in action for `rows_distinct()`, which seemed like the prime candidate for this refactoring:

```r
tbl <- data.frame(x = 1:2, y = "A")
expect_rows_distinct(tbl, c(x, y))
expect_rows_distinct(tbl, c(1, 2))
expect_rows_distinct(tbl, !tidyselect::where(is.character))
expect_rows_distinct(tbl, tidyselect::all_of(c("x", "y")))
expect_rows_distinct(tbl, c(x, tidyselect::any_of(c("y", "z"))))
```

One welcome consequence of this is that the `column` information is no longer NA for the `rows_distinct()` validation step:

```r
agent <- small_table %>%
  create_agent() %>%
  rows_distinct(c(a, d:f)) %>%
  interrogate()
unlist(agent$validation_set$column)
#> [1] "a, d, e, f"
```

A new test file `test-tidyselect_integration.R` has a more comprehensive coverage of {tidyselect} features that we expect to work.

# Remaining considerations

This is a draft PR because of these outstanding issues:

## Deprecation

We might want to consider signalling deprecation for 1) `vars()` (use `c()` instead), and 2) passing character vectors expecting it to "just work" (wrap it in `all_of()` instead). Users have already built up intuition about this behavior from using dplyr, so it hopefully shouldn't be too difficult to grok. I haven't implemented a `vars()` deprecation warning in this PR yet (I don't know how disruptive that'd be) but in the case of `all_of()` the PR just lets the deprecation warning trickle up from tidyselect.

## Coverage and WIP status

This PR needs to finish integrating the new tidyselect implementation for some of the validation functions that still use the old implementation (ex: `rows_complete()`) and also for those that just don't do tidyselect entirely (ex: `col_exists()`)

## Tests

<details>
<summary>outdated</summary>

When I `devtools::test()` (Windows), I get:

> [ FAIL 2 | WARN 16 | SKIP 7 | PASS 5737 ]

Compared to main, this PR introduces 1 new FAIL and 10 new WARNs:

- The warnings are mostly deprecation errors from using or missing `all_of()` in the appropriate places. I'm in the process of hunting the rest of these down.

- The one new error may be a breaking change - the PR changes pointblank's behavior on this test:

https://github.com/rstudio/pointblank/blob/dc1b917c6f2fee3d717b40d0da36c96bb4618172/tests/testthat/test-get_agent_report.R#L84-L92

Whereas pointblank agents strive to delay the evaluation of the validation checks until `interrogate()`, passing the column inputs through `eval_select()` triggers immediate errors for non-existent columns. In other words, the agent fails to "build" entirely so it fails the tests for this agent. I'm sure it's possible to put the old behavior back in (of gracefully signaling the "evaluation issue requires attention" error) but just wanted to put it out there first before I do anything about it since I think this one requires some more thought.

</details>

# Related GitHub Issues and PRs

I'm sure this cuts across several open issues, but to list a few that this PR would close if worked to completion:

- Ref: #416, #433, #221

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [ ] I have listed any major changes in the [NEWS](https://github.com/rstudio/pointblank/blob/main/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/pointblank/tree/main/tests/testthat) for any new functionality.
