### PR TITLE
Documentation and general cleanup for #493, #495

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## New features
 
+* Full `{tidyselect}` support for the `columns` argument of all validation functions. You can now use the full range of familiar column-selection expressions that you could also use in `dplyr::select()`. This also begins a process of deprecation:
+  - `vars()` for selecting columns will continue to work, but `c()` now supersedes `vars()`.
+  - If passing an *external vector* of column names, it should be wrapped in `all_of()`.
+
 * The `label` argument of validation functions now exposes the following string variables via `{glue}` syntax:
 
   - `"{.step}"`: The validation step name

--- a/R/action_levels.R
+++ b/R/action_levels.R
@@ -154,10 +154,10 @@
 #'     actions = al
 #'   ) %>%
 #'   col_vals_gt(
-#'     columns = vars(a), value = 2
+#'     columns = a, value = 2
 #'   ) %>%
 #'   col_vals_lt(
-#'     columns = vars(d), value = 20000
+#'     columns = d, value = 20000
 #'   ) %>%
 #'   interrogate()
 #' ```
@@ -188,11 +188,11 @@
 #'     actions = al
 #'   ) %>%
 #'   col_vals_gt(
-#'     columns = vars(a), value = 2,
+#'     columns = a, value = 2,
 #'     actions = warn_on_fail(warn_at = 0.5)
 #'   ) %>%
 #'   col_vals_lt(
-#'     columns = vars(d), value = 20000
+#'     columns = d, value = 20000
 #'   ) %>%
 #'   interrogate()
 #' ```
@@ -220,7 +220,7 @@
 #' ```r
 #' small_table %>%
 #'   col_vals_gt(
-#'     columns = vars(a), value = 2,
+#'     columns = a, value = 2,
 #'     actions = warn_on_fail(warn_at = 2)
 #'   )
 #' ```
@@ -256,7 +256,7 @@
 #' 
 #' ```r
 #' small_table %>%
-#'   col_vals_gt(columns = vars(a), value = 2)
+#'   col_vals_gt(columns = a, value = 2)
 #' ```
 #' 
 #' ```
@@ -273,7 +273,7 @@
 #' ```r
 #' small_table %>%
 #'   col_vals_gt(
-#'     columns = vars(a), value = 2,
+#'     columns = a, value = 2,
 #'     actions = stop_on_fail(stop_at = 1)
 #'   )
 #' ```

--- a/R/all_passed.R
+++ b/R/all_passed.R
@@ -77,9 +77,9 @@
 #' ```r
 #' agent <-
 #'   create_agent(tbl = tbl) %>%
-#'   col_vals_gt(columns = vars(a), value = 3) %>%
-#'   col_vals_lte(columns = vars(a), value = 10) %>%
-#'   col_vals_increasing(columns = vars(a)) %>%
+#'   col_vals_gt(columns = a, value = 3) %>%
+#'   col_vals_lte(columns = a, value = 10) %>%
+#'   col_vals_increasing(columns = a) %>%
 #'   interrogate()
 #' ```
 #' 

--- a/R/col_count_match.R
+++ b/R/col_count_match.R
@@ -103,6 +103,17 @@
 #' depending on the situation (the first produces a warning, the other
 #' `stop()`s).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_exists.R
+++ b/R/col_exists.R
@@ -69,12 +69,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names, the result will be an expansion of
-#' validation steps to that number of column names (e.g., `vars(col_a, col_b)`
-#' will result in the entry of two validation steps). Aside from column names in
-#' quotes and in `vars()`, **tidyselect** helper functions are available for
-#' specifying columns. They are: `starts_with()`, `ends_with()`, `contains()`,
-#' `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #'
 #' @section Actions:
 #' 

--- a/R/col_exists.R
+++ b/R/col_exists.R
@@ -113,7 +113,7 @@
 #' ```r
 #' agent %>% 
 #'   col_exists(
-#'     columns = vars(a),
+#'     columns = a,
 #'     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
 #'     label = "The `col_exists()` step.",
 #'     active = FALSE
@@ -164,7 +164,7 @@
 #' ```r
 #' agent <-
 #'   create_agent(tbl = tbl) %>%
-#'   col_exists(columns = vars(a)) %>%
+#'   col_exists(columns = a) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -185,7 +185,7 @@
 #' The behavior of side effects can be customized with the `actions` option.
 #' 
 #' ```{r}
-#' tbl %>% col_exists(columns = vars(a))
+#' tbl %>% col_exists(columns = a)
 #' ```
 #' 
 #' ## C: Using the expectation function
@@ -194,7 +194,7 @@
 #' time. This is primarily used in **testthat** tests.
 #' 
 #' ```r
-#' expect_col_exists(tbl, columns = vars(a))
+#' expect_col_exists(tbl, columns = a)
 #' ```
 #' 
 #' ## D: Using the test function
@@ -203,7 +203,7 @@
 #' us.
 #' 
 #' ```{r}
-#' tbl %>% test_col_exists(columns = vars(a))
+#' tbl %>% test_col_exists(columns = a)
 #' ```
 #' 
 #' @family validation functions

--- a/R/col_exists.R
+++ b/R/col_exists.R
@@ -125,7 +125,7 @@
 #' ```yaml
 #' steps:
 #' - col_exists:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     actions:
 #'       warn_fraction: 0.1
 #'       stop_fraction: 0.2

--- a/R/col_exists.R
+++ b/R/col_exists.R
@@ -34,14 +34,6 @@
 #' 
 #' @inheritParams col_vals_gt
 #' 
-#' @param columns *The target columns*
-#'   
-#'   `vector<character>|vars(<columns>)`` // **required**
-#' 
-#'   One or more columns from the table in focus. This can be
-#'   provided as a vector of column names using `c()` or bare column names
-#'   enclosed in [vars()].
-#'   
 #' @return For the validation function, the return value is either a
 #'   `ptblank_agent` object or a table object (depending on whether an agent
 #'   object or a table was passed to `x`). The expectation function invisibly

--- a/R/col_exists.R
+++ b/R/col_exists.R
@@ -86,6 +86,18 @@
 #' depending on the situation (the first produces a warning, the other
 #' `stop()`s).
 #'
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_exists.R
+++ b/R/col_exists.R
@@ -236,6 +236,11 @@ col_exists <- function(
   
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Require columns to be specified
+  if (rlang::quo_is_missing(columns)) {
+    stop('argument "columns" is missing, with no default')
+  }
+  # `NULL` = `everything()`
   if (rlang::quo_is_null(columns)) {
     columns <- rlang::quo(tidyselect::everything())
   }

--- a/R/col_exists.R
+++ b/R/col_exists.R
@@ -240,7 +240,6 @@ col_exists <- function(
   if (rlang::quo_is_missing(columns)) {
     stop('argument "columns" is missing, with no default')
   }
-  # `NULL` = `everything()`
   if (rlang::quo_is_null(columns)) {
     columns <- rlang::quo(tidyselect::everything())
   }

--- a/R/col_exists.R
+++ b/R/col_exists.R
@@ -229,13 +229,10 @@ col_exists <- function(
   preconditions <- NULL
   values <- NULL
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   # Require columns to be specified
   if (rlang::quo_is_missing(columns)) {
     stop('argument "columns" is missing, with no default')

--- a/R/col_exists.R
+++ b/R/col_exists.R
@@ -249,9 +249,9 @@ col_exists <- function(
   )
   if (rlang::is_error(columns)) {
     cnd <- columns
-    # tidyselect 0-column selection should be rethrown
+    # tidyselect 0-column selection should contextualize attempted column
     if (is.null(cnd$parent)) {
-      rlang::cnd_signal(cnd)
+      columns <- columns_expr
     } else {
       # Evaluation errors should be chained and rethrown
       rlang::abort("Evaluation error in `columns`", parent = cnd$parent)

--- a/R/col_is_character.R
+++ b/R/col_is_character.R
@@ -89,6 +89,18 @@
 #' 1)` or `action_levels(stop_at = 1)` are good choices depending on the
 #' situation (the first produces a warning, the other will `stop()`).
 #'
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_is_character.R
+++ b/R/col_is_character.R
@@ -226,13 +226,10 @@ col_is_character <- function(
   preconditions <- NULL
   values <- NULL
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions = NULL)

--- a/R/col_is_character.R
+++ b/R/col_is_character.R
@@ -120,7 +120,7 @@
 #' ```yaml
 #' steps:
 #' - col_is_character:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     actions:
 #'       warn_fraction: 0.1
 #'       stop_fraction: 0.2

--- a/R/col_is_character.R
+++ b/R/col_is_character.R
@@ -108,7 +108,7 @@
 #' ```r
 #' agent %>% 
 #'   col_is_character(
-#'     columns = vars(a),
+#'     columns = a,
 #'     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
 #'     label = "The `col_is_character()` step.",
 #'     active = FALSE
@@ -159,7 +159,7 @@
 #' ```r
 #' agent <-
 #'   create_agent(tbl = tbl) %>%
-#'   col_is_character(columns = vars(b)) %>%
+#'   col_is_character(columns = b) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -181,7 +181,7 @@
 #' 
 #' ```{r}
 #' tbl %>% 
-#'   col_is_character(columns = vars(b)) %>%
+#'   col_is_character(columns = b) %>%
 #'   dplyr::slice(1:5)
 #' ```
 #' 
@@ -191,7 +191,7 @@
 #' time. This is primarily used in **testthat** tests.
 #' 
 #' ```r
-#' expect_col_is_character(tbl, columns = vars(b))
+#' expect_col_is_character(tbl, columns = b)
 #' ```
 #' 
 #' ## D: Using the test function
@@ -200,7 +200,7 @@
 #' us.
 #' 
 #' ```{r}
-#' tbl %>% test_col_is_character(columns = vars(b))
+#' tbl %>% test_col_is_character(columns = b)
 #' ```
 #' 
 #' @family validation functions

--- a/R/col_is_character.R
+++ b/R/col_is_character.R
@@ -63,12 +63,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names, the result will be an expansion of
-#' validation steps to that number of column names (e.g., `vars(col_a, col_b)`
-#' will result in the entry of two validation steps). Aside from column names in
-#' quotes and in `vars()`, **tidyselect** helper functions are available for
-#' specifying columns. They are: `starts_with()`, `ends_with()`, `contains()`,
-#' `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #'
 #' @section Actions:
 #' 

--- a/R/col_is_date.R
+++ b/R/col_is_date.R
@@ -89,6 +89,18 @@
 #' 1)` or `action_levels(stop_at = 1)` are good choices depending on the
 #' situation (the first produces a warning, the other will `stop()`).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_is_date.R
+++ b/R/col_is_date.R
@@ -120,7 +120,7 @@
 #' ```yaml
 #' steps:
 #' - col_is_date:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     actions:
 #'       warn_fraction: 0.1
 #'       stop_fraction: 0.2

--- a/R/col_is_date.R
+++ b/R/col_is_date.R
@@ -63,12 +63,17 @@
 #' 
 #' @section Column Names:
 #' 
-#' If providing multiple column names, the result will be an expansion of
-#' validation steps to that number of column names (e.g., `vars(col_a, col_b)`
-#' will result in the entry of two validation steps). Aside from column names in
-#' quotes and in `vars()`, **tidyselect** helper functions are available for
-#' specifying columns. They are: `starts_with()`, `ends_with()`, `contains()`,
-#' `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #' 
 #' @section Actions:
 #' 

--- a/R/col_is_date.R
+++ b/R/col_is_date.R
@@ -108,7 +108,7 @@
 #' ```r
 #' agent %>% 
 #'   col_is_date(
-#'     columns = vars(a),
+#'     columns = a,
 #'     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
 #'     label = "The `col_is_date()` step.",
 #'     active = FALSE
@@ -151,7 +151,7 @@
 #' ```r
 #' agent <-
 #'   create_agent(tbl = small_table) %>%
-#'   col_is_date(columns = vars(date)) %>%
+#'   col_is_date(columns = date) %>%
 #'   interrogate()
 #' ```
 #'   
@@ -173,7 +173,7 @@
 #' 
 #' ```{r}
 #' small_table %>%
-#'   col_is_date(columns = vars(date)) %>%
+#'   col_is_date(columns = date) %>%
 #'   dplyr::slice(1:5)
 #' ```
 #'
@@ -183,7 +183,7 @@
 #' time. This is primarily used in **testthat** tests.
 #' 
 #' ```r
-#' expect_col_is_date(small_table, columns = vars(date))
+#' expect_col_is_date(small_table, columns = date)
 #' ```
 #' 
 #' ## D: Using the test function
@@ -192,7 +192,7 @@
 #' us.
 #' 
 #' ```{r}
-#' small_table %>% test_col_is_date(columns = vars(date))
+#' small_table %>% test_col_is_date(columns = date)
 #' ```
 #' 
 #' @family validation functions

--- a/R/col_is_date.R
+++ b/R/col_is_date.R
@@ -218,13 +218,10 @@ col_is_date <- function(
   preconditions <- NULL
   values <- NULL
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions = NULL)

--- a/R/col_is_factor.R
+++ b/R/col_is_factor.R
@@ -89,6 +89,18 @@
 #' 1)` or `action_levels(stop_at = 1)` are good choices depending on the
 #' situation (the first produces a warning, the other will `stop()`).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_is_factor.R
+++ b/R/col_is_factor.R
@@ -63,12 +63,17 @@
 #' 
 #' @section Column Names:
 #' 
-#' If providing multiple column names, the result will be an expansion of
-#' validation steps to that number of column names (e.g., `vars(col_a, col_b)`
-#' will result in the entry of two validation steps). Aside from column names in
-#' quotes and in `vars()`, **tidyselect** helper functions are available for
-#' specifying columns. They are: `starts_with()`, `ends_with()`, `contains()`,
-#' `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #' 
 #' @section Actions:
 #' 

--- a/R/col_is_factor.R
+++ b/R/col_is_factor.R
@@ -108,7 +108,7 @@
 #' ```r
 #' agent %>% 
 #'   col_is_factor(
-#'     columns = vars(a),
+#'     columns = a,
 #'     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
 #'     label = "The `col_is_factor()` step.",
 #'     active = FALSE
@@ -157,7 +157,7 @@
 #' ```r
 #' agent <-
 #'   create_agent(tbl = tbl) %>%
-#'   col_is_factor(columns = vars(f)) %>%
+#'   col_is_factor(columns = f) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -179,7 +179,7 @@
 #' 
 #' ```{r}
 #' tbl %>%
-#'   col_is_factor(columns = vars(f)) %>%
+#'   col_is_factor(columns = f) %>%
 #'   dplyr::slice(1:5)
 #' ```
 #' 
@@ -189,7 +189,7 @@
 #' time. This is primarily used in **testthat** tests.
 #' 
 #' ```r
-#' expect_col_is_factor(tbl, vars(f))
+#' expect_col_is_factor(tbl, f)
 #' ```
 #' 
 #' ## D: Using the test function
@@ -198,7 +198,7 @@
 #' us.
 #' 
 #' ```{r}
-#' tbl %>% test_col_is_factor(columns = vars(f))
+#' tbl %>% test_col_is_factor(columns = f)
 #' ```
 #' 
 #' @family validation functions

--- a/R/col_is_factor.R
+++ b/R/col_is_factor.R
@@ -120,7 +120,7 @@
 #' ```yaml
 #' steps:
 #' - col_is_factor:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     actions:
 #'       warn_fraction: 0.1
 #'       stop_fraction: 0.2

--- a/R/col_is_factor.R
+++ b/R/col_is_factor.R
@@ -224,13 +224,10 @@ col_is_factor <- function(
   preconditions <- NULL
   values <- NULL
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions = NULL)

--- a/R/col_is_integer.R
+++ b/R/col_is_integer.R
@@ -89,6 +89,18 @@
 #' 1)` or `action_levels(stop_at = 1)` are good choices depending on the
 #' situation (the first produces a warning, the other will `stop()`).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_is_integer.R
+++ b/R/col_is_integer.R
@@ -108,7 +108,7 @@
 #' ```r
 #' agent %>% 
 #'   col_is_integer(
-#'     columns = vars(a),
+#'     columns = a,
 #'     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
 #'     label = "The `col_is_integer()` step.",
 #'     active = FALSE
@@ -157,7 +157,7 @@
 #' ```r
 #' agent <-
 #'   create_agent(tbl = tbl) %>%
-#'   col_is_integer(columns = vars(b)) %>%
+#'   col_is_integer(columns = b) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -178,7 +178,7 @@
 #' behavior of side effects can be customized with the `actions` option.
 #' 
 #' ```{r}
-#' tbl %>% col_is_integer(columns = vars(b))
+#' tbl %>% col_is_integer(columns = b)
 #' ```
 #' 
 #' ## C: Using the expectation function
@@ -187,7 +187,7 @@
 #' time. This is primarily used in **testthat** tests.
 #' 
 #' ```r
-#' expect_col_is_integer(tbl, columns = vars(b))
+#' expect_col_is_integer(tbl, columns = b)
 #' ```
 #' 
 #' ## D: Using the test function
@@ -196,7 +196,7 @@
 #' us.
 #' 
 #' ```{r}
-#' tbl %>% test_col_is_integer(columns = vars(b))
+#' tbl %>% test_col_is_integer(columns = b)
 #' ```
 #' 
 #' @family validation functions

--- a/R/col_is_integer.R
+++ b/R/col_is_integer.R
@@ -120,7 +120,7 @@
 #' ```yaml
 #' steps:
 #' - col_is_integer:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     actions:
 #'       warn_fraction: 0.1
 #'       stop_fraction: 0.2

--- a/R/col_is_integer.R
+++ b/R/col_is_integer.R
@@ -63,12 +63,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names, the result will be an expansion of
-#' validation steps to that number of column names (e.g., `vars(col_a, col_b)`
-#' will result in the entry of two validation steps). Aside from column names in
-#' quotes and in `vars()`, **tidyselect** helper functions are available for
-#' specifying columns. They are: `starts_with()`, `ends_with()`, `contains()`,
-#' `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #' 
 #' @section Actions:
 #' 

--- a/R/col_is_integer.R
+++ b/R/col_is_integer.R
@@ -222,13 +222,10 @@ col_is_integer <- function(
   preconditions <- NULL
   values <- NULL
   
-  # Capture the `column` expression
+  # Capture the `columns` expression
   columns <- rlang::enquo(columns)
-  
   # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions = NULL)

--- a/R/col_is_logical.R
+++ b/R/col_is_logical.R
@@ -89,6 +89,18 @@
 #' 1)` or `action_levels(stop_at = 1)` are good choices depending on the
 #' situation (the first produces a warning, the other will `stop()`).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_is_logical.R
+++ b/R/col_is_logical.R
@@ -108,7 +108,7 @@
 #' ```r
 #' agent %>% 
 #'   col_is_logical(
-#'     columns = vars(a),
+#'     columns = a,
 #'     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
 #'     label = "The `col_is_logical()` step.",
 #'     active = FALSE
@@ -152,7 +152,7 @@
 #' ```r
 #' agent <-
 #'   create_agent(tbl = small_table) %>%
-#'   col_is_logical(columns = vars(e)) %>%
+#'   col_is_logical(columns = e) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -174,7 +174,7 @@
 #' 
 #' ```{r}
 #' small_table %>%
-#'   col_is_logical(columns = vars(e)) %>%
+#'   col_is_logical(columns = e) %>%
 #'   dplyr::slice(1:5)
 #' ```
 #' 
@@ -184,7 +184,7 @@
 #' time. This is primarily used in **testthat** tests.
 #' 
 #' ```r
-#' expect_col_is_logical(small_table, columns = vars(e))
+#' expect_col_is_logical(small_table, columns = e)
 #' ```
 #' 
 #' ## D: Using the test function
@@ -193,7 +193,7 @@
 #' us.
 #' 
 #' ```{r}
-#' small_table %>% test_col_is_logical(columns = vars(e))
+#' small_table %>% test_col_is_logical(columns = e)
 #' ```
 #' 
 #' @family validation functions

--- a/R/col_is_logical.R
+++ b/R/col_is_logical.R
@@ -219,13 +219,10 @@ col_is_logical <- function(
   preconditions <- NULL
   values <- NULL
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions = NULL)

--- a/R/col_is_logical.R
+++ b/R/col_is_logical.R
@@ -120,7 +120,7 @@
 #' ```yaml
 #' steps:
 #' - col_is_logical:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     actions:
 #'       warn_fraction: 0.1
 #'       stop_fraction: 0.2

--- a/R/col_is_logical.R
+++ b/R/col_is_logical.R
@@ -63,12 +63,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names, the result will be an expansion of
-#' validation steps to that number of column names (e.g., `vars(col_a, col_b)`
-#' will result in the entry of two validation steps). Aside from column names in
-#' quotes and in `vars()`, **tidyselect** helper functions are available for
-#' specifying columns. They are: `starts_with()`, `ends_with()`, `contains()`,
-#' `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #' 
 #' @section Actions:
 #' 

--- a/R/col_is_numeric.R
+++ b/R/col_is_numeric.R
@@ -89,6 +89,18 @@
 #' 1)` or `action_levels(stop_at = 1)` are good choices depending on the
 #' situation (the first produces a warning, the other will `stop()`).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_is_numeric.R
+++ b/R/col_is_numeric.R
@@ -108,7 +108,7 @@
 #' ```r
 #' agent %>% 
 #'   col_is_numeric(
-#'     columns = vars(a),
+#'     columns = a,
 #'     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
 #'     label = "The `col_is_numeric()` step.",
 #'     active = FALSE
@@ -152,7 +152,7 @@
 #' ```r
 #' agent <-
 #'   create_agent(tbl = small_table) %>%
-#'   col_is_numeric(columns = vars(d)) %>%
+#'   col_is_numeric(columns = d) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -174,7 +174,7 @@
 #' 
 #' ```{r}
 #' small_table %>%
-#'   col_is_numeric(columns = vars(d)) %>%
+#'   col_is_numeric(columns = d) %>%
 #'   dplyr::slice(1:5)
 #' ```
 #' 
@@ -184,7 +184,7 @@
 #' time. This is primarily used in **testthat** tests.
 #' 
 #' ```r
-#' expect_col_is_numeric(small_table, columns = vars(d))
+#' expect_col_is_numeric(small_table, columns = d)
 #' ```
 #' 
 #' ## D: Using the test function
@@ -193,7 +193,7 @@
 #' us.
 #' 
 #' ```{r}
-#' small_table %>% test_col_is_numeric(columns = vars(d))
+#' small_table %>% test_col_is_numeric(columns = d)
 #' ```
 #' 
 #' @family validation functions

--- a/R/col_is_numeric.R
+++ b/R/col_is_numeric.R
@@ -120,7 +120,7 @@
 #' ```yaml
 #' steps:
 #' - col_is_numeric:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     actions:
 #'       warn_fraction: 0.1
 #'       stop_fraction: 0.2

--- a/R/col_is_numeric.R
+++ b/R/col_is_numeric.R
@@ -63,12 +63,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names, the result will be an expansion of
-#' validation steps to that number of column names (e.g., `vars(col_a, col_b)`
-#' will result in the entry of two validation steps). Aside from column names in
-#' quotes and in `vars()`, **tidyselect** helper functions are available for
-#' specifying columns. They are: `starts_with()`, `ends_with()`, `contains()`,
-#' `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #' 
 #' @section Actions:
 #' 

--- a/R/col_is_numeric.R
+++ b/R/col_is_numeric.R
@@ -219,13 +219,10 @@ col_is_numeric <- function(
   preconditions <- NULL
   values <- NULL
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions = NULL)

--- a/R/col_is_posix.R
+++ b/R/col_is_posix.R
@@ -219,13 +219,10 @@ col_is_posix <- function(
   preconditions <- NULL
   values <- NULL
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions = NULL)

--- a/R/col_is_posix.R
+++ b/R/col_is_posix.R
@@ -89,6 +89,18 @@
 #' 1)` or `action_levels(stop_at = 1)` are good choices depending on the
 #' situation (the first produces a warning, the other will `stop()`).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_is_posix.R
+++ b/R/col_is_posix.R
@@ -120,7 +120,7 @@
 #' ```yaml
 #' steps:
 #' - col_is_posix:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     actions:
 #'       warn_fraction: 0.1
 #'       stop_fraction: 0.2

--- a/R/col_is_posix.R
+++ b/R/col_is_posix.R
@@ -108,7 +108,7 @@
 #' ```r
 #' agent %>% 
 #'   col_is_posix(
-#'     columns = vars(a),
+#'     columns = a,
 #'     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
 #'     label = "The `col_is_posix()` step.",
 #'     active = FALSE
@@ -152,7 +152,7 @@
 #' ```r
 #' agent <-
 #'   create_agent(tbl = small_table) %>%
-#'   col_is_posix(columns = vars(date_time)) %>%
+#'   col_is_posix(columns = date_time) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -174,7 +174,7 @@
 #' 
 #' ```{r}
 #' small_table %>%
-#'   col_is_posix(columns = vars(date_time)) %>%
+#'   col_is_posix(columns = date_time) %>%
 #'   dplyr::slice(1:5)
 #' ```
 #' 
@@ -184,7 +184,7 @@
 #' time. This is primarily used in **testthat** tests.
 #' 
 #' ```r
-#' expect_col_is_posix(small_table, columns = vars(date_time))
+#' expect_col_is_posix(small_table, columns = date_time)
 #' ```
 #' 
 #' ## D: Using the test function
@@ -193,7 +193,7 @@
 #' us.
 #' 
 #' ```{r}
-#' small_table %>% test_col_is_posix(columns = vars(date_time))
+#' small_table %>% test_col_is_posix(columns = date_time)
 #' ```
 #' 
 #' @family validation functions

--- a/R/col_is_posix.R
+++ b/R/col_is_posix.R
@@ -63,12 +63,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names, the result will be an expansion of
-#' validation steps to that number of column names (e.g., `vars(col_a, col_b)`
-#' will result in the entry of two validation steps). Aside from column names in
-#' quotes and in `vars()`, **tidyselect** helper functions are available for
-#' specifying columns. They are: `starts_with()`, `ends_with()`, `contains()`,
-#' `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #' 
 #' @section Actions:
 #' 

--- a/R/col_schema_match.R
+++ b/R/col_schema_match.R
@@ -131,6 +131,17 @@
 #' depending on the situation (the first produces a warning, the other
 #' `stop()`s).
 #'
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_vals_between.R
+++ b/R/col_vals_between.R
@@ -217,7 +217,7 @@
 #' ```yaml
 #' steps:
 #' - col_vals_between:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     left: 1.0
 #'     right: 2.0
 #'     inclusive:

--- a/R/col_vals_between.R
+++ b/R/col_vals_between.R
@@ -180,6 +180,20 @@
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_vals_between.R
+++ b/R/col_vals_between.R
@@ -95,12 +95,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names to `columns`, the result will be an
-#' expansion of validation steps to that number of column names (e.g.,
-#' `vars(col_a, col_b)` will result in the entry of two validation steps). Aside
-#' from column names in quotes and in `vars()`, **tidyselect** helper functions
-#' are available for specifying columns. They are: `starts_with()`,
-#' `ends_with()`, `contains()`, `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #'
 #' @section Missing Values:
 #' 

--- a/R/col_vals_between.R
+++ b/R/col_vals_between.R
@@ -199,7 +199,7 @@
 #' ```r
 #' agent %>% 
 #'   col_vals_between(
-#'     columns = vars(a),
+#'     columns = a,
 #'     left = 1,
 #'     right = 2,
 #'     inclusive = c(TRUE, FALSE),
@@ -260,7 +260,7 @@
 #' agent <-
 #'   create_agent(tbl = small_table) %>%
 #'   col_vals_between(
-#'     columns = vars(c),
+#'     columns = c,
 #'     left = 1, right = 9,
 #'     na_pass = TRUE
 #'   ) %>%
@@ -286,7 +286,7 @@
 #' ```{r}
 #' small_table %>%
 #'   col_vals_between(
-#'     columns = vars(c),
+#'     columns = c,
 #'     left = 1, right = 9,
 #'     na_pass = TRUE
 #'   ) %>%
@@ -300,7 +300,7 @@
 #' 
 #' ```r
 #' expect_col_vals_between(
-#'   small_table, columns = vars(c),
+#'   small_table, columns = c,
 #'   left = 1, right = 9,
 #'   na_pass = TRUE
 #' )
@@ -314,7 +314,7 @@
 #' ```{r}
 #' small_table %>%
 #'   test_col_vals_between(
-#'     columns = vars(c),
+#'     columns = c,
 #'     left = 1, right = 9,
 #'     na_pass = TRUE
 #'   )
@@ -331,7 +331,7 @@
 #' ```{r}
 #' small_table %>%
 #'   test_col_vals_between(
-#'     columns = vars(c), left = 1, right = 9,
+#'     columns = c, left = 1, right = 9,
 #'     inclusive = c(TRUE, FALSE),
 #'     na_pass = TRUE
 #'   )

--- a/R/col_vals_between.R
+++ b/R/col_vals_between.R
@@ -365,13 +365,10 @@ col_vals_between <- function(
     active = TRUE
 ) {
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
 
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions)

--- a/R/col_vals_decreasing.R
+++ b/R/col_vals_decreasing.R
@@ -85,12 +85,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names to `columns`, the result will be an
-#' expansion of validation steps to that number of column names (e.g.,
-#' `vars(col_a, col_b)` will result in the entry of two validation steps). Aside
-#' from column names in quotes and in `vars()`, **tidyselect** helper functions
-#' are available for specifying columns. They are: `starts_with()`,
-#' `ends_with()`, `contains()`, `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #'
 #' @section Missing Values:
 #' 

--- a/R/col_vals_decreasing.R
+++ b/R/col_vals_decreasing.R
@@ -189,7 +189,7 @@
 #' ```r
 #' agent %>% 
 #'   col_vals_decreasing(
-#'     columns = vars(a),
+#'     columns = a,
 #'     allow_stationary = TRUE,
 #'     increasing_tol = 0.5,
 #'     na_pass = TRUE,
@@ -259,7 +259,7 @@
 #' agent <-
 #'   create_agent(tbl = game_revenue_2) %>%
 #'   col_vals_decreasing(
-#'     columns = vars(time_left),
+#'     columns = time_left,
 #'     allow_stationary = TRUE
 #'   ) %>%
 #'   interrogate()
@@ -284,7 +284,7 @@
 #' ```{r}
 #' game_revenue_2 %>%
 #'   col_vals_decreasing(
-#'     columns = vars(time_left),
+#'     columns = time_left,
 #'     allow_stationary = TRUE
 #'   ) %>%
 #'   dplyr::select(time_left) %>%
@@ -300,7 +300,7 @@
 #' ```r
 #' expect_col_vals_decreasing(
 #'   game_revenue_2,
-#'   columns = vars(time_left),
+#'   columns = time_left,
 #'   allow_stationary = TRUE
 #' )
 #' ```
@@ -313,7 +313,7 @@
 #' ```{r}
 #' game_revenue_2 %>%
 #'   test_col_vals_decreasing(
-#'     columns = vars(time_left),
+#'     columns = time_left,
 #'     allow_stationary = TRUE
 #'   )
 #' ```

--- a/R/col_vals_decreasing.R
+++ b/R/col_vals_decreasing.R
@@ -170,6 +170,20 @@
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_vals_decreasing.R
+++ b/R/col_vals_decreasing.R
@@ -346,13 +346,10 @@ col_vals_decreasing <- function(
     active = TRUE
 ) {
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions)

--- a/R/col_vals_decreasing.R
+++ b/R/col_vals_decreasing.R
@@ -206,7 +206,7 @@
 #' ```yaml
 #' steps:
 #' - col_vals_decreasing:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     allow_stationary: true
 #'     increasing_tol: 0.5
 #'     na_pass: true

--- a/R/col_vals_equal.R
+++ b/R/col_vals_equal.R
@@ -191,7 +191,7 @@
 #' ```yaml
 #' steps:
 #' - col_vals_equal:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     value: 1.0
 #'     na_pass: true
 #'     preconditions: ~. %>% dplyr::filter(a < 10)

--- a/R/col_vals_equal.R
+++ b/R/col_vals_equal.R
@@ -308,13 +308,10 @@ col_vals_equal <- function(
     active = TRUE
 ) {
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions)

--- a/R/col_vals_equal.R
+++ b/R/col_vals_equal.R
@@ -156,6 +156,20 @@
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_vals_equal.R
+++ b/R/col_vals_equal.R
@@ -71,12 +71,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names to `columns`, the result will be an
-#' expansion of validation steps to that number of column names (e.g.,
-#' `vars(col_a, col_b)` will result in the entry of two validation steps). Aside
-#' from column names in quotes and in `vars()`, **tidyselect** helper functions
-#' are available for specifying columns. They are: `starts_with()`,
-#' `ends_with()`, `contains()`, `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #'
 #' @section Missing Values:
 #' 

--- a/R/col_vals_equal.R
+++ b/R/col_vals_equal.R
@@ -175,7 +175,7 @@
 #' ```r
 #' agent %>% 
 #'   col_vals_equal(
-#'     columns = vars(a),
+#'     columns = a,
 #'     value = 1,
 #'     na_pass = TRUE,
 #'     preconditions = ~ . %>% dplyr::filter(a < 10),
@@ -238,7 +238,7 @@
 #' ```r
 #' agent <-
 #'   create_agent(tbl = tbl) %>%
-#'   col_vals_equal(columns = vars(a), value = 5) %>%
+#'   col_vals_equal(columns = a, value = 5) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -260,7 +260,7 @@
 #' 
 #' ```{r}
 #' tbl %>% 
-#'   col_vals_equal(columns = vars(a), value = 5) %>%
+#'   col_vals_equal(columns = a, value = 5) %>%
 #'   dplyr::pull(a)
 #' ```
 #'   
@@ -270,7 +270,7 @@
 #' time. This is primarily used in **testthat** tests.
 #' 
 #' ```r
-#' expect_col_vals_equal(tbl, columns = vars(a), value = 5)
+#' expect_col_vals_equal(tbl, columns = a, value = 5)
 #' ```
 #' 
 #' ## D: Using the test function
@@ -279,7 +279,7 @@
 #' us.
 #' 
 #' ```{r}
-#' test_col_vals_equal(tbl, columns = vars(a), value = 5)
+#' test_col_vals_equal(tbl, columns = a, value = 5)
 #' ```
 #' 
 #' @family validation functions

--- a/R/col_vals_expr.R
+++ b/R/col_vals_expr.R
@@ -134,6 +134,20 @@
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_vals_gt.R
+++ b/R/col_vals_gt.R
@@ -297,7 +297,7 @@
 #' ```r
 #' agent %>% 
 #'   col_vals_gt(
-#'     columns = vars(a),
+#'     columns = a,
 #'     value = 1,
 #'     na_pass = TRUE,
 #'     preconditions = ~ . %>% dplyr::filter(a < 10),
@@ -360,7 +360,7 @@
 #' ```r
 #' agent <-
 #'   create_agent(tbl = tbl) %>%
-#'   col_vals_gt(columns = vars(a), value = 4) %>%
+#'   col_vals_gt(columns = a, value = 4) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -381,7 +381,7 @@
 #' behavior of side effects can be customized with the `actions` option.
 #' 
 #' ```{r}
-#' tbl %>% col_vals_gt(columns = vars(a), value = 4)
+#' tbl %>% col_vals_gt(columns = a, value = 4)
 #' ```
 #'   
 #' ## C: Using the expectation function
@@ -390,7 +390,7 @@
 #' time. This is primarily used in **testthat** tests.
 #' 
 #' ```r
-#' expect_col_vals_gt(tbl, columns = vars(a), value = 4)
+#' expect_col_vals_gt(tbl, columns = a, value = 4)
 #' ```
 #' 
 #' ## D: Using the test function
@@ -399,7 +399,7 @@
 #' us.
 #' 
 #' ```{r}
-#' test_col_vals_gt(tbl, columns = vars(a), value = 4)
+#' test_col_vals_gt(tbl, columns = a, value = 4)
 #' ```
 #' 
 #' @family validation functions

--- a/R/col_vals_gt.R
+++ b/R/col_vals_gt.R
@@ -131,12 +131,19 @@
 #'   means that 15 percent of failing test units results in an overall test
 #'   failure.
 #'   
-#' @param label *An optional label for the validation step*
+#' @param label *Optional label for the validation step*
 #' 
-#'   `scalar<character>` // *default:* `NULL` (`optional`)
+#'   `vector<character>` // *default:* `NULL` (`optional`)
 #' 
-#'   An optional label for the validation step. This label appears in the
-#'   *agent* report and, for the best appearance, it should be kept quite short.
+#'   Optional label for the validation step. This label appears in the *agent*
+#'   report and, for the best appearance, it should be kept quite short.
+#'   
+#'   Label may be a single string or a vector of labels that match the number
+#'   of expanded steps (typically, the number of column-segment combinations).
+#'   
+#'   For validations that get expanded into multiple steps internally, `label`
+#'   exposes information about the current step via `{glue}` syntax (e.g. 
+#'   "{.col}" for column name).
 #'   
 #' @param brief *Brief description for the validation step*
 #' 

--- a/R/col_vals_gt.R
+++ b/R/col_vals_gt.R
@@ -200,8 +200,8 @@
 #' are also supported, such as `contains("date")` and `where(is.double)`. If
 #' passing an *external vector* of columns, it should be wrapped in `all_of()`.
 #' 
-#' If providing multiple column names to `columns`, the result will be an
-#' expansion of validation steps to that number of column names (e.g.,
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
 #' `c(col_a, col_b)` will result in the entry of two validation steps).
 #' 
 #' Previously, columns could be specified in `vars()`. This continues to work, 

--- a/R/col_vals_gt.R
+++ b/R/col_vals_gt.R
@@ -292,7 +292,7 @@
 #' - `"{.seg_val}"`: The current segment's value/group
 #'     
 #' The glue context also supports ordinary expressions for further flexibility
-#' (ex: `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
 #' 
 #' @section Briefs:
 #' 

--- a/R/col_vals_gt.R
+++ b/R/col_vals_gt.R
@@ -143,7 +143,7 @@
 #'   
 #'   For validations that get expanded into multiple steps internally, `label`
 #'   exposes information about the current step via `{glue}` syntax (e.g. 
-#'   "{.col}" for column name).
+#'   "{.col}" for column name). See the *Label* section for more information.
 #'   
 #' @param brief *Brief description for the validation step*
 #' 

--- a/R/col_vals_gt.R
+++ b/R/col_vals_gt.R
@@ -313,7 +313,7 @@
 #' ```yaml
 #' steps:
 #' - col_vals_gt:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     value: 1.0
 #'     na_pass: true
 #'     preconditions: ~. %>% dplyr::filter(a < 10)

--- a/R/col_vals_gt.R
+++ b/R/col_vals_gt.R
@@ -428,13 +428,10 @@ col_vals_gt <- function(
     active = TRUE
 ) {
 
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions)

--- a/R/col_vals_gt.R
+++ b/R/col_vals_gt.R
@@ -53,10 +53,11 @@
 #'   
 #' @param columns *The target columns*
 #' 
-#'   `<column-targeting expression>` // **required**
+#'   `<tidy-select>` // **required**
 #' 
-#'   The column (or a set of columns, provided as a character vector) to which
-#'   this validation should be applied.
+#'   A column-selecting expression, as one would use inside `dplyr::select()`.
+#'   Specifies the column (or a set of columns) to which this validation should
+#'   be applied. See the *Column Names* section for more information.
 #'   
 #' @param value *Value for comparison*
 #' 

--- a/R/col_vals_gt.R
+++ b/R/col_vals_gt.R
@@ -201,12 +201,17 @@
 #'
 #' @section Column Names:
 #' 
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
 #' If providing multiple column names to `columns`, the result will be an
 #' expansion of validation steps to that number of column names (e.g.,
-#' `vars(col_a, col_b)` will result in the entry of two validation steps). Aside
-#' from column names in quotes and in `vars()`, **tidyselect** helper functions
-#' are available for specifying columns. They are: `starts_with()`,
-#' `ends_with()`, `contains()`, `matches()`, and `everything()`.
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #'
 #' @section Missing Values:
 #' 

--- a/R/col_vals_gt.R
+++ b/R/col_vals_gt.R
@@ -137,14 +137,8 @@
 #'   `vector<character>` // *default:* `NULL` (`optional`)
 #' 
 #'   Optional label for the validation step. This label appears in the *agent*
-#'   report and, for the best appearance, it should be kept quite short.
-#'   
-#'   Label may be a single string or a vector of labels that match the number
-#'   of expanded steps (typically, the number of column-segment combinations).
-#'   
-#'   For validations that get expanded into multiple steps internally, `label`
-#'   exposes information about the current step via `{glue}` syntax (e.g. 
-#'   "{.col}" for column name). See the *Label* section for more information.
+#'   report and, for the best appearance, it should be kept quite short. See
+#'   the *Labels* section for more information.
 #'   
 #' @param brief *Brief description for the validation step*
 #' 
@@ -285,6 +279,20 @@
 #' choices depending on the situation (the first produces a warning when a
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
+#' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (ex: `"{toupper(.step)}"`) as long as they return a length-1 string.
 #' 
 #' @section Briefs:
 #' 

--- a/R/col_vals_gte.R
+++ b/R/col_vals_gte.R
@@ -157,6 +157,20 @@
 #' situation (the first produces a warning when a quarter of the total test
 #' units fails, the other `stop()`s at the same threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_vals_gte.R
+++ b/R/col_vals_gte.R
@@ -307,13 +307,10 @@ col_vals_gte <- function(
     active = TRUE
 ) {
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions)

--- a/R/col_vals_gte.R
+++ b/R/col_vals_gte.R
@@ -73,12 +73,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names to `columns`, the result will be an
-#' expansion of validation steps to that number of column names (e.g.,
-#' `vars(col_a, col_b)` will result in the entry of two validation steps). Aside
-#' from column names in quotes and in `vars()`, **tidyselect** helper functions
-#' are available for specifying columns. They are: `starts_with()`,
-#' `ends_with()`, `contains()`, `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #'
 #' @section Missing Values:
 #' 

--- a/R/col_vals_gte.R
+++ b/R/col_vals_gte.R
@@ -192,7 +192,7 @@
 #' ```yaml
 #' steps:
 #' - col_vals_gte:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     value: 1.0
 #'     na_pass: true
 #'     preconditions: ~. %>% dplyr::filter(a < 10)

--- a/R/col_vals_gte.R
+++ b/R/col_vals_gte.R
@@ -176,7 +176,7 @@
 #' ```r
 #' agent %>% 
 #'   col_vals_gte(
-#'     columns = vars(a),
+#'     columns = a,
 #'     value = 1,
 #'     na_pass = TRUE,
 #'     preconditions = ~ . %>% dplyr::filter(a < 10),
@@ -239,7 +239,7 @@
 #' ```r
 #' agent <-
 #'   create_agent(tbl = tbl) %>%
-#'   col_vals_gte(columns = vars(a), value = 5) %>%
+#'   col_vals_gte(columns = a, value = 5) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -260,7 +260,7 @@
 #' behavior of side effects can be customized with the `actions` option.
 #' 
 #' ```{r}
-#' tbl %>% col_vals_gte(columns = vars(a), value = 5)
+#' tbl %>% col_vals_gte(columns = a, value = 5)
 #' ```
 #'   
 #' ## C: Using the expectation function
@@ -269,7 +269,7 @@
 #' time. This is primarily used in **testthat** tests.
 #' 
 #' ```r
-#' expect_col_vals_gte(tbl, columns = vars(a), value = 5)
+#' expect_col_vals_gte(tbl, columns = a, value = 5)
 #' ```
 #' 
 #' ## D: Using the test function
@@ -278,7 +278,7 @@
 #' us.
 #' 
 #' ```{r}
-#' test_col_vals_gte(tbl, columns = vars(a), value = 5)
+#' test_col_vals_gte(tbl, columns = a, value = 5)
 #' ```
 #' 
 #' @family validation functions

--- a/R/col_vals_in_set.R
+++ b/R/col_vals_in_set.R
@@ -69,12 +69,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names, the result will be an expansion of
-#' validation steps to that number of column names (e.g., `vars(col_a, col_b)`
-#' will result in the entry of two validation steps). Aside from column names in
-#' quotes and in `vars()`, **tidyselect** helper functions are available for
-#' specifying columns. They are: `starts_with()`, `ends_with()`, `contains()`,
-#' `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #' 
 #' @section Preconditions:
 #' 

--- a/R/col_vals_in_set.R
+++ b/R/col_vals_in_set.R
@@ -147,6 +147,20 @@
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_vals_in_set.R
+++ b/R/col_vals_in_set.R
@@ -301,13 +301,10 @@ col_vals_in_set <- function(
     active = TRUE
 ) {
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions)

--- a/R/col_vals_in_set.R
+++ b/R/col_vals_in_set.R
@@ -181,7 +181,7 @@
 #' ```yaml
 #' steps:
 #' - col_vals_in_set:
-#'    columns: vars(a)
+#'    columns: c(a)
 #'    set:
 #'    - 1.0
 #'    - 2.0

--- a/R/col_vals_in_set.R
+++ b/R/col_vals_in_set.R
@@ -166,7 +166,7 @@
 #' ```r
 #' agent %>% 
 #'   col_vals_in_set(
-#'     columns = vars(a),
+#'     columns = a,
 #'     set = c(1, 2, 3, 4),
 #'     preconditions = ~ . %>% dplyr::filter(a < 10),
 #'     segments = b ~ c("group_1", "group_2"),
@@ -222,7 +222,7 @@
 #' agent <-
 #'   create_agent(tbl = small_table) %>%
 #'   col_vals_in_set(
-#'     columns = vars(f), set = c("low", "mid", "high")
+#'     columns = f, set = c("low", "mid", "high")
 #'   ) %>%
 #'   interrogate()
 #' ```
@@ -246,7 +246,7 @@
 #' ```{r}
 #' small_table %>%
 #'   col_vals_in_set(
-#'     columns = vars(f), set = c("low", "mid", "high")
+#'     columns = f, set = c("low", "mid", "high")
 #'   ) %>%
 #'   dplyr::pull(f) %>%
 #'   unique()
@@ -260,7 +260,7 @@
 #' ```r
 #' expect_col_vals_in_set(
 #'   small_table,
-#'   columns = vars(f), set = c("low", "mid", "high")
+#'   columns = f, set = c("low", "mid", "high")
 #' )
 #' ```
 #' 
@@ -272,7 +272,7 @@
 #' ```{r}
 #' small_table %>%
 #'   test_col_vals_in_set(
-#'     columns = vars(f), set = c("low", "mid", "high")
+#'     columns = f, set = c("low", "mid", "high")
 #'   )
 #' ```
 #' 

--- a/R/col_vals_increasing.R
+++ b/R/col_vals_increasing.R
@@ -85,12 +85,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names to `columns`, the result will be an
-#' expansion of validation steps to that number of column names (e.g.,
-#' `vars(col_a, col_b)` will result in the entry of two validation steps). Aside
-#' from column names in quotes and in `vars()`, **tidyselect** helper functions
-#' are available for specifying columns. They are: `starts_with()`,
-#' `ends_with()`, `contains()`, `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #'
 #' @section Missing Values:
 #' 

--- a/R/col_vals_increasing.R
+++ b/R/col_vals_increasing.R
@@ -206,7 +206,7 @@
 #' ```yaml
 #' steps:
 #' - col_vals_increasing:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     allow_stationary: true
 #'     decreasing_tol: 0.5
 #'     na_pass: true

--- a/R/col_vals_increasing.R
+++ b/R/col_vals_increasing.R
@@ -334,13 +334,10 @@ col_vals_increasing <- function(
     active = TRUE
 ) {
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions)

--- a/R/col_vals_increasing.R
+++ b/R/col_vals_increasing.R
@@ -170,6 +170,20 @@
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_vals_increasing.R
+++ b/R/col_vals_increasing.R
@@ -189,7 +189,7 @@
 #' ```r
 #' agent %>% 
 #'   col_vals_increasing(
-#'     columns = vars(a),
+#'     columns = a,
 #'     allow_stationary = TRUE,
 #'     decreasing_tol = 0.5,
 #'     na_pass = TRUE,
@@ -247,7 +247,7 @@
 #' agent <-
 #'   create_agent(tbl = game_revenue) %>%
 #'   col_vals_increasing(
-#'     columns = vars(session_start),
+#'     columns = session_start,
 #'     allow_stationary = TRUE
 #'   ) %>%
 #'   interrogate()
@@ -272,7 +272,7 @@
 #' ```{r}
 #' game_revenue %>%
 #'   col_vals_increasing(
-#'     columns = vars(session_start),
+#'     columns = session_start,
 #'     allow_stationary = TRUE
 #'   ) %>%
 #'   dplyr::select(session_start) %>%
@@ -288,7 +288,7 @@
 #' ```r
 #' expect_col_vals_increasing(
 #'   game_revenue,
-#'   columns = vars(session_start),
+#'   columns = session_start,
 #'   allow_stationary = TRUE
 #' )
 #' ```
@@ -301,7 +301,7 @@
 #' ```{r}
 #' game_revenue %>%
 #'   test_col_vals_increasing(
-#'     columns = vars(session_start),
+#'     columns = session_start,
 #'     allow_stationary = TRUE
 #'   )
 #' ```

--- a/R/col_vals_lt.R
+++ b/R/col_vals_lt.R
@@ -309,13 +309,10 @@ col_vals_lt <- function(
     active = TRUE
 ) {
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions)

--- a/R/col_vals_lt.R
+++ b/R/col_vals_lt.R
@@ -192,7 +192,7 @@
 #' ```yaml
 #' steps:
 #' - col_vals_lt:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     value: 1.0
 #'     na_pass: true
 #'     preconditions: ~. %>% dplyr::filter(a < 10)

--- a/R/col_vals_lt.R
+++ b/R/col_vals_lt.R
@@ -157,6 +157,20 @@
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_vals_lt.R
+++ b/R/col_vals_lt.R
@@ -72,12 +72,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names to `columns`, the result will be an
-#' expansion of validation steps to that number of column names (e.g.,
-#' `vars(col_a, col_b)` will result in the entry of two validation steps). Aside
-#' from column names in quotes and in `vars()`, **tidyselect** helper functions
-#' are available for specifying columns. They are: `starts_with()`,
-#' `ends_with()`, `contains()`, `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #'
 #' @section Missing Values:
 #' 

--- a/R/col_vals_lt.R
+++ b/R/col_vals_lt.R
@@ -176,7 +176,7 @@
 #' ```r
 #' agent %>% 
 #'   col_vals_lt(
-#'     columns = vars(a),
+#'     columns = a,
 #'     value = 1,
 #'     na_pass = TRUE,
 #'     preconditions = ~ . %>% dplyr::filter(a < 10),
@@ -239,7 +239,7 @@
 #' ```r
 #' agent <-
 #'   create_agent(tbl = tbl) %>%
-#'   col_vals_lt(columns = vars(c), value = 5) %>%
+#'   col_vals_lt(columns = c, value = 5) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -261,7 +261,7 @@
 #' 
 #' ```{r}
 #' tbl %>% 
-#'   col_vals_lt(columns = vars(c), value = 5) %>%
+#'   col_vals_lt(columns = c, value = 5) %>%
 #'   dplyr::pull(c)
 #' ```
 #'   
@@ -271,7 +271,7 @@
 #' time. This is primarily used in **testthat** tests.
 #' 
 #' ```r
-#' expect_col_vals_lt(tbl, columns = vars(c), value = 5)
+#' expect_col_vals_lt(tbl, columns = c, value = 5)
 #' ```
 #' 
 #' ## D: Using the test function
@@ -280,7 +280,7 @@
 #' us.
 #' 
 #' ```{r}
-#' test_col_vals_lt(tbl, columns = vars(c), value = 5)
+#' test_col_vals_lt(tbl, columns = c, value = 5)
 #' ```
 #' 
 #' @family validation functions

--- a/R/col_vals_lte.R
+++ b/R/col_vals_lte.R
@@ -158,6 +158,20 @@
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_vals_lte.R
+++ b/R/col_vals_lte.R
@@ -73,12 +73,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names to `columns`, the result will be an
-#' expansion of validation steps to that number of column names (e.g.,
-#' `vars(col_a, col_b)` will result in the entry of two validation steps). Aside
-#' from column names in quotes and in `vars()`, **tidyselect** helper functions
-#' are available for specifying columns. They are: `starts_with()`,
-#' `ends_with()`, `contains()`, `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #'
 #' @section Missing Values:
 #' 

--- a/R/col_vals_lte.R
+++ b/R/col_vals_lte.R
@@ -193,7 +193,7 @@
 #' ```yaml
 #' steps:
 #' - col_vals_lte:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     value: 1.0
 #'     na_pass: true
 #'     preconditions: ~. %>% dplyr::filter(a < 10)

--- a/R/col_vals_lte.R
+++ b/R/col_vals_lte.R
@@ -310,13 +310,10 @@ col_vals_lte <- function(
     active = TRUE
 ) {
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions)

--- a/R/col_vals_lte.R
+++ b/R/col_vals_lte.R
@@ -177,7 +177,7 @@
 #' ```r
 #' agent %>% 
 #'   col_vals_lte(
-#'     columns = vars(a),
+#'     columns = a,
 #'     value = 1,
 #'     na_pass = TRUE,
 #'     preconditions = ~ . %>% dplyr::filter(a < 10),
@@ -240,7 +240,7 @@
 #' ```r
 #' agent <-
 #'   create_agent(tbl = tbl) %>%
-#'   col_vals_lte(columns = vars(c), value = 4) %>%
+#'   col_vals_lte(columns = c, value = 4) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -262,7 +262,7 @@
 #' 
 #' ```{r}
 #' tbl %>% 
-#'   col_vals_lte(columns = vars(c), value = 4) %>%
+#'   col_vals_lte(columns = c, value = 4) %>%
 #'   dplyr::pull(c)
 #' ```
 #'   
@@ -272,7 +272,7 @@
 #' time. This is primarily used in **testthat** tests.
 #' 
 #' ```r
-#' expect_col_vals_lte(tbl, columns = vars(c), value = 4)
+#' expect_col_vals_lte(tbl, columns = c, value = 4)
 #' ```
 #' 
 #' ## D: Using the test function
@@ -281,7 +281,7 @@
 #' us.
 #' 
 #' ```{r}
-#' test_col_vals_lte(tbl, columns = vars(c), value = 4)
+#' test_col_vals_lte(tbl, columns = c, value = 4)
 #' ```
 #' 
 #' @family validation functions

--- a/R/col_vals_make_set.R
+++ b/R/col_vals_make_set.R
@@ -170,7 +170,7 @@
 #' ```r
 #' agent %>% 
 #'   col_vals_make_set(
-#'     columns = vars(a),
+#'     columns = a,
 #'     set = c(1, 2, 3, 4),
 #'     preconditions = ~ . %>% dplyr::filter(a < 10),
 #'     segments = b ~ c("group_1", "group_2"),
@@ -226,7 +226,7 @@
 #' agent <-
 #'   create_agent(tbl = small_table) %>%
 #'   col_vals_make_set(
-#'     columns = vars(f), set = c("low", "mid", "high")
+#'     columns = f, set = c("low", "mid", "high")
 #'   ) %>%
 #'   interrogate()
 #' ```
@@ -250,7 +250,7 @@
 #' ```{r}
 #' small_table %>%
 #'   col_vals_make_set(
-#'     columns = vars(f), set = c("low", "mid", "high")
+#'     columns = f, set = c("low", "mid", "high")
 #'   ) %>%
 #'   dplyr::pull(f) %>%
 #'   unique()
@@ -264,7 +264,7 @@
 #' ```r
 #' expect_col_vals_make_set(
 #'   small_table,
-#'   columns = vars(f), set = c("low", "mid", "high")
+#'   columns = f, set = c("low", "mid", "high")
 #' )
 #' ```
 #' 
@@ -276,7 +276,7 @@
 #' ```{r}
 #' small_table %>%
 #'   test_col_vals_make_set(
-#'     columns = vars(f), set = c("low", "mid", "high")
+#'     columns = f, set = c("low", "mid", "high")
 #'   )
 #' ```
 #' 

--- a/R/col_vals_make_set.R
+++ b/R/col_vals_make_set.R
@@ -303,13 +303,10 @@ col_vals_make_set <- function(
     active = TRUE
 ) {
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions)

--- a/R/col_vals_make_set.R
+++ b/R/col_vals_make_set.R
@@ -73,12 +73,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names, the result will be an expansion of
-#' validation steps to that number of column names (e.g., `vars(col_a, col_b)`
-#' will result in the entry of two validation steps). Aside from column names in
-#' quotes and in `vars()`, **tidyselect** helper functions are available for
-#' specifying columns. They are: `starts_with()`, `ends_with()`, `contains()`,
-#' `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #' 
 #' @section Preconditions:
 #' 

--- a/R/col_vals_make_set.R
+++ b/R/col_vals_make_set.R
@@ -185,7 +185,7 @@
 #' ```yaml
 #' steps:
 #' - col_vals_make_set:
-#'    columns: vars(a)
+#'    columns: c(a)
 #'    set:
 #'    - 1.0
 #'    - 2.0

--- a/R/col_vals_make_set.R
+++ b/R/col_vals_make_set.R
@@ -151,6 +151,20 @@
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_vals_make_subset.R
+++ b/R/col_vals_make_subset.R
@@ -69,12 +69,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names, the result will be an expansion of
-#' validation steps to that number of column names (e.g., `vars(col_a, col_b)`
-#' will result in the entry of two validation steps). Aside from column names in
-#' quotes and in `vars()`, **tidyselect** helper functions are available for
-#' specifying columns. They are: `starts_with()`, `ends_with()`, `contains()`,
-#' `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #' 
 #' @section Preconditions:
 #' 

--- a/R/col_vals_make_subset.R
+++ b/R/col_vals_make_subset.R
@@ -300,13 +300,10 @@ col_vals_make_subset <- function(
     active = TRUE
 ) {
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions)

--- a/R/col_vals_make_subset.R
+++ b/R/col_vals_make_subset.R
@@ -147,6 +147,20 @@
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_vals_make_subset.R
+++ b/R/col_vals_make_subset.R
@@ -166,7 +166,7 @@
 #' ```r
 #' agent %>% 
 #'   col_vals_make_subset(
-#'     columns = vars(a),
+#'     columns = a,
 #'     set = c(1, 2, 3, 4),
 #'     preconditions = ~ . %>% dplyr::filter(a < 10),
 #'     segments = b ~ c("group_1", "group_2"),
@@ -223,7 +223,7 @@
 #' agent <-
 #'   create_agent(tbl = small_table) %>%
 #'   col_vals_make_subset(
-#'     columns = vars(f), set = c("low", "high")
+#'     columns = f, set = c("low", "high")
 #'   ) %>%
 #'   interrogate()
 #' ```
@@ -247,7 +247,7 @@
 #' ```{r}
 #' small_table %>%
 #'   col_vals_make_subset(
-#'     columns = vars(f), set = c("low", "high")
+#'     columns = f, set = c("low", "high")
 #'   ) %>%
 #'   dplyr::pull(f) %>%
 #'   unique()
@@ -261,7 +261,7 @@
 #' ```r
 #' expect_col_vals_make_subset(
 #'   small_table,
-#'   columns = vars(f), set = c("low", "high")
+#'   columns = f, set = c("low", "high")
 #' )
 #' ```
 #' 
@@ -273,7 +273,7 @@
 #' ```{r}
 #' small_table %>%
 #'   test_col_vals_make_subset(
-#'     columns = vars(f), set = c("low", "high")
+#'     columns = f, set = c("low", "high")
 #'   )
 #' ```
 #' 

--- a/R/col_vals_make_subset.R
+++ b/R/col_vals_make_subset.R
@@ -181,7 +181,7 @@
 #' ```yaml
 #' steps:
 #' - col_vals_make_subset:
-#'    columns: vars(a)
+#'    columns: c(a)
 #'    set:
 #'    - 1.0
 #'    - 2.0

--- a/R/col_vals_not_between.R
+++ b/R/col_vals_not_between.R
@@ -368,13 +368,10 @@ col_vals_not_between <- function(
     active = TRUE
 ) {
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions)

--- a/R/col_vals_not_between.R
+++ b/R/col_vals_not_between.R
@@ -181,6 +181,20 @@
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_vals_not_between.R
+++ b/R/col_vals_not_between.R
@@ -200,7 +200,7 @@
 #' ```r
 #' agent %>% 
 #'   col_vals_not_between(
-#'     columns = vars(a),
+#'     columns = a,
 #'     left = 1,
 #'     right = 2,
 #'     inclusive = c(TRUE, FALSE),
@@ -262,7 +262,7 @@
 #' agent <-
 #'   create_agent(tbl = small_table) %>%
 #'   col_vals_not_between(
-#'     columns = vars(c),
+#'     columns = c,
 #'     left = 10, right = 20,
 #'     na_pass = TRUE
 #'   ) %>%
@@ -288,7 +288,7 @@
 #' ```{r}
 #' small_table %>%
 #'   col_vals_not_between(
-#'     columns = vars(c),
+#'     columns = c,
 #'     left = 10, right = 20,
 #'     na_pass = TRUE
 #'   ) %>%
@@ -302,7 +302,7 @@
 #' 
 #' ```r
 #' expect_col_vals_not_between(
-#'   small_table, columns = vars(c),
+#'   small_table, columns = c,
 #'   left = 10, right = 20,
 #'   na_pass = TRUE
 #' )
@@ -316,7 +316,7 @@
 #' ```{r}
 #' small_table %>%
 #'   test_col_vals_not_between(
-#'     columns = vars(c),
+#'     columns = c,
 #'     left = 10, right = 20,
 #'     na_pass = TRUE
 #'   )
@@ -333,7 +333,7 @@
 #' ```{r}
 #' small_table %>%
 #'   test_col_vals_not_between(
-#'     columns = vars(c),
+#'     columns = c,
 #'     left = 9, right = 20,
 #'     inclusive = c(FALSE, TRUE),
 #'     na_pass = TRUE

--- a/R/col_vals_not_between.R
+++ b/R/col_vals_not_between.R
@@ -218,7 +218,7 @@
 #' ```yaml
 #' steps:
 #' - col_vals_not_between:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     left: 1.0
 #'     right: 2.0
 #'     inclusive:

--- a/R/col_vals_not_between.R
+++ b/R/col_vals_not_between.R
@@ -96,12 +96,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names to `columns`, the result will be an
-#' expansion of validation steps to that number of column names (e.g.,
-#' `vars(col_a, col_b)` will result in the entry of two validation steps). Aside
-#' from column names in quotes and in `vars()`, **tidyselect** helper functions
-#' are available for specifying columns. They are: `starts_with()`,
-#' `ends_with()`, `contains()`, `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #'
 #' @section Missing Values:
 #' 

--- a/R/col_vals_not_equal.R
+++ b/R/col_vals_not_equal.R
@@ -307,13 +307,10 @@ col_vals_not_equal <- function(
     active = TRUE
 ) {
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions)

--- a/R/col_vals_not_equal.R
+++ b/R/col_vals_not_equal.R
@@ -190,7 +190,7 @@
 #' ```yaml
 #' steps:
 #' - col_vals_not_equal:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     value: 1.0
 #'     na_pass: true
 #'     preconditions: ~. %>% dplyr::filter(a < 10)

--- a/R/col_vals_not_equal.R
+++ b/R/col_vals_not_equal.R
@@ -70,12 +70,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names, the result will be an expansion of
-#' validation steps to that number of column names (e.g., `vars(col_a, col_b)`
-#' will result in the entry of two validation steps). Aside from column names in
-#' quotes and in `vars()`, **tidyselect** helper functions are available for
-#' specifying columns. They are: `starts_with()`, `ends_with()`, `contains()`,
-#' `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #'
 #' @section Missing Values:
 #' 

--- a/R/col_vals_not_equal.R
+++ b/R/col_vals_not_equal.R
@@ -174,7 +174,7 @@
 #' ```r
 #' agent %>% 
 #'   col_vals_not_equal(
-#'     columns = vars(a),
+#'     columns = a,
 #'     value = 1,
 #'     na_pass = TRUE,
 #'     preconditions = ~ . %>% dplyr::filter(a < 10),
@@ -237,7 +237,7 @@
 #' ```r
 #' agent <-
 #'   create_agent(tbl = tbl) %>%
-#'   col_vals_not_equal(columns = vars(a), value = 6) %>%
+#'   col_vals_not_equal(columns = a, value = 6) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -259,7 +259,7 @@
 #' 
 #' ```{r}
 #' tbl %>% 
-#'   col_vals_not_equal(columns = vars(a), value = 6) %>%
+#'   col_vals_not_equal(columns = a, value = 6) %>%
 #'   dplyr::pull(a)
 #' ```
 #'   
@@ -269,7 +269,7 @@
 #' time. This is primarily used in **testthat** tests.
 #' 
 #' ```r
-#' expect_col_vals_not_equal(tbl, columns = vars(a), value = 6)
+#' expect_col_vals_not_equal(tbl, columns = a, value = 6)
 #' ```
 #' 
 #' ## D: Using the test function
@@ -278,7 +278,7 @@
 #' us.
 #' 
 #' ```{r}
-#' test_col_vals_not_equal(tbl, columns = vars(a), value = 6)
+#' test_col_vals_not_equal(tbl, columns = a, value = 6)
 #' ```
 #' 
 #' @family validation functions

--- a/R/col_vals_not_equal.R
+++ b/R/col_vals_not_equal.R
@@ -155,6 +155,20 @@
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_vals_not_in_set.R
+++ b/R/col_vals_not_in_set.R
@@ -69,12 +69,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names, the result will be an expansion of
-#' validation steps to that number of column names (e.g., `vars(col_a, col_b)`
-#' will result in the entry of two validation steps). Aside from column names in
-#' quotes and in `vars()`, **tidyselect** helper functions are available for
-#' specifying columns. They are: `starts_with()`, `ends_with()`, `contains()`,
-#' `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #' 
 #' @section Preconditions:
 #' 

--- a/R/col_vals_not_in_set.R
+++ b/R/col_vals_not_in_set.R
@@ -166,7 +166,7 @@
 #' ```r
 #' agent %>% 
 #'   col_vals_not_in_set(
-#'     columns = vars(a),
+#'     columns = a,
 #'     set = c(1, 2, 3, 4),
 #'     preconditions = ~ . %>% dplyr::filter(a < 10),
 #'     segments = b ~ c("group_1", "group_2"),
@@ -218,7 +218,7 @@
 #' agent <-
 #'   create_agent(tbl = small_table) %>%
 #'   col_vals_not_in_set(
-#'     columns = vars(f), set = c("lows", "mids", "highs")
+#'     columns = f, set = c("lows", "mids", "highs")
 #'   ) %>%
 #'   interrogate()
 #' ```
@@ -242,7 +242,7 @@
 #' ```
 #' small_table %>%
 #'   col_vals_not_in_set(
-#'     columns = vars(f), set = c("lows", "mids", "highs")
+#'     columns = f, set = c("lows", "mids", "highs")
 #'   ) %>%
 #'   dplyr::pull(f) %>%
 #'   unique()
@@ -256,7 +256,7 @@
 #' ```r
 #' expect_col_vals_not_in_set(
 #'   small_table,
-#'   columns = vars(f), set = c("lows", "mids", "highs")
+#'   columns = f, set = c("lows", "mids", "highs")
 #' )
 #' ```
 #' 
@@ -268,7 +268,7 @@
 #' ```{r}
 #' small_table %>%
 #'   test_col_vals_not_in_set(
-#'     columns = vars(f), set = c("lows", "mids", "highs")
+#'     columns = f, set = c("lows", "mids", "highs")
 #'   )
 #' ```
 #' 

--- a/R/col_vals_not_in_set.R
+++ b/R/col_vals_not_in_set.R
@@ -181,7 +181,7 @@
 #' ```yaml
 #' steps:
 #' - col_vals_not_in_set:
-#'    columns: vars(a)
+#'    columns: c(a)
 #'    set:
 #'    - 1.0
 #'    - 2.0

--- a/R/col_vals_not_in_set.R
+++ b/R/col_vals_not_in_set.R
@@ -297,13 +297,10 @@ col_vals_not_in_set <- function(
     active = TRUE
 ) {
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions)

--- a/R/col_vals_not_in_set.R
+++ b/R/col_vals_not_in_set.R
@@ -147,6 +147,20 @@
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_vals_not_null.R
+++ b/R/col_vals_not_null.R
@@ -141,6 +141,20 @@
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_vals_not_null.R
+++ b/R/col_vals_not_null.R
@@ -160,7 +160,7 @@
 #' ```r
 #' agent %>% 
 #'   col_vals_not_null(
-#'     columns = vars(a),
+#'     columns = a,
 #'     preconditions = ~ . %>% dplyr::filter(a < 10),
 #'     segments = b ~ c("group_1", "group_2"),
 #'     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
@@ -218,7 +218,7 @@
 #' ```r
 #' agent <-
 #'   create_agent(tbl = tbl) %>%
-#'   col_vals_not_null(columns = vars(b)) %>%
+#'   col_vals_not_null(columns = b) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -240,7 +240,7 @@
 #' 
 #' ```{r}
 #' tbl %>%
-#'   col_vals_not_null(columns = vars(b)) %>%
+#'   col_vals_not_null(columns = b) %>%
 #'   dplyr::pull(b)
 #' ```
 #'
@@ -250,7 +250,7 @@
 #' time. This is primarily used in **testthat** tests.
 #' 
 #' ```r
-#' expect_col_vals_not_null(tbl, columns = vars(b))
+#' expect_col_vals_not_null(tbl, columns = b)
 #' ```
 #' 
 #' ## D: Using the test function
@@ -259,7 +259,7 @@
 #' us.
 #' 
 #' ```{r}
-#' tbl %>% test_col_vals_not_null(columns = vars(b))
+#' tbl %>% test_col_vals_not_null(columns = b)
 #' ```
 #' 
 #' @family validation functions

--- a/R/col_vals_not_null.R
+++ b/R/col_vals_not_null.R
@@ -63,12 +63,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names, the result will be an expansion of
-#' validation steps to that number of column names (e.g., `vars(col_a, col_b)`
-#' will result in the entry of two validation steps). Aside from column names in
-#' quotes and in `vars()`, **tidyselect** helper functions are available for
-#' specifying columns. They are: `starts_with()`, `ends_with()`, `contains()`,
-#' `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #' 
 #' @section Preconditions:
 #' 

--- a/R/col_vals_not_null.R
+++ b/R/col_vals_not_null.R
@@ -174,7 +174,7 @@
 #' ```yaml
 #' steps:
 #' - col_vals_not_null:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     preconditions: ~. %>% dplyr::filter(a < 10)
 #'     segments: b ~ c("group_1", "group_2")
 #'     actions:

--- a/R/col_vals_not_null.R
+++ b/R/col_vals_not_null.R
@@ -288,13 +288,10 @@ col_vals_not_null <- function(
   
   values <- NULL
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions)

--- a/R/col_vals_null.R
+++ b/R/col_vals_null.R
@@ -62,12 +62,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names, the result will be an expansion of
-#' validation steps to that number of column names (e.g., `vars(col_a, col_b)`
-#' will result in the entry of two validation steps). Aside from column names in
-#' quotes and in `vars()`, **tidyselect** helper functions are available for
-#' specifying columns. They are: `starts_with()`, `ends_with()`, `contains()`,
-#' `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #' 
 #' @section Preconditions:
 #' 

--- a/R/col_vals_null.R
+++ b/R/col_vals_null.R
@@ -173,7 +173,7 @@
 #' ```yaml
 #' steps:
 #' - col_vals_null:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     preconditions: ~. %>% dplyr::filter(a < 10)
 #'     segments: b ~ c("group_1", "group_2")
 #'     actions:

--- a/R/col_vals_null.R
+++ b/R/col_vals_null.R
@@ -159,7 +159,7 @@
 #' ```r
 #' agent %>% 
 #'   col_vals_null(
-#'     columns = vars(a),
+#'     columns = a,
 #'     preconditions = ~ . %>% dplyr::filter(a < 10),
 #'     segments = b ~ c("group_1", "group_2"),
 #'     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
@@ -217,7 +217,7 @@
 #' ```r
 #' agent <-
 #'   create_agent(tbl = tbl) %>%
-#'   col_vals_null(columns = vars(c)) %>%
+#'   col_vals_null(columns = c) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -239,7 +239,7 @@
 #' 
 #' ```{r}
 #' tbl %>%
-#'   col_vals_null(columns = vars(c)) %>%
+#'   col_vals_null(columns = c) %>%
 #'   dplyr::pull(c)
 #' ```
 #'
@@ -249,7 +249,7 @@
 #' time. This is primarily used in **testthat** tests.
 #' 
 #' ```r
-#' expect_col_vals_null(tbl, columns = vars(c))
+#' expect_col_vals_null(tbl, columns = c)
 #' ```
 #' 
 #' ## D: Using the test function
@@ -258,7 +258,7 @@
 #' us.
 #' 
 #' ```{r}
-#' tbl %>% test_col_vals_null(columns = vars(c))
+#' tbl %>% test_col_vals_null(columns = c)
 #' ```
 #' 
 #' @family validation functions

--- a/R/col_vals_null.R
+++ b/R/col_vals_null.R
@@ -140,6 +140,20 @@
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_vals_null.R
+++ b/R/col_vals_null.R
@@ -287,13 +287,10 @@ col_vals_null <- function(
   
   values <- NULL
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions)

--- a/R/col_vals_regex.R
+++ b/R/col_vals_regex.R
@@ -189,7 +189,7 @@
 #' ```yaml
 #' steps:
 #' - col_vals_regex:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     regex: '[0-9]-[a-z]{3}-[0-9]{3}'
 #'     na_pass: true
 #'     preconditions: ~. %>% dplyr::filter(a < 10)

--- a/R/col_vals_regex.R
+++ b/R/col_vals_regex.R
@@ -154,6 +154,20 @@
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/col_vals_regex.R
+++ b/R/col_vals_regex.R
@@ -173,7 +173,7 @@
 #' ```
 #' agent %>% 
 #'   col_vals_regex(
-#'     columns = vars(a),
+#'     columns = a,
 #'     regex = "[0-9]-[a-z]{3}-[0-9]{3}",
 #'     na_pass = TRUE,
 #'     preconditions = ~ . %>% dplyr::filter(a < 10),
@@ -233,7 +233,7 @@
 #' ```r
 #' agent <-
 #'   create_agent(tbl = small_table) %>%
-#'   col_vals_regex(columns = vars(b), regex = pattern) %>%
+#'   col_vals_regex(columns = b, regex = pattern) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -255,7 +255,7 @@
 #' 
 #' ```{r}
 #' small_table %>%
-#'   col_vals_regex(columns = vars(b), regex = pattern) %>%
+#'   col_vals_regex(columns = b, regex = pattern) %>%
 #'   dplyr::slice(1:5)
 #' ```
 #'
@@ -265,7 +265,7 @@
 #' time. This is primarily used in **testthat** tests.
 #' 
 #' ```r
-#' expect_col_vals_regex(small_table, columns = vars(b), regex = pattern)
+#' expect_col_vals_regex(small_table, columns = b, regex = pattern)
 #' ```
 #' 
 #' ## D: Using the test function
@@ -274,7 +274,7 @@
 #' us.
 #' 
 #' ```{r}
-#' small_table %>% test_col_vals_regex(columns = vars(b), regex = pattern)
+#' small_table %>% test_col_vals_regex(columns = b, regex = pattern)
 #' ```
 #' 
 #' @family validation functions

--- a/R/col_vals_regex.R
+++ b/R/col_vals_regex.R
@@ -301,13 +301,10 @@ col_vals_regex <- function(
     active = TRUE
 ) {
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions)

--- a/R/col_vals_regex.R
+++ b/R/col_vals_regex.R
@@ -69,12 +69,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names, the result will be an expansion of
-#' validation steps to that number of column names (e.g., `vars(col_a, col_b)`
-#' will result in the entry of two validation steps). Aside from column names in
-#' quotes and in `vars()`, **tidyselect** helper functions are available for
-#' specifying columns. They are: `starts_with()`, `ends_with()`, `contains()`,
-#' `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #'
 #' @section Missing Values:
 #' 

--- a/R/col_vals_within_spec.R
+++ b/R/col_vals_within_spec.R
@@ -239,7 +239,7 @@
 #' ```yaml
 #' steps:
 #' - col_vals_within_spec:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     spec: email
 #'     na_pass: true
 #'     preconditions: ~. %>% dplyr::filter(b < 10)

--- a/R/col_vals_within_spec.R
+++ b/R/col_vals_within_spec.R
@@ -119,12 +119,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names, the result will be an expansion of
-#' validation steps to that number of column names (e.g., `vars(col_a, col_b)`
-#' will result in the entry of two validation steps). Aside from column names in
-#' quotes and in `vars()`, **tidyselect** helper functions are available for
-#' specifying columns. They are: `starts_with()`, `ends_with()`, `contains()`,
-#' `matches()`, and `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #'
 #' @section Missing Values:
 #' 

--- a/R/col_vals_within_spec.R
+++ b/R/col_vals_within_spec.R
@@ -363,13 +363,10 @@ col_vals_within_spec <- function(
     active = TRUE
 ) {
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions)

--- a/R/col_vals_within_spec.R
+++ b/R/col_vals_within_spec.R
@@ -223,7 +223,7 @@
 #' ```r
 #' agent %>% 
 #'   col_vals_within_spec(
-#'     columns = vars(a),
+#'     columns = a,
 #'     spec = "email",
 #'     na_pass = TRUE,
 #'     preconditions = ~ . %>% dplyr::filter(b < 10),
@@ -282,7 +282,7 @@
 #' agent <-
 #'   create_agent(tbl = spec_slice) %>%
 #'   col_vals_within_spec(
-#'     columns = vars(email_addresses),
+#'     columns = email_addresses,
 #'     spec = "email"
 #'   ) %>%
 #'   interrogate()
@@ -307,7 +307,7 @@
 #' ```{r}
 #' spec_slice %>%
 #'   col_vals_within_spec(
-#'     columns = vars(email_addresses),
+#'     columns = email_addresses,
 #'     spec = "email"
 #'   ) %>%
 #'   dplyr::select(email_addresses)
@@ -321,7 +321,7 @@
 #' ```r
 #' expect_col_vals_within_spec(
 #'   spec_slice,
-#'   columns = vars(email_addresses),
+#'   columns = email_addresses,
 #'   spec = "email"
 #' )
 #' ```
@@ -334,7 +334,7 @@
 #' ```{r}
 #' spec_slice %>%
 #'   test_col_vals_within_spec(
-#'     columns = vars(email_addresses),
+#'     columns = email_addresses,
 #'     spec = "email"
 #'   )
 #' ```

--- a/R/col_vals_within_spec.R
+++ b/R/col_vals_within_spec.R
@@ -204,6 +204,20 @@
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/conjointly.R
+++ b/R/conjointly.R
@@ -54,7 +54,7 @@
 #'   A collection one-sided formulas that consist of validation functions that
 #'   validate row units (the `col_vals_*()` series), column existence
 #'   ([col_exists()]), or column type (the `col_is_*()` series). An example of
-#'   this is `~ col_vals_gte(., vars(a), 5.5), ~ col_vals_not_null(., vars(b)`).
+#'   this is `~ col_vals_gte(., a, 5.5), ~ col_vals_not_null(., b`).
 #' 
 #' @param .list *Alternative to `...`*
 #' 
@@ -186,9 +186,9 @@
 #' ```r
 #' agent %>% 
 #'   conjointly(
-#'     ~ col_vals_lt(., columns = vars(a), value = 8),
-#'     ~ col_vals_gt(., columns = vars(c), value = vars(a)),
-#'     ~ col_vals_not_null(., columns = vars(b)),
+#'     ~ col_vals_lt(., columns = a, value = 8),
+#'     ~ col_vals_gt(., columns = c, value = vars(a)),
+#'     ~ col_vals_not_null(., columns = b),
 #'     preconditions = ~ . %>% dplyr::filter(a < 10),
 #'     segments = b ~ c("group_1", "group_2"),
 #'     actions = action_levels(warn_at = 0.1, stop_at = 0.2), 
@@ -203,9 +203,9 @@
 #' steps:
 #' - conjointly:
 #'     fns:
-#'     - ~col_vals_lt(., columns = vars(a), value = 8)
-#'     - ~col_vals_gt(., columns = vars(c), value = vars(a))
-#'     - ~col_vals_not_null(., columns = vars(b))
+#'     - ~col_vals_lt(., columns = a, value = 8)
+#'     - ~col_vals_gt(., columns = c, value = vars(a))
+#'     - ~col_vals_not_null(., columns = b)
 #'     preconditions: ~. %>% dplyr::filter(a < 10)
 #'     segments: b ~ c("group_1", "group_2")
 #'     actions:
@@ -252,9 +252,9 @@
 #' agent <-
 #'   create_agent(tbl = tbl) %>%
 #'   conjointly(
-#'     ~ col_vals_lt(., columns = vars(a), value = 8),
-#'     ~ col_vals_gt(., columns = vars(c), value = vars(a)),
-#'     ~ col_vals_not_null(., columns = vars(b))
+#'     ~ col_vals_lt(., columns = a, value = 8),
+#'     ~ col_vals_gt(., columns = c, value = vars(a)),
+#'     ~ col_vals_not_null(., columns = b)
 #'     ) %>%
 #'   interrogate()
 #' ```
@@ -283,9 +283,9 @@
 #' ```{r}
 #' tbl %>%
 #'   conjointly(
-#'     ~ col_vals_lt(., columns = vars(a), value = 8),
-#'     ~ col_vals_gt(., columns = vars(c), value = vars(a)),
-#'     ~ col_vals_not_null(., columns = vars(b))
+#'     ~ col_vals_lt(., columns = a, value = 8),
+#'     ~ col_vals_gt(., columns = c, value = vars(a)),
+#'     ~ col_vals_not_null(., columns = b)
 #'   )
 #' ```
 #'
@@ -297,9 +297,9 @@
 #' ```r
 #' expect_conjointly(
 #'   tbl,
-#'   ~ col_vals_lt(., columns = vars(a), value = 8),
-#'   ~ col_vals_gt(., columns = vars(c), value = vars(a)),
-#'   ~ col_vals_not_null(., columns = vars(b))
+#'   ~ col_vals_lt(., columns = a, value = 8),
+#'   ~ col_vals_gt(., columns = c, value = vars(a)),
+#'   ~ col_vals_not_null(., columns = b)
 #' )
 #' ```
 #' 
@@ -311,9 +311,9 @@
 #' ```{r}
 #' tbl %>%
 #'   test_conjointly(
-#'     ~ col_vals_lt(., columns = vars(a), value = 8),
-#'     ~ col_vals_gt(., columns = vars(c), value = vars(a)),
-#'     ~ col_vals_not_null(., columns = vars(b))
+#'     ~ col_vals_lt(., columns = a, value = 8),
+#'     ~ col_vals_gt(., columns = c, value = vars(a)),
+#'     ~ col_vals_not_null(., columns = b)
 #'   )
 #' ```
 #' 

--- a/R/conjointly.R
+++ b/R/conjointly.R
@@ -89,12 +89,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names in any of the supplied validation steps,
-#' the result will be an expansion of sub-validation steps to that number of
-#' column names. Aside from column names in quotes and in `vars()`,
-#' **tidyselect** helper functions are available for specifying columns. They
-#' are: `starts_with()`, `ends_with()`, `contains()`, `matches()`, and
-#' `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #' 
 #' @section Preconditions:
 #' 

--- a/R/conjointly.R
+++ b/R/conjointly.R
@@ -167,6 +167,19 @@
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/create_agent.R
+++ b/R/create_agent.R
@@ -394,16 +394,16 @@
 #' ```r
 #' agent <-
 #'   agent %>% 
-#'   col_exists(columns = vars(date, date_time)) %>%
+#'   col_exists(columns = date, date_time) %>%
 #'   col_vals_regex(
-#'     columns = vars(b),
+#'     columns = b,
 #'     regex = "[0-9]-[a-z]{3}-[0-9]{3}"
 #'   ) %>%
 #'   rows_distinct() %>%
-#'   col_vals_gt(columns = vars(d), value = 100) %>%
-#'   col_vals_lte(columns = vars(c), value = 5) %>%
+#'   col_vals_gt(columns = d, value = 100) %>%
+#'   col_vals_lte(columns = c, value = 5) %>%
 #'   col_vals_between(
-#'     columns = vars(c),
+#'     columns = c,
 #'     left = vars(a), right = vars(d),
 #'     na_pass = TRUE
 #'   ) %>%

--- a/R/create_multiagent.R
+++ b/R/create_multiagent.R
@@ -107,7 +107,7 @@
 #'     tbl_name = "tbl_1",
 #'     label = "Example table 1."
 #'   ) %>%
-#'   col_vals_gt(columns = vars(a), value = 4) %>%
+#'   col_vals_gt(columns = a, value = 4) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -120,7 +120,7 @@
 #'     tbl_name = "tbl_2",
 #'     label = "Example table 2."
 #'   ) %>%
-#'   col_is_character(columns = vars(b)) %>%
+#'   col_is_character(columns = b) %>%
 #'   interrogate()
 #' ```
 #' 

--- a/R/draft_validation.R
+++ b/R/draft_validation.R
@@ -154,116 +154,116 @@
 #'   ) %>%
 #'   # Expect that column `name` is of type: character
 #'   col_is_character(
-#'     columns = vars(name)
+#'     columns = name
 #'   ) %>%
 #'   # Expect that column `year` is of type: numeric
 #'   col_is_numeric(
-#'     columns = vars(year)
+#'     columns = year
 #'   ) %>%
 #'   # Expect that values in `year` should be between `1975` and `2020`
 #'   col_vals_between(
-#'     columns = vars(year),
+#'     columns = year,
 #'     left = 1975,
 #'     right = 2020
 #'   ) %>%
 #'   # Expect that column `month` is of type: numeric
 #'   col_is_numeric(
-#'     columns = vars(month)
+#'     columns = month
 #'   ) %>%
 #'   # Expect that values in `month` should be between `1` and `12`
 #'   col_vals_between(
-#'     columns = vars(month),
+#'     columns = month,
 #'     left = 1,
 #'     right = 12
 #'   ) %>%
 #'   # Expect that column `day` is of type: integer
 #'   col_is_integer(
-#'     columns = vars(day)
+#'     columns = day
 #'   ) %>%
 #'   # Expect that values in `day` should be between `1` and `31`
 #'   col_vals_between(
-#'     columns = vars(day),
+#'     columns = day,
 #'     left = 1,
 #'     right = 31
 #'   ) %>%
 #'   # Expect that column `hour` is of type: numeric
 #'   col_is_numeric(
-#'     columns = vars(hour)
+#'     columns = hour
 #'   ) %>%
 #'   # Expect that values in `hour` should be between `0` and `23`
 #'   col_vals_between(
-#'     columns = vars(hour),
+#'     columns = hour,
 #'     left = 0,
 #'     right = 23
 #'   ) %>%
 #'   # Expect that column `lat` is of type: numeric
 #'   col_is_numeric(
-#'     columns = vars(lat)
+#'     columns = lat
 #'   ) %>%
 #'   # Expect that values in `lat` should be between `-90` and `90`
 #'   col_vals_between(
-#'     columns = vars(lat),
+#'     columns = lat,
 #'     left = -90,
 #'     right = 90
 #'   ) %>%
 #'   # Expect that column `long` is of type: numeric
 #'   col_is_numeric(
-#'     columns = vars(long)
+#'     columns = long
 #'   ) %>%
 #'   # Expect that values in `long` should be between `-180` and `180`
 #'   col_vals_between(
-#'     columns = vars(long),
+#'     columns = long,
 #'     left = -180,
 #'     right = 180
 #'   ) %>%
 #'   # Expect that column `status` is of type: character
 #'   col_is_character(
-#'     columns = vars(status)
+#'     columns = status
 #'   ) %>%
 #'   # Expect that column `category` is of type: factor
 #'   col_is_factor(
-#'     columns = vars(category)
+#'     columns = category
 #'   ) %>%
 #'   # Expect that column `wind` is of type: integer
 #'   col_is_integer(
-#'     columns = vars(wind)
+#'     columns = wind
 #'   ) %>%
 #'   # Expect that values in `wind` should be between `10` and `160`
 #'   col_vals_between(
-#'     columns = vars(wind),
+#'     columns = wind,
 #'     left = 10,
 #'     right = 160
 #'   ) %>%
 #'   # Expect that column `pressure` is of type: integer
 #'   col_is_integer(
-#'     columns = vars(pressure)
+#'     columns = pressure
 #'   ) %>%
 #'   # Expect that values in `pressure` should be between `882` and `1022`
 #'   col_vals_between(
-#'     columns = vars(pressure),
+#'     columns = pressure,
 #'     left = 882,
 #'     right = 1022
 #'   ) %>%
 #'   # Expect that column `tropicalstorm_force_diameter` is of type: integer
 #'   col_is_integer(
-#'     columns = vars(tropicalstorm_force_diameter)
+#'     columns = tropicalstorm_force_diameter
 #'   ) %>%
 #'   # Expect that values in `tropicalstorm_force_diameter` should be between
 #'   # `0` and `870`
 #'   col_vals_between(
-#'     columns = vars(tropicalstorm_force_diameter),
+#'     columns = tropicalstorm_force_diameter,
 #'     left = 0,
 #'     right = 870,
 #'     na_pass = TRUE
 #'   ) %>%
 #'   # Expect that column `hurricane_force_diameter` is of type: integer
 #'   col_is_integer(
-#'     columns = vars(hurricane_force_diameter)
+#'     columns = hurricane_force_diameter
 #'   ) %>%
 #'   # Expect that values in `hurricane_force_diameter` should be between
 #'   # `0` and `300`
 #'   col_vals_between(
-#'     columns = vars(hurricane_force_diameter),
+#'     columns = hurricane_force_diameter,
 #'     left = 0,
 #'     right = 300,
 #'     na_pass = TRUE

--- a/R/emailing.R
+++ b/R/emailing.R
@@ -93,8 +93,8 @@
 #'     )
 #'   )
 #' ) %>%
-#'   col_vals_gt(vars(a), 1) %>%
-#'   col_vals_lt(vars(a), 7) 
+#'   col_vals_gt(a, 1) %>%
+#'   col_vals_lt(a, 7) 
 #' ```
 #' 
 #' YAML representation:
@@ -116,10 +116,10 @@
 #' embed_report: true
 #' steps:
 #' - col_vals_gt:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     value: 1.0
 #' - col_vals_lt:
-#'     columns: vars(a)
+#'     columns: c(a)
 #'     value: 7.0
 #' ```
 #'   

--- a/R/emailing.R
+++ b/R/emailing.R
@@ -176,8 +176,8 @@
 #'       )
 #'     )
 #'   ) %>%
-#'   col_vals_gt(vars(a), value = 1) %>%
-#'   col_vals_lt(vars(a), value = 7) %>%
+#'   col_vals_gt(a, value = 1) %>%
+#'   col_vals_lt(a, value = 7) %>%
 #'   interrogate()
 #' ```
 #'  
@@ -294,8 +294,8 @@ email_blast <- function(
 #'     label = "An example.",
 #'     actions = al
 #'   ) %>%
-#'   col_vals_gt(vars(a), value = 1) %>%
-#'   col_vals_lt(vars(a), value = 7) %>%
+#'   col_vals_gt(a, value = 1) %>%
+#'   col_vals_lt(a, value = 7) %>%
 #'   interrogate() %>%
 #'   email_create()
 #'   

--- a/R/get_agent_report.R
+++ b/R/get_agent_report.R
@@ -210,7 +210,7 @@
 #'     tbl_name = "small_table",
 #'     label = "An example."
 #'   ) %>%
-#'   col_vals_gt(columns = vars(a), value = 4) %>%
+#'   col_vals_gt(columns = a, value = 4) %>%
 #'   interrogate()
 #' ```
 #' 

--- a/R/get_agent_x_list.R
+++ b/R/get_agent_x_list.R
@@ -145,8 +145,8 @@
 #'     tbl = tbl,
 #'     actions = al
 #'   ) %>%
-#'   col_vals_gt(columns = vars(a), value = 7) %>%
-#'   col_is_numeric(columns = vars(a)) %>%
+#'   col_vals_gt(columns = a, value = 7) %>%
+#'   col_is_numeric(columns = a) %>%
 #'   interrogate()
 #' ```
 #'   

--- a/R/get_data_extracts.R
+++ b/R/get_data_extracts.R
@@ -77,7 +77,7 @@
 #'       dplyr::select(a:f),
 #'     label = "`get_data_extracts()`"
 #'   ) %>%
-#'   col_vals_gt(vars(d), value = 1000) %>%
+#'   col_vals_gt(d, value = 1000) %>%
 #'   col_vals_between(
 #'     columns = c,
 #'     left = vars(a), right = vars(d),

--- a/R/get_data_extracts.R
+++ b/R/get_data_extracts.R
@@ -79,7 +79,7 @@
 #'   ) %>%
 #'   col_vals_gt(vars(d), value = 1000) %>%
 #'   col_vals_between(
-#'     columns = vars(c),
+#'     columns = c,
 #'     left = vars(a), right = vars(d),
 #'     na_pass = TRUE
 #'   ) %>%

--- a/R/get_multiagent_report.R
+++ b/R/get_multiagent_report.R
@@ -146,32 +146,32 @@
 #'     actions = al
 #'   ) %>%
 #'   col_vals_gt(
-#'     columns = vars(date_time),
+#'     columns = date_time,
 #'     value = vars(date),
 #'     na_pass = TRUE
 #'   ) %>%
 #'   col_vals_gt(
-#'     columns = vars(b), 
+#'     columns = b, 
 #'     value = vars(g),
 #'     na_pass = TRUE
 #'   ) %>%
 #'   rows_distinct() %>%
 #'   col_vals_equal(
-#'     columns = vars(d), 
+#'     columns = d, 
 #'     value = vars(d),
 #'     na_pass = TRUE
 #'   ) %>%
 #'   col_vals_between(
-#'     columns = vars(c), 
+#'     columns = c, 
 #'     left = vars(a), right = vars(d)
 #'   ) %>%
 #'   col_vals_not_between(
-#'     columns = vars(c),
+#'     columns = c,
 #'     left = 10, right = 20,
 #'     na_pass = TRUE
 #'   ) %>%
-#'   rows_distinct(columns = vars(d, e, f)) %>%
-#'   col_is_integer(columns = vars(a)) %>%
+#'   rows_distinct(columns = d, e, f) %>%
+#'   col_is_integer(columns = a) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -181,9 +181,9 @@
 #' ```r
 #' agent_2 <- 
 #'   agent_1 %>%
-#'   col_exists(columns = vars(date, date_time)) %>%
+#'   col_exists(columns = date, date_time) %>%
 #'   col_vals_regex(
-#'     columns = vars(b), 
+#'     columns = b, 
 #'     regex = "[0-9]-[a-z]{3}-[0-9]{3}",
 #'     active = FALSE
 #'   ) %>%
@@ -197,7 +197,7 @@
 #' agent_3 <- 
 #'   agent_2 %>%
 #'   col_vals_in_set(
-#'     columns = vars(f),
+#'     columns = f,
 #'     set = c("low", "mid", "high")
 #'   ) %>%
 #'   remove_steps(i = 5) %>%

--- a/R/get_sundered_data.R
+++ b/R/get_sundered_data.R
@@ -94,9 +94,9 @@
 #'       dplyr::select(a:f),
 #'     label = "`get_sundered_data()`"
 #'   ) %>%
-#'   col_vals_gt(columns = vars(d), value = 1000) %>%
+#'   col_vals_gt(columns = d, value = 1000) %>%
 #'   col_vals_between(
-#'     columns = vars(c),
+#'     columns = c,
 #'     left = vars(a), right = vars(d),
 #'     na_pass = TRUE
 #'   ) %>%

--- a/R/has_columns.R
+++ b/R/has_columns.R
@@ -119,16 +119,16 @@
 #'     tbl_name = "small_table"
 #'   ) %>%
 #'   col_vals_gt(
-#'     columns = vars(c), value = vars(a),
+#'     columns = c, value = vars(a),
 #'     active = ~ . %>% has_columns(vars(a, c))
 #'   ) %>%
 #'   col_vals_lt(
-#'     columns = vars(h), value = vars(d),
+#'     columns = h, value = vars(d),
 #'     preconditions = ~ . %>% dplyr::mutate(h = d - a),
 #'     active = ~ . %>% has_columns(vars(a, d))
 #'   ) %>%
 #'   col_is_character(
-#'     columns = vars(j),
+#'     columns = j,
 #'     active = ~ . %>% has_columns("j")
 #'   ) %>%
 #'   interrogate()

--- a/R/incorporate.R
+++ b/R/incorporate.R
@@ -75,7 +75,7 @@
 #'     fn = ~ . %>% ncol()
 #'   ) %>%
 #'   info_columns(
-#'     columns = vars(a),
+#'     columns = a,
 #'     info = "In the range of 1 to 10. ((SIMPLE))"
 #'   ) %>%
 #'   info_columns(

--- a/R/info_add.R
+++ b/R/info_add.R
@@ -343,7 +343,7 @@ info_tabular <- function(
 #'     info = "*info text* 3. Statistics: {snippet_1}."
 #'   ) %>%
 #'   info_columns(
-#'     columns = vars(date, date_time),
+#'     columns = c(date, date_time),
 #'     info = "UTC time."
 #'   )
 #' 
@@ -401,7 +401,7 @@ info_tabular <- function(
 #' informant <-
 #'   informant %>%
 #'   info_columns(
-#'     columns = vars(a),
+#'     columns = a,
 #'     info = "In the range of 1 to 10. ((SIMPLE))"
 #'   ) %>%
 #'   info_columns(
@@ -1064,7 +1064,7 @@ info_section <- function(
 #'     fn = snip_highest(column = "a")
 #'   ) %>%
 #'   info_columns(
-#'     columns = vars(a),
+#'     columns = a,
 #'     info = "In the range of 1 to {max_a}. ((SIMPLE))"
 #'   ) %>%
 #'   info_columns(

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -105,7 +105,7 @@
 #'     tbl = tbl,
 #'     label = "`interrogate()` example"
 #'   ) %>%
-#'   col_vals_gt(columns = vars(a), value = 5) %>%
+#'   col_vals_gt(columns = a, value = 5) %>%
 #'   interrogate()
 #' ```
 #' 

--- a/R/logging.R
+++ b/R/logging.R
@@ -144,8 +144,8 @@
 #'     label = "An example.",
 #'     actions = al
 #'   ) %>%
-#'   col_vals_gt(columns = vars(d), 300) %>%
-#'   col_vals_in_set(columns = vars(f), c("low", "high")) %>%
+#'   col_vals_gt(columns = d, 300) %>%
+#'   col_vals_in_set(columns = f, c("low", "high")) %>%
 #'   interrogate()
 #' 
 #' agent

--- a/R/object_ops.R
+++ b/R/object_ops.R
@@ -241,7 +241,7 @@
 #'   ) %>%
 #'   col_vals_gt(
 #'     columns = b,
-#'     value = vars(g),
+#'     value = g,
 #'     na_pass = TRUE,
 #'     label = "b > g"
 #'   ) %>%

--- a/R/object_ops.R
+++ b/R/object_ops.R
@@ -133,14 +133,14 @@
 #' ```r
 #' agent <-
 #'   agent %>% 
-#'   col_exists(columns = vars(date, date_time)) %>%
+#'   col_exists(columns = c(date, date_time)) %>%
 #'   col_vals_regex(
-#'     columns = vars(b),
+#'     columns = b,
 #'     regex = "[0-9]-[a-z]{3}-[0-9]{3}"
 #'   ) %>%
 #'   rows_distinct() %>%
-#'   col_vals_gt(columns = vars(d), value = 100) %>%
-#'   col_vals_lte(columns = vars(c), value = 5) %>%
+#'   col_vals_gt(columns = d, value = 100) %>%
+#'   col_vals_lte(columns = c, value = 5) %>%
 #'   interrogate()
 #' ```
 #'
@@ -197,7 +197,7 @@
 #'     fn = snip_lowest(column = "a")
 #'   ) %>%
 #'   info_columns(
-#'     columns = vars(a),
+#'     columns = a,
 #'     info = "From {low_a} to {high_a}."
 #'   ) %>%
 #'   info_columns(
@@ -240,13 +240,13 @@
 #'     actions = al
 #'   ) %>%
 #'   col_vals_gt(
-#'     columns = vars(b),
+#'     columns = b,
 #'     value = vars(g),
 #'     na_pass = TRUE,
 #'     label = "b > g"
 #'   ) %>%
 #'   col_is_character(
-#'     columns = vars(b, f),
+#'     columns = c(b, f),
 #'     label = "Verifying character-type columns" 
 #'   ) %>%
 #'   interrogate()
@@ -611,14 +611,14 @@ x_read_disk <- function(
 #' ```r
 #' agent <-
 #'   agent %>% 
-#'   col_exists(columns = vars(date, date_time)) %>%
+#'   col_exists(columns = c(date, date_time)) %>%
 #'   col_vals_regex(
-#'     columns = vars(b),
+#'     columns = b,
 #'     regex = "[0-9]-[a-z]{3}-[0-9]{3}"
 #'   ) %>%
 #'   rows_distinct() %>%
-#'   col_vals_gt(columns = vars(d), value = 100) %>%
-#'   col_vals_lte(columns = vars(c), value = 5) %>%
+#'   col_vals_gt(columns = d, value = 100) %>%
+#'   col_vals_lte(columns = c, value = 5) %>%
 #'   interrogate()
 #' ```
 #'
@@ -672,7 +672,7 @@ x_read_disk <- function(
 #'     fn = snip_lowest(column = "a")
 #'   ) %>%
 #'   info_columns(
-#'     columns = vars(a),
+#'     columns = a,
 #'     info = "From {low_a} to {high_a}."
 #'   ) %>%
 #'   info_columns(
@@ -895,9 +895,9 @@ export_report <- function(
 #'     label = "An example.",
 #'     actions = al
 #'   ) %>%
-#'   col_exists(columns = vars(date, date_time)) %>%
+#'   col_exists(columns = c(date, date_time)) %>%
 #'   col_vals_regex(
-#'     columns = vars(b),
+#'     columns = b,
 #'     regex = "[0-9]-[a-z]{3}-[0-9]{3}"
 #'   ) %>%
 #'   rows_distinct() %>%

--- a/R/remove_deactivate.R
+++ b/R/remove_deactivate.R
@@ -60,11 +60,11 @@
 #'     label = "An example."
 #'   ) %>%
 #'   col_exists(
-#'     columns = vars(date),
+#'     columns = date,
 #'     active = FALSE
 #'   ) %>%
 #'   col_vals_regex(
-#'     columns = vars(b),
+#'     columns = b,
 #'     regex = "[0-9]-[a-z]{3}-[0-9]{3}",
 #'     active = FALSE
 #'   ) %>%
@@ -146,9 +146,9 @@ activate_steps <- function(
 #'     tbl_name = "small_table",
 #'     label = "An example."
 #'   ) %>%
-#'   col_exists(columns = vars(date)) %>%
+#'   col_exists(columns = date) %>%
 #'   col_vals_regex(
-#'     columns = vars(b),
+#'     columns = b,
 #'     regex = "[0-9]-[a-z]{3}-[0-9]"
 #'   ) %>%
 #'   interrogate()
@@ -227,9 +227,9 @@ deactivate_steps <- function(
 #'     tbl_name = "small_table",
 #'     label = "An example."
 #'   ) %>%
-#'   col_exists(columns = vars(date)) %>%
+#'   col_exists(columns = date) %>%
 #'   col_vals_regex(
-#'     columns = vars(b),
+#'     columns = b,
 #'     regex = "[0-9]-[a-z]{3}-[0-9]"
 #'   ) %>%
 #'   interrogate()

--- a/R/row_count_match.R
+++ b/R/row_count_match.R
@@ -137,6 +137,19 @@
 #' depending on the situation (the first produces a warning, the other
 #' `stop()`s).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/rows_complete.R
+++ b/R/rows_complete.R
@@ -150,7 +150,7 @@
 #' ```r
 #' agent %>% 
 #'   rows_complete(
-#'     columns = vars(a, b),
+#'     columns = a, b,
 #'     preconditions = ~ . %>% dplyr::filter(a < 10),
 #'     segments = b ~ c("group_1", "group_2"),
 #'     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
@@ -205,7 +205,7 @@
 #' ```r
 #' agent <-
 #'   create_agent(tbl = tbl) %>%
-#'   rows_complete(columns = vars(a, b)) %>%
+#'   rows_complete(columns = c(a, b)) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -227,7 +227,7 @@
 #' 
 #' ```{r}
 #' tbl %>%
-#'   rows_complete(columns = vars(a, b)) %>%
+#'   rows_complete(columns = c(a, b)) %>%
 #'   dplyr::pull(a)
 #' ```
 #' 
@@ -237,7 +237,7 @@
 #' time. This is primarily used in **testthat** tests.
 #' 
 #' ```r
-#' expect_rows_complete(tbl, columns = vars(a, b))
+#' expect_rows_complete(tbl, columns = c(a, b))
 #' ```
 #' 
 #' ## D: Using the test function
@@ -246,7 +246,7 @@
 #' us.
 #' 
 #' ```{r}
-#' test_rows_complete(tbl, columns = vars(a, b))
+#' test_rows_complete(tbl, columns = c(a, b))
 #' ```
 #' 
 #' @family validation functions

--- a/R/rows_complete.R
+++ b/R/rows_complete.R
@@ -37,6 +37,14 @@
 #' the following **tidyselect** helper functions: `starts_with()`,
 #' `ends_with()`, `contains()`, `matches()`, and `everything()`.
 #' 
+#' @param columns *The target columns*
+#' 
+#'   `<tidy-select>` // *default:* `everything()`
+#' 
+#'   A column-selecting expression, as one would use inside `dplyr::select()`.
+#'   Specifies the column (or a set of columns) to which this validation should
+#'   be applied. See the *Column Names* section for more information.
+#' 
 #' @inheritParams col_vals_gt
 #'   
 #' @return For the validation function, the return value is either a

--- a/R/rows_complete.R
+++ b/R/rows_complete.R
@@ -271,13 +271,12 @@ rows_complete <- function(
     active = TRUE
 ) {
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
+  
+  # Default to `everything()`
   if (rlang::quo_is_null(columns)) {
     columns <- rlang::quo(tidyselect::everything())
   }

--- a/R/rows_complete.R
+++ b/R/rows_complete.R
@@ -134,6 +134,20 @@
 #' warning when a quarter of the total test units fails, the other `stop()`s at
 #' the same threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/rows_complete.R
+++ b/R/rows_complete.R
@@ -261,7 +261,7 @@ NULL
 #' @export
 rows_complete <- function(
     x,
-    columns = NULL,
+    columns = tidyselect::everything(),
     preconditions = NULL,
     segments = NULL,
     actions = NULL,
@@ -273,13 +273,13 @@ rows_complete <- function(
   
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # `rows_*()` functions default to `everything()`
+  if (rlang::quo_is_missing(columns) || rlang::quo_is_null(columns)) {
+    # `everything()` isn't namespaced to `{tidyselect}` for leaner yaml writing
+    columns <- rlang::new_quosure(call("everything"), rlang::caller_env())
+  }
   # Get `columns` as a label
   columns_expr <- as_columns_expr(columns)
-  
-  # Default to `everything()`
-  if (rlang::quo_is_null(columns)) {
-    columns <- rlang::quo(tidyselect::everything())
-  }
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions = NULL)

--- a/R/rows_complete.R
+++ b/R/rows_complete.R
@@ -273,10 +273,9 @@ rows_complete <- function(
   
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
-  # `rows_*()` functions default to `everything()`
-  if (rlang::quo_is_missing(columns) || rlang::quo_is_null(columns)) {
-    # `everything()` isn't namespaced to `{tidyselect}` for leaner yaml writing
-    columns <- rlang::new_quosure(call("everything"), rlang::caller_env())
+  # `rows_*()` functions treat `NULL` as `everything()`
+  if (rlang::quo_is_null(columns)) {
+    columns <- rlang::quo(tidyselect::everything())
   }
   # Get `columns` as a label
   columns_expr <- as_columns_expr(columns)

--- a/R/rows_complete.R
+++ b/R/rows_complete.R
@@ -150,7 +150,7 @@
 #' ```r
 #' agent %>% 
 #'   rows_complete(
-#'     columns = a, b,
+#'     columns = c(a, b),
 #'     preconditions = ~ . %>% dplyr::filter(a < 10),
 #'     segments = b ~ c("group_1", "group_2"),
 #'     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
@@ -164,7 +164,7 @@
 #' ```yaml
 #' steps:
 #' - rows_complete:
-#'     columns: vars(a, b)
+#'     columns: c(a, b)
 #'     preconditions: ~. %>% dplyr::filter(a < 10)
 #'     segments: b ~ c("group_1", "group_2")
 #'     actions:

--- a/R/rows_complete.R
+++ b/R/rows_complete.R
@@ -376,7 +376,7 @@ rows_complete <- function(
 #' @export
 expect_rows_complete <- function(
     object,
-    columns = NULL,
+    columns = tidyselect::everything(),
     preconditions = NULL,
     threshold = 1
 ) {
@@ -431,7 +431,7 @@ expect_rows_complete <- function(
 #' @export
 test_rows_complete <- function(
     object,
-    columns = NULL,
+    columns = tidyselect::everything(),
     preconditions = NULL,
     threshold = 1
 ) {

--- a/R/rows_distinct.R
+++ b/R/rows_distinct.R
@@ -135,6 +135,20 @@
 #' warning when a quarter of the total test units fails, the other `stop()`s at
 #' the same threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.col}"`: The current column name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/rows_distinct.R
+++ b/R/rows_distinct.R
@@ -272,13 +272,12 @@ rows_distinct <- function(
     active = TRUE
 ) {
   
-  # Get `columns` as a label
-  columns_expr <- 
-    rlang::as_label(rlang::quo(!!enquo(columns))) %>%
-    gsub("^\"|\"$", "", .)
-  
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # Get `columns` as a label
+  columns_expr <- as_columns_expr(columns)
+  
+  # Default to `everything()`
   if (rlang::quo_is_null(columns)) {
     columns <- rlang::quo(tidyselect::everything())
   }

--- a/R/rows_distinct.R
+++ b/R/rows_distinct.R
@@ -377,7 +377,7 @@ rows_distinct <- function(
 #' @export
 expect_rows_distinct <- function(
     object,
-    columns = NULL,
+    columns = tidyselect::everything(),
     preconditions = NULL,
     threshold = 1
 ) {
@@ -432,7 +432,7 @@ expect_rows_distinct <- function(
 #' @export
 test_rows_distinct <- function(
     object,
-    columns = NULL,
+    columns = tidyselect::everything(),
     preconditions = NULL,
     threshold = 1
 ) {

--- a/R/rows_distinct.R
+++ b/R/rows_distinct.R
@@ -151,7 +151,7 @@
 #' ```r
 #' agent %>% 
 #'   rows_distinct(
-#'     columns = vars(a, b),
+#'     columns = c(a, b),
 #'     preconditions = ~ . %>% dplyr::filter(a < 10),
 #'     segments = b ~ c("group_1", "group_2"),
 #'     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
@@ -206,7 +206,7 @@
 #' ```r
 #' agent <-
 #'   create_agent(tbl = tbl) %>%
-#'   rows_distinct(columns = vars(a, b)) %>%
+#'   rows_distinct(columns = c(a, b)) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -228,7 +228,7 @@
 #' 
 #' ```{r}
 #' tbl %>%
-#'   rows_distinct(columns = vars(a, b)) %>%
+#'   rows_distinct(columns = c(a, b)) %>%
 #'   dplyr::pull(a)
 #' ```
 #' 
@@ -238,7 +238,7 @@
 #' time. This is primarily used in **testthat** tests.
 #' 
 #' ```r
-#' expect_rows_distinct(tbl, columns = vars(a, b))
+#' expect_rows_distinct(tbl, columns = c(a, b))
 #' ```
 #' 
 #' ## D: Using the test function
@@ -247,7 +247,7 @@
 #' us.
 #' 
 #' ```{r}
-#' test_rows_distinct(tbl, columns = vars(a, b))
+#' test_rows_distinct(tbl, columns = c(a, b))
 #' ```
 #' 
 #' @family validation functions

--- a/R/rows_distinct.R
+++ b/R/rows_distinct.R
@@ -38,6 +38,14 @@
 #' the following **tidyselect** helper functions: `starts_with()`,
 #' `ends_with()`, `contains()`, `matches()`, and `everything()`.
 #' 
+#' @param columns *The target columns*
+#' 
+#'   `<tidy-select>` // *default:* `everything()`
+#' 
+#'   A column-selecting expression, as one would use inside `dplyr::select()`.
+#'   Specifies the column (or a set of columns) to which this validation should
+#'   be applied. See the *Column Names* section for more information.
+#' 
 #' @inheritParams col_vals_gt
 #'   
 #' @return For the validation function, the return value is either a

--- a/R/rows_distinct.R
+++ b/R/rows_distinct.R
@@ -274,10 +274,9 @@ rows_distinct <- function(
   
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
-  # `rows_*()` functions default to `everything()`
-  if (rlang::quo_is_missing(columns) || rlang::quo_is_null(columns)) {
-    # `everything()` isn't namespaced to `{tidyselect}` for leaner yaml writing
-    columns <- rlang::new_quosure(call("everything"), rlang::caller_env())
+  # `rows_*()` functions treat `NULL` as `everything()`
+  if (rlang::quo_is_null(columns)) {
+    columns <- rlang::quo(tidyselect::everything())
   }
   # Get `columns` as a label
   columns_expr <- as_columns_expr(columns)

--- a/R/rows_distinct.R
+++ b/R/rows_distinct.R
@@ -262,7 +262,7 @@ NULL
 #' @export
 rows_distinct <- function(
     x,
-    columns = NULL,
+    columns = tidyselect::everything(),
     preconditions = NULL,
     segments = NULL,
     actions = NULL,
@@ -274,13 +274,13 @@ rows_distinct <- function(
   
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
+  # `rows_*()` functions default to `everything()`
+  if (rlang::quo_is_missing(columns) || rlang::quo_is_null(columns)) {
+    # `everything()` isn't namespaced to `{tidyselect}` for leaner yaml writing
+    columns <- rlang::new_quosure(call("everything"), rlang::caller_env())
+  }
   # Get `columns` as a label
   columns_expr <- as_columns_expr(columns)
-  
-  # Default to `everything()`
-  if (rlang::quo_is_null(columns)) {
-    columns <- rlang::quo(tidyselect::everything())
-  }
   
   # Resolve the columns based on the expression
   columns <- resolve_columns(x = x, var_expr = columns, preconditions = NULL)

--- a/R/rows_distinct.R
+++ b/R/rows_distinct.R
@@ -165,7 +165,7 @@
 #' ```
 #' steps:
 #' - rows_distinct:
-#'     columns: vars(a, b)
+#'     columns: c(a, b)
 #'     preconditions: ~. %>% dplyr::filter(a < 10)
 #'     segments: b ~ c("group_1", "group_2")
 #'     actions:

--- a/R/serially.R
+++ b/R/serially.R
@@ -52,9 +52,9 @@
 #' Here's an example of how to arrange expressions:
 #' 
 #' ```
-#' ~ test_col_exists(., columns = vars(count)),
-#' ~ test_col_is_numeric(., columns = vars(count)),
-#' ~ col_vals_gt(., columns = vars(count), value = 2)
+#' ~ test_col_exists(., columns = count),
+#' ~ test_col_is_numeric(., columns = count),
+#' ~ col_vals_gt(., columns = count, value = 2)
 #' ```
 #' 
 #' This series concentrates on the column called `count` and first checks
@@ -83,7 +83,7 @@
 #'   [col_vals_increasing()], etc.) can optionally be inserted at the end of the
 #'   series, serving as a validation step that only undergoes interrogation if
 #'   the prior tests adequately pass. An example of this is
-#'   `~ test_column_exists(., vars(a)), ~ col_vals_not_null(., vars(a))`).
+#'   `~ test_column_exists(., a), ~ col_vals_not_null(., a)`).
 #'   
 #' @param .list *Alternative to `...`*
 #' 
@@ -184,9 +184,9 @@
 #' ```r
 #' agent %>% 
 #'   serially(
-#'     ~ col_vals_lt(., columns = vars(a), value = 8),
-#'     ~ col_vals_gt(., columns = vars(c), value = vars(a)),
-#'     ~ col_vals_not_null(., columns = vars(b)),
+#'     ~ col_vals_lt(., columns = a, value = 8),
+#'     ~ col_vals_gt(., columns = c, value = vars(a)),
+#'     ~ col_vals_not_null(., columns = b),
 #'     preconditions = ~ . %>% dplyr::filter(a < 10),
 #'     actions = action_levels(warn_at = 0.1, stop_at = 0.2), 
 #'     label = "The `serially()` step.",
@@ -200,9 +200,9 @@
 #' steps:
 #' - serially:
 #'     fns:
-#'     - ~col_vals_lt(., columns = vars(a), value = 8)
-#'     - ~col_vals_gt(., columns = vars(c), value = vars(a))
-#'     - ~col_vals_not_null(., vars(b))
+#'     - ~col_vals_lt(., columns = a, value = 8)
+#'     - ~col_vals_gt(., columns = c, value = vars(a))
+#'     - ~col_vals_not_null(., b)
 #'     preconditions: ~. %>% dplyr::filter(a < 10)
 #'     actions:
 #'       warn_fraction: 0.1
@@ -249,9 +249,9 @@
 #' agent_1 <-
 #'   create_agent(tbl = tbl) %>%
 #'   serially(
-#'     ~ test_col_is_numeric(., columns = vars(a, b)),
-#'     ~ test_col_vals_not_null(., columns = vars(a, b)),
-#'     ~ col_vals_gt(., columns = vars(b), value = vars(a))
+#'     ~ test_col_is_numeric(., columns = c(a, b)),
+#'     ~ test_col_vals_not_null(., columns = c(a, b)),
+#'     ~ col_vals_gt(., columns = b, value = vars(a))
 #'     ) %>%
 #'   interrogate()
 #' ```
@@ -276,8 +276,8 @@
 #' agent_2 <-
 #'   create_agent(tbl = tbl) %>%
 #'   serially(
-#'     ~ test_col_is_numeric(., columns = vars(a, b)),
-#'     ~ test_col_vals_not_null(., columns = vars(a, b))
+#'     ~ test_col_is_numeric(., columns = c(a, b)),
+#'     ~ test_col_vals_not_null(., columns = c(a, b))
 #'   ) %>%
 #'   interrogate()
 #' ```
@@ -299,9 +299,9 @@
 #' ```{r}
 #' tbl %>%
 #'   serially(
-#'     ~ test_col_is_numeric(., columns = vars(a, b)),
-#'     ~ test_col_vals_not_null(., columns = vars(a, b)),
-#'     ~ col_vals_gt(., columns = vars(b), value = vars(a))
+#'     ~ test_col_is_numeric(., columns = c(a, b)),
+#'     ~ test_col_vals_not_null(., columns = c(a, b)),
+#'     ~ col_vals_gt(., columns = b, value = vars(a))
 #'   )
 #' ```
 #'
@@ -313,9 +313,9 @@
 #' ```r
 #' expect_serially(
 #'   tbl,
-#'   ~ test_col_is_numeric(., columns = vars(a, b)),
-#'   ~ test_col_vals_not_null(., columns = vars(a, b)),
-#'   ~ col_vals_gt(., columns = vars(b), value = vars(a))
+#'   ~ test_col_is_numeric(., columns = c(a, b)),
+#'   ~ test_col_vals_not_null(., columns = c(a, b)),
+#'   ~ col_vals_gt(., columns = b, value = vars(a))
 #' )
 #' ```
 #' 
@@ -327,9 +327,9 @@
 #' ```{r}
 #' tbl %>%
 #'   test_serially(
-#'     ~ test_col_is_numeric(., columns = vars(a, b)),
-#'     ~ test_col_vals_not_null(., columns = vars(a, b)),
-#'     ~ col_vals_gt(., columns = vars(b), value = vars(a))
+#'     ~ test_col_is_numeric(., columns = c(a, b)),
+#'     ~ test_col_vals_not_null(., columns = c(a, b)),
+#'     ~ col_vals_gt(., columns = b, value = vars(a))
 #'   )
 #' ```
 #'

--- a/R/serially.R
+++ b/R/serially.R
@@ -165,6 +165,17 @@
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/serially.R
+++ b/R/serially.R
@@ -184,8 +184,8 @@
 #' ```r
 #' agent %>% 
 #'   serially(
-#'     ~ col_vals_lt(., columns = a, value = 8),
-#'     ~ col_vals_gt(., columns = c, value = vars(a)),
+#'     ~ test_col_vals_lt(., columns = a, value = 8),
+#'     ~ test_col_vals_gt(., columns = c, value = vars(a)),
 #'     ~ col_vals_not_null(., columns = b),
 #'     preconditions = ~ . %>% dplyr::filter(a < 10),
 #'     actions = action_levels(warn_at = 0.1, stop_at = 0.2), 
@@ -200,9 +200,9 @@
 #' steps:
 #' - serially:
 #'     fns:
-#'     - ~col_vals_lt(., columns = a, value = 8)
-#'     - ~col_vals_gt(., columns = c, value = vars(a))
-#'     - ~col_vals_not_null(., b)
+#'     - ~test_col_vals_lt(., columns = a, value = 8)
+#'     - ~test_col_vals_gt(., columns = c, value = vars(a))
+#'     - ~col_vals_not_null(., columns = b)
 #'     preconditions: ~. %>% dplyr::filter(a < 10)
 #'     actions:
 #'       warn_fraction: 0.1

--- a/R/serially.R
+++ b/R/serially.R
@@ -118,12 +118,17 @@
 #'
 #' @section Column Names:
 #' 
-#' If providing multiple column names in any of the supplied validation steps,
-#' the result will be an expansion of sub-validation steps to that number of
-#' column names. Aside from column names in quotes and in `vars()`,
-#' **tidyselect** helper functions are available for specifying columns. They
-#' are: `starts_with()`, `ends_with()`, `contains()`, `matches()`, and
-#' `everything()`.
+#' `columns` may be a single column (as symbol `a` or string `"a"`) or a vector
+#' of columns (`c(a, b, c)` or `c("a", "b", "c")`). `{tidyselect}` helpers
+#' are also supported, such as `contains("date")` and `where(is.double)`. If
+#' passing an *external vector* of columns, it should be wrapped in `all_of()`.
+#' 
+#' When multiple columns are selected by `columns`, the result will be an
+#' expansion of validation steps to that number of columns (e.g.,
+#' `c(col_a, col_b)` will result in the entry of two validation steps).
+#' 
+#' Previously, columns could be specified in `vars()`. This continues to work, 
+#' but `c()` offers the same capability and supersedes `vars()` in `columns`.
 #' 
 #' @section Preconditions:
 #' 

--- a/R/specially.R
+++ b/R/specially.R
@@ -104,6 +104,17 @@
 #' quarter of the total test units fails, the other `stop()`s at the same
 #' threshold level).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/table_transformers.R
+++ b/R/table_transformers.R
@@ -354,6 +354,7 @@ tt_string_info <- function(tbl) {
 #' ```{r}
 #' tt_tbl_dims(tbl = small_table) %>%
 #'   dplyr::filter(.param. == "columns") %>%
+#'   test_col_vals_lt(
 #'     columns = value,
 #'     value = 10
 #'   )

--- a/R/table_transformers.R
+++ b/R/table_transformers.R
@@ -67,7 +67,7 @@
 #' ```{r}
 #' tt_summary_stats(tbl = game_revenue) %>%
 #'   col_vals_lt(
-#'     columns = vars(item_revenue),
+#'     columns = item_revenue,
 #'     value = 150,
 #'     segments = .param. ~ "max"
 #'   )
@@ -83,7 +83,7 @@
 #'   dplyr::filter(item_type == "iap") %>%
 #'   tt_summary_stats() %>%
 #'   col_vals_between(
-#'     columns = vars(item_revenue),
+#'     columns = item_revenue,
 #'     left = 8, right = 12,
 #'     segments = .param. ~ "med"
 #'   )
@@ -112,7 +112,7 @@
 #'   rows_complete() %>%
 #'   rows_distinct() %>%
 #'   col_vals_between(
-#'     columns = vars(item_revenue),
+#'     columns = item_revenue,
 #'     left = 8, right = 12,
 #'     preconditions = ~ . %>%
 #'       dplyr::filter(item_type == "iap") %>%
@@ -238,11 +238,11 @@ tt_summary_stats <- function(tbl) {
 #' ```{r}
 #' tt_string_info(tbl = game_revenue) %>%
 #'   col_vals_equal(
-#'     columns = vars(player_id),
+#'     columns = player_id,
 #'     value = 15
 #'   ) %>%
 #'   col_vals_equal(
-#'     columns = vars(session_id),
+#'     columns = session_id,
 #'     value = 24
 #'   )
 #' ```
@@ -256,7 +256,7 @@ tt_summary_stats <- function(tbl) {
 #' ```{r}
 #' tt_string_info(tbl = small_table) %>%
 #'   test_col_vals_lte(
-#'     columns = vars(f),
+#'     columns = f,
 #'     value = 4
 #'   )
 #' ```
@@ -343,7 +343,7 @@ tt_string_info <- function(tbl) {
 #' tt_tbl_dims(tbl = game_revenue) %>%
 #'   dplyr::filter(.param. == "rows") %>%
 #'   test_col_vals_gt(
-#'     columns = vars(value),
+#'     columns = value,
 #'     value = 1500
 #'   )
 #' ```
@@ -354,8 +354,7 @@ tt_string_info <- function(tbl) {
 #' ```{r}
 #' tt_tbl_dims(tbl = small_table) %>%
 #'   dplyr::filter(.param. == "columns") %>%
-#'   test_col_vals_lt(
-#'     columns = vars(value),
+#'     columns = value,
 #'     value = 10
 #'   )
 #' ```
@@ -421,7 +420,7 @@ tt_tbl_dims <- function(tbl) {
 #' ```{r}
 #' tt_tbl_colnames(tbl = game_revenue) %>%
 #'   test_col_vals_make_subset(
-#'     columns = vars(value),
+#'     columns = value,
 #'     set = c("acquisition", "country")
 #'   )
 #' ```
@@ -436,7 +435,7 @@ tt_tbl_dims <- function(tbl) {
 #'   tt_tbl_colnames() %>%
 #'   tt_string_info() %>%
 #'   test_col_vals_lt(
-#'     columns = vars(value),
+#'     columns = value,
 #'     value = 15
 #'   )
 #' ```
@@ -953,7 +952,7 @@ tt_time_slice <- function(
 #'     keep = "right"
 #'   ) %>%
 #'   test_col_vals_lte(
-#'     columns = vars(session_duration), 
+#'     columns = session_duration, 
 #'     value = get_tt_param(
 #'       tbl = stats_tbl,
 #'       param = "max",

--- a/R/tbl_from_file.R
+++ b/R/tbl_from_file.R
@@ -135,7 +135,7 @@
 #'       col_types = "TDdcddlc"
 #'     )
 #'   ) %>%
-#'   col_vals_gt(columns = vars(a), value = 0)
+#'   col_vals_gt(columns = a, value = 0)
 #' ```
 #'
 #' All of the file-reading instructions are encapsulated in the `tbl` expression
@@ -162,7 +162,7 @@
 #'     tbl_name = "small_table",
 #'     label = "`file_tbl()` example.",
 #'   ) %>%
-#'   col_vals_gt(columns = vars(a), value = 0) %>%
+#'   col_vals_gt(columns = a, value = 0) %>%
 #'   interrogate()
 #' ```
 #' 

--- a/R/tbl_from_file.R
+++ b/R/tbl_from_file.R
@@ -463,7 +463,7 @@ file_tbl <- function(
 #' #       col_types = "TDdcddlc"
 #' #     )
 #' #   ) %>%
-#' #   col_vals_gt(vars(a), 0) %>%
+#' #   col_vals_gt(a, 0) %>%
 #' #   interrogate()
 #' 
 #' # The `from_github()` helper function is

--- a/R/tbl_match.R
+++ b/R/tbl_match.R
@@ -126,6 +126,19 @@
 #' depending on the situation (the first produces a warning, the other
 #' `stop()`s).
 #' 
+#' @section Labels:
+#' 
+#' `label` may be a single string or a character vector that matches the number
+#' of expanded steps. `label` also supports `{glue}` syntax and exposes the
+#' following dynamic variables contextualized to the current step:
+#'   
+#' - `"{.step}"`: The validation step name
+#' - `"{.seg_col}"`: The current segment's column name
+#' - `"{.seg_val}"`: The current segment's value/group
+#'     
+#' The glue context also supports ordinary expressions for further flexibility
+#' (e.g., `"{toupper(.step)}"`) as long as they return a length-1 string.
+#' 
 #' @section Briefs:
 #' 
 #' Want to describe this validation step in some detail? Keep in mind that this

--- a/R/tbl_store.R
+++ b/R/tbl_store.R
@@ -620,7 +620,7 @@ add_to_name_list <- function(
 #'     label = "`tbl_source()` example",
 #'     actions = action_levels(warn_at = 0.10)
 #'   ) %>% 
-#'   col_exists(columns = vars(date, date_time)) %>%
+#'   col_exists(columns = c(date, date_time)) %>%
 #'   interrogate()
 #' ```
 #' 

--- a/R/tbl_store.R
+++ b/R/tbl_store.R
@@ -107,7 +107,7 @@
 #'   label = "An example that uses a table store.",
 #'   actions = action_levels(warn_at = 0.10)
 #' ) %>% 
-#'   col_exists(vars(date, date_time)) %>%
+#'   col_exists(c(date, date_time)) %>%
 #'   write_yaml()
 #' ```
 #'   
@@ -122,7 +122,7 @@
 #' locale: en
 #' steps:
 #'   - col_exists:
-#'     columns: vars(date, date_time)
+#'     columns: c(date, date_time)
 #' ```
 #' 
 #' Now, whenever the `sml_table_high` table needs to be validated, it can be

--- a/R/utils.R
+++ b/R/utils.R
@@ -222,12 +222,12 @@ is_secret_agent <- function(x) {
   is_ptblank_agent(x) && (x$label == "::QUIET::")
 }
 
-resolve_columns <- function(x, var_expr, preconditions) {
+resolve_columns <- function(x, var_expr, preconditions, ...) {
   
   force(x) # To avoid `restarting interrupted promise evaluation` warnings
   
   out <- tryCatch(
-    expr = resolve_columns_internal(x, var_expr, preconditions),
+    expr = resolve_columns_internal(x, var_expr, preconditions, ...),
     error = function(cnd) cnd
   )
   
@@ -245,7 +245,7 @@ resolve_columns <- function(x, var_expr, preconditions) {
   
 }
 
-resolve_columns_internal <- function(x, var_expr, preconditions) {
+resolve_columns_internal <- function(x, var_expr, preconditions, ...) {
   
   # Return NA if the expr is NULL
   if (rlang::quo_is_null(var_expr)) {
@@ -282,7 +282,7 @@ resolve_columns_internal <- function(x, var_expr, preconditions) {
   }
   
   # Proceed with tidyselect
-  column <- tidyselect::eval_select(var_expr, tbl)
+  column <- tidyselect::eval_select(var_expr, tbl, ...)
   column <- names(column)
   
   if (length(column) < 1) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -222,12 +222,14 @@ is_secret_agent <- function(x) {
   is_ptblank_agent(x) && (x$label == "::QUIET::")
 }
 
-resolve_columns <- function(x, var_expr, preconditions, ...) {
+resolve_columns <- function(x, var_expr, preconditions, ...,
+                            call = rlang::caller_env()) {
   
   force(x) # To avoid `restarting interrupted promise evaluation` warnings
   
   out <- tryCatch(
-    expr = resolve_columns_internal(x, var_expr, preconditions, ...),
+    expr = resolve_columns_internal(x, var_expr, preconditions, ...,
+                                    call = call),
     error = function(cnd) cnd
   )
   
@@ -245,7 +247,7 @@ resolve_columns <- function(x, var_expr, preconditions, ...) {
   
 }
 
-resolve_columns_internal <- function(x, var_expr, preconditions, ...) {
+resolve_columns_internal <- function(x, var_expr, preconditions, ..., call) {
   
   # Return NA if the expr is NULL
   if (rlang::quo_is_null(var_expr)) {
@@ -282,7 +284,7 @@ resolve_columns_internal <- function(x, var_expr, preconditions, ...) {
   }
   
   # Proceed with tidyselect
-  column <- tidyselect::eval_select(var_expr, tbl, ...)
+  column <- tidyselect::eval_select(var_expr, tbl, error_call = call, ...)
   column <- names(column)
   
   if (length(column) < 1) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -218,6 +218,10 @@ materialize_table <- function(tbl, check = TRUE) {
   tbl
 }
 
+as_columns_expr <- function(columns) {
+  gsub("^\"|\"$", "", rlang::as_label(columns))
+}
+
 is_secret_agent <- function(x) {
   is_ptblank_agent(x) && (x$label == "::QUIET::")
 }

--- a/R/write_testthat_file.R
+++ b/R/write_testthat_file.R
@@ -79,7 +79,7 @@
 #'   
 #'   expect_col_exists(
 #'     tbl,
-#'     columns = vars(date_time),
+#'     columns = date_time,
 #'     threshold = 1
 #'   ) 
 #' })
@@ -88,7 +88,7 @@
 #'   
 #'   expect_col_vals_lte(
 #'     tbl,
-#'     columns = vars(c),
+#'     columns = c,
 #'     value = 5,
 #'     threshold = 0.25
 #'   ) 
@@ -106,8 +106,8 @@
 #'     tbl = ~ small_table,
 #'     actions = action_levels(stop_at = 0.25)
 #'   ) %>%
-#'   col_exists(vars(date_time)) %>%
-#'   col_vals_lte(vars(c), value = 5)
+#'   col_exists(date_time) %>%
+#'   col_vals_lte(c, value = 5)
 #'   
 #' write_testthat_file(
 #'   agent = agent,
@@ -206,13 +206,13 @@
 #'     label = "An example.",
 #'     actions = al
 #'   ) %>%
-#'   col_exists(vars(date, date_time)) %>%
+#'   col_exists(c(date, date_time)) %>%
 #'   col_vals_regex(
-#'     vars(b),
+#'     b,
 #'     regex = "[0-9]-[a-z]{3}-[0-9]{3}"
 #'   ) %>%
-#'   col_vals_gt(vars(d), value = 100) %>%
-#'   col_vals_lte(vars(c), value = 5) %>%
+#'   col_vals_gt(d, value = 100) %>%
+#'   col_vals_lte(c, value = 5) %>%
 #'   interrogate()
 #' ```
 #' 
@@ -245,7 +245,7 @@
 #'   
 #'   expect_col_exists(
 #'     tbl,
-#'     columns = vars(date),
+#'     columns = date,
 #'     threshold = 1
 #'   ) 
 #' })
@@ -254,7 +254,7 @@
 #'   
 #'   expect_col_exists(
 #'     tbl,
-#'     columns = vars(date_time),
+#'     columns = date_time,
 #'     threshold = 1
 #'   ) 
 #' })
@@ -264,7 +264,7 @@
 #'   
 #'   expect_col_vals_regex(
 #'     tbl,
-#'     columns = vars(b),
+#'     columns = b,
 #'     regex = "[0-9]-[a-z]{3}-[0-9]{3}",
 #'     threshold = 0.25
 #'   ) 
@@ -274,7 +274,7 @@
 #'   
 #'   expect_col_vals_gt(
 #'     tbl,
-#'     columns = vars(d),
+#'     columns = d,
 #'     value = 100,
 #'     threshold = 0.25
 #'   ) 
@@ -284,7 +284,7 @@
 #'   
 #'   expect_col_vals_lte(
 #'     tbl,
-#'     columns = vars(c),
+#'     columns = c,
 #'     value = 5,
 #'     threshold = 0.25
 #'   ) 

--- a/R/yaml_read_agent.R
+++ b/R/yaml_read_agent.R
@@ -304,14 +304,14 @@ yaml_agent_interrogate <- function(
 #'       notify_at = 0.35
 #'     )
 #'   ) %>%
-#'   col_exists(columns = vars(date, date_time)) %>%
+#'   col_exists(columns = c(date, date_time)) %>%
 #'   col_vals_regex(
-#'     columns = vars(b),
+#'     columns = b,
 #'     regex = "[0-9]-[a-z]{3}-[0-9]{3}"
 #'   ) %>%
 #'   rows_distinct() %>%
-#'   col_vals_gt(columns = vars(d), value = 100) %>%
-#'   col_vals_lte(columns = vars(c), value = 5)
+#'   col_vals_gt(columns = d, value = 100) %>%
+#'   col_vals_lte(columns = c, value = 5)
 #' ```
 #'
 #' The agent can be written to a **pointblank** YAML file with [yaml_write()].
@@ -357,19 +357,19 @@ yaml_agent_interrogate <- function(
 #'   label = "A simple example with the `small_table`."
 #' ) %>%
 #'   col_exists(
-#'     columns = vars(date, date_time)
+#'     columns = c(date, date_time)
 #'   ) %>%
 #'   col_vals_regex(
-#'     columns = vars(b),
+#'     columns = b,
 #'     regex = "[0-9]-[a-z]{3}-[0-9]{3}"
 #'   ) %>%
 #'   rows_distinct() %>%
 #'   col_vals_gt(
-#'     columns = vars(d),
+#'     columns = d,
 #'     value = 100
 #'   ) %>%
 #'   col_vals_lte(
-#'     columns = vars(c),
+#'     columns = c,
 #'     value = 5
 #'   ) 
 #' ```

--- a/R/yaml_read_agent.R
+++ b/R/yaml_read_agent.R
@@ -539,7 +539,7 @@ make_validation_steps <- function(steps) {
   tidyselect_regex <- 
     paste0(
       "^(",
-      paste(c("vars", exported_tidyselect_fns()), collapse = "|"),
+      paste(c("vars", "c", exported_tidyselect_fns()), collapse = "|"),
       ")\\(.*?\\)$"
     )
   

--- a/R/yaml_write.R
+++ b/R/yaml_write.R
@@ -1327,16 +1327,16 @@ as_agent_yaml_list <- function(agent, expanded) {
       
     } else if (validation_fn %in% c("rows_distinct", "rows_complete")) {
 
-      if (is.na(step_list$column[[1]][[1]])) {
-        vars_cols <- NULL
-      } else {
-        vars_cols <- as_c_fn(step_list$column[[1]])
-      }
+      column_text <- 
+        get_column_text(
+          step_list = step_list,
+          expanded = expanded
+        )
       
       lst_step <- 
         list(
           validation_fn = list(
-            columns = vars_cols,
+            columns = column_text,
             preconditions = as_list_preconditions(step_list$preconditions),
             segments = as_list_segments(step_list$seg_expr),
             actions = as_action_levels(
@@ -1560,6 +1560,9 @@ get_column_text <- function(step_list, expanded) {
     } else {
       column_text <- step_list$columns_expr
     }
+    
+    # Strip tidyselect namespacing for leaner yaml writing
+    column_text <- gsub("\\btidyselect::", "", column_text)
     
   } else {
     

--- a/R/yaml_write.R
+++ b/R/yaml_write.R
@@ -687,8 +687,8 @@ yaml_agent_string <- function(
   
 }
 
-as_vars_fn <- function(columns) {
-  paste0("vars(", columns, ")")
+as_c_fn <- function(columns) {
+  paste0("c(", columns, ")")
 }
 
 as_list_preconditions <- function(preconditions) {
@@ -1330,7 +1330,7 @@ as_agent_yaml_list <- function(agent, expanded) {
       if (is.na(step_list$column[[1]][[1]])) {
         vars_cols <- NULL
       } else {
-        vars_cols <- as_vars_fn(step_list$column[[1]])
+        vars_cols <- as_c_fn(step_list$column[[1]])
       }
       
       lst_step <- 
@@ -1555,7 +1555,7 @@ get_column_text <- function(step_list, expanded) {
     if (!is.na(step_list$column[[1]]) &&
         step_list$column[[1]] == step_list$columns_expr) {
       
-      column_text <- as_vars_fn(step_list$column[[1]])
+      column_text <- as_c_fn(step_list$column[[1]])
       
     } else {
       column_text <- step_list$columns_expr
@@ -1563,7 +1563,7 @@ get_column_text <- function(step_list, expanded) {
     
   } else {
     
-    column_text <- as_vars_fn(columns = step_list$column[[1]])
+    column_text <- as_c_fn(columns = step_list$column[[1]])
   }
   
   column_text

--- a/R/yaml_write.R
+++ b/R/yaml_write.R
@@ -81,9 +81,9 @@
 #'   `scalar<logical>` // *default:* `FALSE`
 #' 
 #'   Should the written validation expressions for an *agent* be expanded such
-#'   that **tidyselect** and [vars()] expressions for columns are evaluated,
-#'   yielding a validation function per column? By default, this is `FALSE` so
-#'   expressions as written will be retained in the YAML representation.
+#'   that **tidyselect** expressions for columns are evaluated, yielding a
+#'   validation function per column? By default, this is `FALSE` so expressions
+#'   as written will be retained in the YAML representation.
 #' 
 #' @param quiet *Inform (or not) upon file writing*
 #' 
@@ -180,7 +180,7 @@
 #' - col_exists:
 #'     columns: c(date, date_time)
 #' - col_vals_regex:
-#'     columns: vars(b)
+#'     columns: c(b)
 #'     regex: '[0-9]-[a-z]{3}-[0-9]{3}'
 #' - rows_distinct:
 #'     columns: ~
@@ -576,10 +576,9 @@ yaml_write <- function(
 #' @param path An optional path to the YAML file (combined with `filename`).
 #' 
 #' @param expanded Should the written validation expressions for an *agent* be
-#'   expanded such that **tidyselect** and [vars()] expressions for columns are
-#'   evaluated, yielding a validation function per column? By default, this is
-#'   `FALSE` so expressions as written will be retained in the YAML
-#'   representation.
+#'   expanded such that **tidyselect** expressions for columns are evaluated, 
+#'   yielding a validation function per column? By default, this is `FALSE`
+#'   so expressions as written will be retained in the YAML representation.
 #' 
 #' @return Nothing is returned. Instead, text is printed to the console.
 #'   

--- a/R/yaml_write.R
+++ b/R/yaml_write.R
@@ -178,17 +178,17 @@
 #'   notify_fraction: 0.35
 #' steps:
 #' - col_exists:
-#'     columns: vars(date, date_time)
+#'     columns: c(date, date_time)
 #' - col_vals_regex:
 #'     columns: vars(b)
 #'     regex: '[0-9]-[a-z]{3}-[0-9]{3}'
 #' - rows_distinct:
 #'     columns: ~
 #' - col_vals_gt:
-#'     columns: vars(d)
+#'     columns: c(d)
 #'     value: 100.0
 #' - col_vals_lte:
-#'     columns: vars(c)
+#'     columns: c(c)
 #'     value: 5.0
 #' ```
 #' 

--- a/R/yaml_write.R
+++ b/R/yaml_write.R
@@ -649,52 +649,42 @@ yaml_agent_string <- function(
     expanded = FALSE
 ) {
   
-  if (is.null(agent) && is.null(filename)) {
-    stop(
-      "An `agent` object or a `filename` for a YAML file must be specified.",
-      call. = FALSE
-    )
-  }
-  
-  if (!is.null(agent) && !is.null(filename)) {
-    stop(
-      "Only `agent` or `filename` should be specified (not both).",
-      call. = FALSE
-    )
-  }
-  
-  if (!is.null(agent)) {
-    
-    # Display the agent's YAML as a nicely formatted string by
-    # generating the YAML (`as_agent_yaml_list() %>% as.yaml()`) and
-    # then emitting it to the console via `message()`
-    message(
-      as_agent_yaml_list(
-        agent = agent,
-        expanded = expanded
-      ) %>%
-        yaml::as.yaml(
-          handlers = list(
-            logical = function(x) {
-              result <- ifelse(x, "true", "false")
-              class(result) <- "verbatim"
-              result
-            }
+  switch(
+    rlang::check_exclusive(agent, filename),
+    agent = {
+      # Display the agent's YAML as a nicely formatted string by
+      # generating the YAML (`as_agent_yaml_list() %>% as.yaml()`) and
+      # then emitting it to the console via `message()`
+      message(
+        as_agent_yaml_list(
+          agent = agent,
+          expanded = expanded
+        ) %>%
+          yaml::as.yaml(
+            handlers = list(
+              logical = function(x) {
+                result <- ifelse(x, "true", "false")
+                class(result) <- "verbatim"
+                result
+              }
+            )
           )
-        )
-    )
-    
-  } else {
-    
-    if (!is.null(path)) {
-      filename <- file.path(path, filename)
+      )
+    },
+    filename = {
+      # Display the agent's YAML as a nicely formatted string by
+      # reading the YAML file specified by `file` (and perhaps `path`)
+      # and then emitting it to the console via `message()`
+      if (!is.null(path)) {
+        filename <- file.path(path, filename)
+      }
+      message(
+        readLines(filename) %>%
+          paste(collapse = "\n")
+      )
     }
-    
-    # Display the agent's YAML as a nicely formatted string by
-    # reading the YAML file specified by `file` (and perhaps `path`)
-    # and then emitting it to the console via `message()`
-    message(readLines(filename) %>% paste(collapse = "\n"))
-  }
+  )
+  
 }
 
 as_vars_fn <- function(columns) {

--- a/R/yaml_write.R
+++ b/R/yaml_write.R
@@ -139,14 +139,14 @@
 #' ```r
 #' agent <-
 #'   agent %>% 
-#'   col_exists(columns = vars(date, date_time)) %>%
+#'   col_exists(columns = c(date, date_time)) %>%
 #'   col_vals_regex(
-#'     columns = vars(b),
+#'     columns = b,
 #'     regex = "[0-9]-[a-z]{3}-[0-9]{3}"
 #'   ) %>%
 #'   rows_distinct() %>%
-#'   col_vals_gt(columns = vars(d), value = 100) %>%
-#'   col_vals_lte(columns = vars(c), value = 5)
+#'   col_vals_gt(columns = d, value = 100) %>%
+#'   col_vals_lte(columns = c, value = 5)
 #' ```
 #'
 #' The agent can be written to a **pointblank**-readable YAML file with the
@@ -282,7 +282,7 @@
 #' informant <- 
 #'   informant %>%
 #'   info_columns(
-#'     columns = vars(a),
+#'     columns = a,
 #'     info = "In the range of 1 to 10. (SIMPLE)"
 #'   ) %>%
 #'   info_columns(
@@ -290,7 +290,7 @@
 #'     info = "Time-based values (e.g., `Sys.time()`)."
 #'   ) %>%
 #'   info_columns(
-#'     columns = "date",
+#'     columns = date,
 #'     info = "The date part of `date_time`. (CALC)"
 #'   )
 #' ```

--- a/man/action_levels.Rd
+++ b/man/action_levels.Rd
@@ -161,10 +161,10 @@ validation steps and interrogate the \code{small_table}.
     actions = al
   ) \%>\%
   col_vals_gt(
-    columns = vars(a), value = 2
+    columns = a, value = 2
   ) \%>\%
   col_vals_lt(
-    columns = vars(d), value = 20000
+    columns = d, value = 20000
   ) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
@@ -192,11 +192,11 @@ another such object to the validation step instead (this time using the
     actions = al
   ) \%>\%
   col_vals_gt(
-    columns = vars(a), value = 2,
+    columns = a, value = 2,
     actions = warn_on_fail(warn_at = 0.5)
   ) \%>\%
   col_vals_lt(
-    columns = vars(d), value = 20000
+    columns = d, value = 20000
   ) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
@@ -221,7 +221,7 @@ data).
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
   col_vals_gt(
-    columns = vars(a), value = 2,
+    columns = a, value = 2,
     actions = warn_on_fail(warn_at = 2)
   )
 }\if{html}{\out{</div>}}
@@ -256,7 +256,7 @@ With the same pipeline, not supplying anything for \code{actions} (it's \code{NU
 default) will have the same effect as using \code{stop_on_fail(stop_at = 1)}.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
-  col_vals_gt(columns = vars(a), value = 2)
+  col_vals_gt(columns = a, value = 2)
 }\if{html}{\out{</div>}}
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{## Error: Exceedance of failed test units where values in `a` should have
@@ -270,7 +270,7 @@ Here's the equivalent set of statements:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
   col_vals_gt(
-    columns = vars(a), value = 2,
+    columns = a, value = 2,
     actions = stop_on_fail(stop_at = 1)
   )
 }\if{html}{\out{</div>}}

--- a/man/activate_steps.Rd
+++ b/man/activate_steps.Rd
@@ -51,11 +51,11 @@ agent_1 <-
     label = "An example."
   ) \%>\%
   col_exists(
-    columns = vars(date),
+    columns = date,
     active = FALSE
   ) \%>\%
   col_vals_regex(
-    columns = vars(b),
+    columns = b,
     regex = "[0-9]-[a-z]{3}-[0-9]{3}",
     active = FALSE
   ) \%>\%

--- a/man/all_passed.Rd
+++ b/man/all_passed.Rd
@@ -68,9 +68,9 @@ Validate that values in column \code{a} are always greater than 4.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = tbl) \%>\%
-  col_vals_gt(columns = vars(a), value = 3) \%>\%
-  col_vals_lte(columns = vars(a), value = 10) \%>\%
-  col_vals_increasing(columns = vars(a)) \%>\%
+  col_vals_gt(columns = a, value = 3) \%>\%
+  col_vals_lte(columns = a, value = 10) \%>\%
+  col_vals_increasing(columns = a) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 

--- a/man/col_count_match.Rd
+++ b/man/col_count_match.Rd
@@ -77,12 +77,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_count_match.Rd
+++ b/man/col_count_match.Rd
@@ -211,6 +211,20 @@ depending on the situation (the first produces a warning, the other
 \code{stop()}s).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_exists.Rd
+++ b/man/col_exists.Rd
@@ -31,11 +31,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-`vector\if{html}{\out{<character>}}|vars(\if{html}{\out{<columns>}})`` // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-One or more columns from the table in focus. This can be
-provided as a vector of column names using \code{c()} or bare column names
-enclosed in \code{\link[=vars]{vars()}}.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{actions}{\emph{Thresholds and actions for different states}
 

--- a/man/col_exists.Rd
+++ b/man/col_exists.Rd
@@ -61,12 +61,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_exists.Rd
+++ b/man/col_exists.Rd
@@ -210,7 +210,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_exists(
-    columns = vars(a),
+    columns = a,
     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
     label = "The `col_exists()` step.",
     active = FALSE
@@ -268,7 +268,7 @@ Validate that column \code{a} exists in the \code{tbl} table with \code{col_exis
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = tbl) \%>\%
-  col_exists(columns = vars(a)) \%>\%
+  col_exists(columns = a) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -289,7 +289,7 @@ This way of using validation functions acts as a data filter. Data is
 passed through but should \code{stop()} if there is a single test unit failing.
 The behavior of side effects can be customized with the \code{actions} option.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% col_exists(columns = vars(a))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% col_exists(columns = a)
 #> # A tibble: 6 x 2
 #>       a     b
 #>   <dbl> <dbl>
@@ -307,7 +307,7 @@ The behavior of side effects can be customized with the \code{actions} option.
 With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_exists(tbl, columns = vars(a))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_exists(tbl, columns = a)
 }\if{html}{\out{</div>}}
 }
 
@@ -316,7 +316,7 @@ time. This is primarily used in \strong{testthat} tests.
 With the \verb{test_*()} form, we should get a single logical value returned to
 us.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% test_col_exists(columns = vars(a))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% test_col_exists(columns = a)
 #> [1] TRUE
 }\if{html}{\out{</div>}}
 }

--- a/man/col_exists.Rd
+++ b/man/col_exists.Rd
@@ -190,6 +190,21 @@ depending on the situation (the first produces a warning, the other
 \code{stop()}s).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_exists.Rd
+++ b/man/col_exists.Rd
@@ -162,12 +162,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names, the result will be an expansion of
-validation steps to that number of column names (e.g., \code{vars(col_a, col_b)}
-will result in the entry of two validation steps). Aside from column names in
-quotes and in \code{vars()}, \strong{tidyselect} helper functions are available for
-specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{contains()},
-\code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Actions}{

--- a/man/col_exists.Rd
+++ b/man/col_exists.Rd
@@ -221,7 +221,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_exists:
-    columns: vars(a)
+    columns: c(a)
     actions:
       warn_fraction: 0.1
       stop_fraction: 0.2

--- a/man/col_is_character.Rd
+++ b/man/col_is_character.Rd
@@ -211,7 +211,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_is_character(
-    columns = vars(a),
+    columns = a,
     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
     label = "The `col_is_character()` step.",
     active = FALSE
@@ -269,7 +269,7 @@ Validate that column \code{b} has the \code{character} class.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = tbl) \%>\%
-  col_is_character(columns = vars(b)) \%>\%
+  col_is_character(columns = b) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -291,7 +291,7 @@ through but should \code{stop()} if there is a single test unit failing. The
 behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% 
-  col_is_character(columns = vars(b)) \%>\%
+  col_is_character(columns = b) \%>\%
   dplyr::slice(1:5)
 #> # A tibble: 5 x 2
 #>       a b    
@@ -309,7 +309,7 @@ behavior of side effects can be customized with the \code{actions} option.
 With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_is_character(tbl, columns = vars(b))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_is_character(tbl, columns = b)
 }\if{html}{\out{</div>}}
 }
 
@@ -318,7 +318,7 @@ time. This is primarily used in \strong{testthat} tests.
 With the \verb{test_*()} form, we should get a single logical value returned to
 us.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% test_col_is_character(columns = vars(b))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% test_col_is_character(columns = b)
 #> [1] TRUE
 }\if{html}{\out{</div>}}
 }

--- a/man/col_is_character.Rd
+++ b/man/col_is_character.Rd
@@ -192,6 +192,21 @@ happens. For the \verb{col_is_*()}-type functions, using \code{action_levels(war
 situation (the first produces a warning, the other will \code{stop()}).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_is_character.Rd
+++ b/man/col_is_character.Rd
@@ -31,10 +31,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{actions}{\emph{Thresholds and actions for different states}
 
@@ -60,12 +61,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_is_character.Rd
+++ b/man/col_is_character.Rd
@@ -222,7 +222,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_is_character:
-    columns: vars(a)
+    columns: c(a)
     actions:
       warn_fraction: 0.1
       stop_fraction: 0.2

--- a/man/col_is_character.Rd
+++ b/man/col_is_character.Rd
@@ -164,12 +164,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names, the result will be an expansion of
-validation steps to that number of column names (e.g., \code{vars(col_a, col_b)}
-will result in the entry of two validation steps). Aside from column names in
-quotes and in \code{vars()}, \strong{tidyselect} helper functions are available for
-specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{contains()},
-\code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Actions}{

--- a/man/col_is_date.Rd
+++ b/man/col_is_date.Rd
@@ -192,6 +192,21 @@ happens. For the \verb{col_is_*()}-type functions, using \code{action_levels(war
 situation (the first produces a warning, the other will \code{stop()}).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_is_date.Rd
+++ b/man/col_is_date.Rd
@@ -31,10 +31,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{actions}{\emph{Thresholds and actions for different states}
 
@@ -60,12 +61,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_is_date.Rd
+++ b/man/col_is_date.Rd
@@ -211,7 +211,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_is_date(
-    columns = vars(a),
+    columns = a,
     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
     label = "The `col_is_date()` step.",
     active = FALSE
@@ -268,7 +268,7 @@ Validate that the column \code{date} has the \code{Date} class.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = small_table) \%>\%
-  col_is_date(columns = vars(date)) \%>\%
+  col_is_date(columns = date) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -290,7 +290,7 @@ through but should \code{stop()} if there is a single test unit failing. The
 behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
-  col_is_date(columns = vars(date)) \%>\%
+  col_is_date(columns = date) \%>\%
   dplyr::slice(1:5)
 #> # A tibble: 5 x 8
 #>   date_time           date           a b             c      d e     f    
@@ -308,7 +308,7 @@ behavior of side effects can be customized with the \code{actions} option.
 With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_is_date(small_table, columns = vars(date))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_is_date(small_table, columns = date)
 }\if{html}{\out{</div>}}
 }
 
@@ -317,7 +317,7 @@ time. This is primarily used in \strong{testthat} tests.
 With the \verb{test_*()} form, we should get a single logical value returned to
 us.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\% test_col_is_date(columns = vars(date))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\% test_col_is_date(columns = date)
 #> [1] TRUE
 }\if{html}{\out{</div>}}
 }

--- a/man/col_is_date.Rd
+++ b/man/col_is_date.Rd
@@ -222,7 +222,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_is_date:
-    columns: vars(a)
+    columns: c(a)
     actions:
       warn_fraction: 0.1
       stop_fraction: 0.2

--- a/man/col_is_date.Rd
+++ b/man/col_is_date.Rd
@@ -164,12 +164,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names, the result will be an expansion of
-validation steps to that number of column names (e.g., \code{vars(col_a, col_b)}
-will result in the entry of two validation steps). Aside from column names in
-quotes and in \code{vars()}, \strong{tidyselect} helper functions are available for
-specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{contains()},
-\code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Actions}{

--- a/man/col_is_factor.Rd
+++ b/man/col_is_factor.Rd
@@ -192,6 +192,21 @@ happens. For the \verb{col_is_*()}-type functions, using \code{action_levels(war
 situation (the first produces a warning, the other will \code{stop()}).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_is_factor.Rd
+++ b/man/col_is_factor.Rd
@@ -31,10 +31,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{actions}{\emph{Thresholds and actions for different states}
 
@@ -60,12 +61,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_is_factor.Rd
+++ b/man/col_is_factor.Rd
@@ -222,7 +222,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_is_factor:
-    columns: vars(a)
+    columns: c(a)
     actions:
       warn_fraction: 0.1
       stop_fraction: 0.2

--- a/man/col_is_factor.Rd
+++ b/man/col_is_factor.Rd
@@ -211,7 +211,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_is_factor(
-    columns = vars(a),
+    columns = a,
     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
     label = "The `col_is_factor()` step.",
     active = FALSE
@@ -274,7 +274,7 @@ Validate that the column \code{f} in the \code{tbl} object is of the \code{facto
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = tbl) \%>\%
-  col_is_factor(columns = vars(f)) \%>\%
+  col_is_factor(columns = f) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -296,7 +296,7 @@ through but should \code{stop()} if there is a single test unit failing. The
 behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\%
-  col_is_factor(columns = vars(f)) \%>\%
+  col_is_factor(columns = f) \%>\%
   dplyr::slice(1:5)
 #> # A tibble: 5 x 8
 #>   date_time           date           a b             c      d e     f    
@@ -314,7 +314,7 @@ behavior of side effects can be customized with the \code{actions} option.
 With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_is_factor(tbl, vars(f))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_is_factor(tbl, f)
 }\if{html}{\out{</div>}}
 }
 
@@ -323,7 +323,7 @@ time. This is primarily used in \strong{testthat} tests.
 With the \verb{test_*()} form, we should get a single logical value returned to
 us.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% test_col_is_factor(columns = vars(f))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% test_col_is_factor(columns = f)
 #> [1] TRUE
 }\if{html}{\out{</div>}}
 }

--- a/man/col_is_factor.Rd
+++ b/man/col_is_factor.Rd
@@ -164,12 +164,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names, the result will be an expansion of
-validation steps to that number of column names (e.g., \code{vars(col_a, col_b)}
-will result in the entry of two validation steps). Aside from column names in
-quotes and in \code{vars()}, \strong{tidyselect} helper functions are available for
-specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{contains()},
-\code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Actions}{

--- a/man/col_is_integer.Rd
+++ b/man/col_is_integer.Rd
@@ -211,7 +211,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_is_integer(
-    columns = vars(a),
+    columns = a,
     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
     label = "The `col_is_integer()` step.",
     active = FALSE
@@ -267,7 +267,7 @@ Validate that column \code{b} has the \code{integer} class.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = tbl) \%>\%
-  col_is_integer(columns = vars(b)) \%>\%
+  col_is_integer(columns = b) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -288,7 +288,7 @@ This way of using validation functions acts as a data filter. Data is passed
 through but should \code{stop()} if there is a single test unit failing. The
 behavior of side effects can be customized with the \code{actions} option.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% col_is_integer(columns = vars(b))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% col_is_integer(columns = b)
 #> # A tibble: 6 x 2
 #>   a         b
 #>   <chr> <int>
@@ -306,7 +306,7 @@ behavior of side effects can be customized with the \code{actions} option.
 With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_is_integer(tbl, columns = vars(b))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_is_integer(tbl, columns = b)
 }\if{html}{\out{</div>}}
 }
 
@@ -315,7 +315,7 @@ time. This is primarily used in \strong{testthat} tests.
 With the \verb{test_*()} form, we should get a single logical value returned to
 us.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% test_col_is_integer(columns = vars(b))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% test_col_is_integer(columns = b)
 #> [1] TRUE
 }\if{html}{\out{</div>}}
 }

--- a/man/col_is_integer.Rd
+++ b/man/col_is_integer.Rd
@@ -192,6 +192,21 @@ happens. For the \verb{col_is_*()}-type functions, using \code{action_levels(war
 situation (the first produces a warning, the other will \code{stop()}).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_is_integer.Rd
+++ b/man/col_is_integer.Rd
@@ -31,10 +31,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{actions}{\emph{Thresholds and actions for different states}
 
@@ -60,12 +61,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_is_integer.Rd
+++ b/man/col_is_integer.Rd
@@ -222,7 +222,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_is_integer:
-    columns: vars(a)
+    columns: c(a)
     actions:
       warn_fraction: 0.1
       stop_fraction: 0.2

--- a/man/col_is_integer.Rd
+++ b/man/col_is_integer.Rd
@@ -164,12 +164,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names, the result will be an expansion of
-validation steps to that number of column names (e.g., \code{vars(col_a, col_b)}
-will result in the entry of two validation steps). Aside from column names in
-quotes and in \code{vars()}, \strong{tidyselect} helper functions are available for
-specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{contains()},
-\code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Actions}{

--- a/man/col_is_logical.Rd
+++ b/man/col_is_logical.Rd
@@ -222,7 +222,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_is_logical:
-    columns: vars(a)
+    columns: c(a)
     actions:
       warn_fraction: 0.1
       stop_fraction: 0.2

--- a/man/col_is_logical.Rd
+++ b/man/col_is_logical.Rd
@@ -192,6 +192,21 @@ happens. For the \verb{col_is_*()}-type functions, using \code{action_levels(war
 situation (the first produces a warning, the other will \code{stop()}).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_is_logical.Rd
+++ b/man/col_is_logical.Rd
@@ -31,10 +31,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{actions}{\emph{Thresholds and actions for different states}
 
@@ -60,12 +61,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_is_logical.Rd
+++ b/man/col_is_logical.Rd
@@ -164,12 +164,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names, the result will be an expansion of
-validation steps to that number of column names (e.g., \code{vars(col_a, col_b)}
-will result in the entry of two validation steps). Aside from column names in
-quotes and in \code{vars()}, \strong{tidyselect} helper functions are available for
-specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{contains()},
-\code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Actions}{

--- a/man/col_is_logical.Rd
+++ b/man/col_is_logical.Rd
@@ -211,7 +211,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_is_logical(
-    columns = vars(a),
+    columns = a,
     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
     label = "The `col_is_logical()` step.",
     active = FALSE
@@ -269,7 +269,7 @@ Validate that the column \code{e} has the \code{logical} class.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = small_table) \%>\%
-  col_is_logical(columns = vars(e)) \%>\%
+  col_is_logical(columns = e) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -291,7 +291,7 @@ through but should \code{stop()} if there is a single test unit failing. The
 behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
-  col_is_logical(columns = vars(e)) \%>\%
+  col_is_logical(columns = e) \%>\%
   dplyr::slice(1:5)
 #> # A tibble: 5 x 8
 #>   date_time           date           a b             c      d e     f    
@@ -309,7 +309,7 @@ behavior of side effects can be customized with the \code{actions} option.
 With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_is_logical(small_table, columns = vars(e))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_is_logical(small_table, columns = e)
 }\if{html}{\out{</div>}}
 }
 
@@ -318,7 +318,7 @@ time. This is primarily used in \strong{testthat} tests.
 With the \verb{test_*()} form, we should get a single logical value returned to
 us.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\% test_col_is_logical(columns = vars(e))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\% test_col_is_logical(columns = e)
 #> [1] TRUE
 }\if{html}{\out{</div>}}
 }

--- a/man/col_is_numeric.Rd
+++ b/man/col_is_numeric.Rd
@@ -222,7 +222,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_is_numeric:
-    columns: vars(a)
+    columns: c(a)
     actions:
       warn_fraction: 0.1
       stop_fraction: 0.2

--- a/man/col_is_numeric.Rd
+++ b/man/col_is_numeric.Rd
@@ -192,6 +192,21 @@ happens. For the \verb{col_is_*()}-type functions, using \code{action_levels(war
 situation (the first produces a warning, the other will \code{stop()}).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_is_numeric.Rd
+++ b/man/col_is_numeric.Rd
@@ -31,10 +31,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{actions}{\emph{Thresholds and actions for different states}
 
@@ -60,12 +61,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_is_numeric.Rd
+++ b/man/col_is_numeric.Rd
@@ -211,7 +211,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_is_numeric(
-    columns = vars(a),
+    columns = a,
     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
     label = "The `col_is_numeric()` step.",
     active = FALSE
@@ -269,7 +269,7 @@ Validate that the column \code{d} has the \code{numeric} class.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = small_table) \%>\%
-  col_is_numeric(columns = vars(d)) \%>\%
+  col_is_numeric(columns = d) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -291,7 +291,7 @@ through but should \code{stop()} if there is a single test unit failing. The
 behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
-  col_is_numeric(columns = vars(d)) \%>\%
+  col_is_numeric(columns = d) \%>\%
   dplyr::slice(1:5)
 #> # A tibble: 5 x 8
 #>   date_time           date           a b             c      d e     f    
@@ -309,7 +309,7 @@ behavior of side effects can be customized with the \code{actions} option.
 With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_is_numeric(small_table, columns = vars(d))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_is_numeric(small_table, columns = d)
 }\if{html}{\out{</div>}}
 }
 
@@ -318,7 +318,7 @@ time. This is primarily used in \strong{testthat} tests.
 With the \verb{test_*()} form, we should get a single logical value returned to
 us.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\% test_col_is_numeric(columns = vars(d))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\% test_col_is_numeric(columns = d)
 #> [1] TRUE
 }\if{html}{\out{</div>}}
 }

--- a/man/col_is_numeric.Rd
+++ b/man/col_is_numeric.Rd
@@ -164,12 +164,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names, the result will be an expansion of
-validation steps to that number of column names (e.g., \code{vars(col_a, col_b)}
-will result in the entry of two validation steps). Aside from column names in
-quotes and in \code{vars()}, \strong{tidyselect} helper functions are available for
-specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{contains()},
-\code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Actions}{

--- a/man/col_is_posix.Rd
+++ b/man/col_is_posix.Rd
@@ -222,7 +222,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_is_posix:
-    columns: vars(a)
+    columns: c(a)
     actions:
       warn_fraction: 0.1
       stop_fraction: 0.2

--- a/man/col_is_posix.Rd
+++ b/man/col_is_posix.Rd
@@ -192,6 +192,21 @@ happens. For the \verb{col_is_*()}-type functions, using \code{action_levels(war
 situation (the first produces a warning, the other will \code{stop()}).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_is_posix.Rd
+++ b/man/col_is_posix.Rd
@@ -31,10 +31,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{actions}{\emph{Thresholds and actions for different states}
 
@@ -60,12 +61,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_is_posix.Rd
+++ b/man/col_is_posix.Rd
@@ -211,7 +211,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_is_posix(
-    columns = vars(a),
+    columns = a,
     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
     label = "The `col_is_posix()` step.",
     active = FALSE
@@ -269,7 +269,7 @@ Validate that the column \code{date_time} is indeed a date-time column.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = small_table) \%>\%
-  col_is_posix(columns = vars(date_time)) \%>\%
+  col_is_posix(columns = date_time) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -291,7 +291,7 @@ through but should \code{stop()} if there is a single test unit failing. The
 behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
-  col_is_posix(columns = vars(date_time)) \%>\%
+  col_is_posix(columns = date_time) \%>\%
   dplyr::slice(1:5)
 #> # A tibble: 5 x 8
 #>   date_time           date           a b             c      d e     f    
@@ -309,7 +309,7 @@ behavior of side effects can be customized with the \code{actions} option.
 With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_is_posix(small_table, columns = vars(date_time))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_is_posix(small_table, columns = date_time)
 }\if{html}{\out{</div>}}
 }
 
@@ -318,7 +318,7 @@ time. This is primarily used in \strong{testthat} tests.
 With the \verb{test_*()} form, we should get a single logical value returned to
 us.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\% test_col_is_posix(columns = vars(date_time))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\% test_col_is_posix(columns = date_time)
 #> [1] TRUE
 }\if{html}{\out{</div>}}
 }

--- a/man/col_is_posix.Rd
+++ b/man/col_is_posix.Rd
@@ -164,12 +164,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names, the result will be an expansion of
-validation steps to that number of column names (e.g., \code{vars(col_a, col_b)}
-will result in the entry of two validation steps). Aside from column names in
-quotes and in \code{vars()}, \strong{tidyselect} helper functions are available for
-specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{contains()},
-\code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Actions}{

--- a/man/col_schema_match.Rd
+++ b/man/col_schema_match.Rd
@@ -110,12 +110,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_schema_match.Rd
+++ b/man/col_schema_match.Rd
@@ -242,6 +242,20 @@ depending on the situation (the first produces a warning, the other
 \code{stop()}s).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_vals_between.Rd
+++ b/man/col_vals_between.Rd
@@ -375,7 +375,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_vals_between:
-    columns: vars(a)
+    columns: c(a)
     left: 1.0
     right: 2.0
     inclusive:

--- a/man/col_vals_between.Rd
+++ b/man/col_vals_between.Rd
@@ -339,6 +339,23 @@ quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_vals_between.Rd
+++ b/man/col_vals_between.Rd
@@ -358,7 +358,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_vals_between(
-    columns = vars(a),
+    columns = a,
     left = 1,
     right = 2,
     inclusive = c(TRUE, FALSE),
@@ -433,7 +433,7 @@ are \code{NA} values, we'll choose to let those pass validation by setting
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = small_table) \%>\%
   col_vals_between(
-    columns = vars(c),
+    columns = c,
     left = 1, right = 9,
     na_pass = TRUE
   ) \%>\%
@@ -459,7 +459,7 @@ behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
   col_vals_between(
-    columns = vars(c),
+    columns = c,
     left = 1, right = 9,
     na_pass = TRUE
   ) \%>\%
@@ -474,7 +474,7 @@ With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_between(
-  small_table, columns = vars(c),
+  small_table, columns = c,
   left = 1, right = 9,
   na_pass = TRUE
 )
@@ -488,7 +488,7 @@ us.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
   test_col_vals_between(
-    columns = vars(c),
+    columns = c,
     left = 1, right = 9,
     na_pass = TRUE
   )
@@ -505,7 +505,7 @@ values are \code{9} and they now fall outside of the upper (or right) bound.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
   test_col_vals_between(
-    columns = vars(c), left = 1, right = 9,
+    columns = c, left = 1, right = 9,
     inclusive = c(TRUE, FALSE),
     na_pass = TRUE
   )

--- a/man/col_vals_between.Rd
+++ b/man/col_vals_between.Rd
@@ -55,10 +55,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{left}{\emph{Definition of left bound}
 
@@ -136,12 +137,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_vals_between.Rd
+++ b/man/col_vals_between.Rd
@@ -247,12 +247,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names to \code{columns}, the result will be an
-expansion of validation steps to that number of column names (e.g.,
-\code{vars(col_a, col_b)} will result in the entry of two validation steps). Aside
-from column names in quotes and in \code{vars()}, \strong{tidyselect} helper functions
-are available for specifying columns. They are: \code{starts_with()},
-\code{ends_with()}, \code{contains()}, \code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Missing Values}{

--- a/man/col_vals_decreasing.Rd
+++ b/man/col_vals_decreasing.Rd
@@ -234,12 +234,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names to \code{columns}, the result will be an
-expansion of validation steps to that number of column names (e.g.,
-\code{vars(col_a, col_b)} will result in the entry of two validation steps). Aside
-from column names in quotes and in \code{vars()}, \strong{tidyselect} helper functions
-are available for specifying columns. They are: \code{starts_with()},
-\code{ends_with()}, \code{contains()}, \code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Missing Values}{

--- a/man/col_vals_decreasing.Rd
+++ b/man/col_vals_decreasing.Rd
@@ -361,7 +361,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_vals_decreasing:
-    columns: vars(a)
+    columns: c(a)
     allow_stationary: true
     increasing_tol: 0.5
     na_pass: true

--- a/man/col_vals_decreasing.Rd
+++ b/man/col_vals_decreasing.Rd
@@ -326,6 +326,23 @@ quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_vals_decreasing.Rd
+++ b/man/col_vals_decreasing.Rd
@@ -52,10 +52,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{allow_stationary}{\emph{Allowance for stationary pauses in values}
 
@@ -128,12 +129,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_vals_decreasing.Rd
+++ b/man/col_vals_decreasing.Rd
@@ -345,7 +345,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_vals_decreasing(
-    columns = vars(a),
+    columns = a,
     allow_stationary = TRUE,
     increasing_tol = 0.5,
     na_pass = TRUE,
@@ -430,7 +430,7 @@ to \code{TRUE}).
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = game_revenue_2) \%>\%
   col_vals_decreasing(
-    columns = vars(time_left),
+    columns = time_left,
     allow_stationary = TRUE
   ) \%>\%
   interrogate()
@@ -455,7 +455,7 @@ behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{game_revenue_2 \%>\%
   col_vals_decreasing(
-    columns = vars(time_left),
+    columns = time_left,
     allow_stationary = TRUE
   ) \%>\%
   dplyr::select(time_left) \%>\%
@@ -475,7 +475,7 @@ time. This is primarily used in \strong{testthat} tests.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_decreasing(
   game_revenue_2,
-  columns = vars(time_left),
+  columns = time_left,
   allow_stationary = TRUE
 )
 }\if{html}{\out{</div>}}
@@ -488,7 +488,7 @@ us.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{game_revenue_2 \%>\%
   test_col_vals_decreasing(
-    columns = vars(time_left),
+    columns = time_left,
     allow_stationary = TRUE
   )
 #> [1] TRUE

--- a/man/col_vals_equal.Rd
+++ b/man/col_vals_equal.Rd
@@ -49,10 +49,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{value}{\emph{Value for comparison}
 
@@ -113,12 +114,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_vals_equal.Rd
+++ b/man/col_vals_equal.Rd
@@ -217,12 +217,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names to \code{columns}, the result will be an
-expansion of validation steps to that number of column names (e.g.,
-\code{vars(col_a, col_b)} will result in the entry of two validation steps). Aside
-from column names in quotes and in \code{vars()}, \strong{tidyselect} helper functions
-are available for specifying columns. They are: \code{starts_with()},
-\code{ends_with()}, \code{contains()}, \code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Missing Values}{

--- a/man/col_vals_equal.Rd
+++ b/man/col_vals_equal.Rd
@@ -328,7 +328,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_vals_equal(
-    columns = vars(a),
+    columns = a,
     value = 1,
     na_pass = TRUE,
     preconditions = ~ . \%>\% dplyr::filter(a < 10),
@@ -398,7 +398,7 @@ units, one for each row).
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = tbl) \%>\%
-  col_vals_equal(columns = vars(a), value = 5) \%>\%
+  col_vals_equal(columns = a, value = 5) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -420,7 +420,7 @@ through but should \code{stop()} if there is a single test unit failing. The
 behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% 
-  col_vals_equal(columns = vars(a), value = 5) \%>\%
+  col_vals_equal(columns = a, value = 5) \%>\%
   dplyr::pull(a)
 #> [1] 5 5 5 5 5 5
 }\if{html}{\out{</div>}}
@@ -431,7 +431,7 @@ behavior of side effects can be customized with the \code{actions} option.
 With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_equal(tbl, columns = vars(a), value = 5)
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_equal(tbl, columns = a, value = 5)
 }\if{html}{\out{</div>}}
 }
 
@@ -440,7 +440,7 @@ time. This is primarily used in \strong{testthat} tests.
 With the \verb{test_*()} form, we should get a single logical value returned to
 us.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{test_col_vals_equal(tbl, columns = vars(a), value = 5)
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{test_col_vals_equal(tbl, columns = a, value = 5)
 #> [1] TRUE
 }\if{html}{\out{</div>}}
 }

--- a/man/col_vals_equal.Rd
+++ b/man/col_vals_equal.Rd
@@ -343,7 +343,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_vals_equal:
-    columns: vars(a)
+    columns: c(a)
     value: 1.0
     na_pass: true
     preconditions: ~. \%>\% dplyr::filter(a < 10)

--- a/man/col_vals_equal.Rd
+++ b/man/col_vals_equal.Rd
@@ -309,6 +309,23 @@ quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_vals_expr.Rd
+++ b/man/col_vals_expr.Rd
@@ -83,12 +83,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_vals_expr.Rd
+++ b/man/col_vals_expr.Rd
@@ -253,6 +253,23 @@ quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_vals_gt.Rd
+++ b/man/col_vals_gt.Rd
@@ -344,7 +344,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_vals_gt:
-    columns: vars(a)
+    columns: c(a)
     value: 1.0
     na_pass: true
     preconditions: ~. \%>\% dplyr::filter(a < 10)

--- a/man/col_vals_gt.Rd
+++ b/man/col_vals_gt.Rd
@@ -329,7 +329,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_vals_gt(
-    columns = vars(a),
+    columns = a,
     value = 1,
     na_pass = TRUE,
     preconditions = ~ . \%>\% dplyr::filter(a < 10),
@@ -399,7 +399,7 @@ test units, one for each row).
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = tbl) \%>\%
-  col_vals_gt(columns = vars(a), value = 4) \%>\%
+  col_vals_gt(columns = a, value = 4) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -420,7 +420,7 @@ This way of using validation functions acts as a data filter. Data is passed
 through but should \code{stop()} if there is a single test unit failing. The
 behavior of side effects can be customized with the \code{actions} option.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% col_vals_gt(columns = vars(a), value = 4)
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% col_vals_gt(columns = a, value = 4)
 #> # A tibble: 6 x 6
 #>       a     b     c d     e     f    
 #>   <dbl> <dbl> <dbl> <chr> <chr> <chr>
@@ -438,7 +438,7 @@ behavior of side effects can be customized with the \code{actions} option.
 With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_gt(tbl, columns = vars(a), value = 4)
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_gt(tbl, columns = a, value = 4)
 }\if{html}{\out{</div>}}
 }
 
@@ -447,7 +447,7 @@ time. This is primarily used in \strong{testthat} tests.
 With the \verb{test_*()} form, we should get a single logical value returned to
 us.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{test_col_vals_gt(tbl, columns = vars(a), value = 4)
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{test_col_vals_gt(tbl, columns = a, value = 4)
 #> [1] TRUE
 }\if{html}{\out{</div>}}
 }

--- a/man/col_vals_gt.Rd
+++ b/man/col_vals_gt.Rd
@@ -49,10 +49,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{value}{\emph{Value for comparison}
 
@@ -113,12 +114,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 
@@ -216,12 +218,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names to \code{columns}, the result will be an
-expansion of validation steps to that number of column names (e.g.,
-\code{vars(col_a, col_b)} will result in the entry of two validation steps). Aside
-from column names in quotes and in \code{vars()}, \strong{tidyselect} helper functions
-are available for specifying columns. They are: \code{starts_with()},
-\code{ends_with()}, \code{contains()}, \code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Missing Values}{
@@ -301,6 +308,23 @@ otherwise, nothing happens. For the \verb{col_vals_*()}-type functions, using
 choices depending on the situation (the first produces a warning when a
 quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
+}
+
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
 }
 
 \section{Briefs}{

--- a/man/col_vals_gte.Rd
+++ b/man/col_vals_gte.Rd
@@ -343,7 +343,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_vals_gte:
-    columns: vars(a)
+    columns: c(a)
     value: 1.0
     na_pass: true
     preconditions: ~. \%>\% dplyr::filter(a < 10)

--- a/man/col_vals_gte.Rd
+++ b/man/col_vals_gte.Rd
@@ -309,6 +309,23 @@ situation (the first produces a warning when a quarter of the total test
 units fails, the other \code{stop()}s at the same threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_vals_gte.Rd
+++ b/man/col_vals_gte.Rd
@@ -219,12 +219,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names to \code{columns}, the result will be an
-expansion of validation steps to that number of column names (e.g.,
-\code{vars(col_a, col_b)} will result in the entry of two validation steps). Aside
-from column names in quotes and in \code{vars()}, \strong{tidyselect} helper functions
-are available for specifying columns. They are: \code{starts_with()},
-\code{ends_with()}, \code{contains()}, \code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Missing Values}{

--- a/man/col_vals_gte.Rd
+++ b/man/col_vals_gte.Rd
@@ -50,10 +50,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{value}{\emph{Value for comparison}
 
@@ -114,12 +115,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_vals_gte.Rd
+++ b/man/col_vals_gte.Rd
@@ -328,7 +328,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_vals_gte(
-    columns = vars(a),
+    columns = a,
     value = 1,
     na_pass = TRUE,
     preconditions = ~ . \%>\% dplyr::filter(a < 10),
@@ -398,7 +398,7 @@ are 6 test units, one for each row).
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = tbl) \%>\%
-  col_vals_gte(columns = vars(a), value = 5) \%>\%
+  col_vals_gte(columns = a, value = 5) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -419,7 +419,7 @@ This way of using validation functions acts as a data filter. Data is passed
 through but should \code{stop()} if there is a single test unit failing. The
 behavior of side effects can be customized with the \code{actions} option.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% col_vals_gte(columns = vars(a), value = 5)
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% col_vals_gte(columns = a, value = 5)
 #> # A tibble: 6 x 6
 #>       a     b     c d     e     f    
 #>   <dbl> <dbl> <dbl> <chr> <chr> <chr>
@@ -437,7 +437,7 @@ behavior of side effects can be customized with the \code{actions} option.
 With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_gte(tbl, columns = vars(a), value = 5)
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_gte(tbl, columns = a, value = 5)
 }\if{html}{\out{</div>}}
 }
 
@@ -446,7 +446,7 @@ time. This is primarily used in \strong{testthat} tests.
 With the \verb{test_*()} form, we should get a single logical value returned to
 us.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{test_col_vals_gte(tbl, columns = vars(a), value = 5)
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{test_col_vals_gte(tbl, columns = a, value = 5)
 #> [1] TRUE
 }\if{html}{\out{</div>}}
 }

--- a/man/col_vals_in_set.Rd
+++ b/man/col_vals_in_set.Rd
@@ -302,7 +302,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_vals_in_set(
-    columns = vars(a),
+    columns = a,
     set = c(1, 2, 3, 4),
     preconditions = ~ . \%>\% dplyr::filter(a < 10),
     segments = b ~ c("group_1", "group_2"),
@@ -372,7 +372,7 @@ any failing test units (there are 13 test units, one for each row).
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = small_table) \%>\%
   col_vals_in_set(
-    columns = vars(f), set = c("low", "mid", "high")
+    columns = f, set = c("low", "mid", "high")
   ) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
@@ -396,7 +396,7 @@ behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
   col_vals_in_set(
-    columns = vars(f), set = c("low", "mid", "high")
+    columns = f, set = c("low", "mid", "high")
   ) \%>\%
   dplyr::pull(f) \%>\%
   unique()
@@ -411,7 +411,7 @@ time. This is primarily used in \strong{testthat} tests.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_in_set(
   small_table,
-  columns = vars(f), set = c("low", "mid", "high")
+  columns = f, set = c("low", "mid", "high")
 )
 }\if{html}{\out{</div>}}
 }
@@ -423,7 +423,7 @@ us.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
   test_col_vals_in_set(
-    columns = vars(f), set = c("low", "mid", "high")
+    columns = f, set = c("low", "mid", "high")
   )
 #> [1] TRUE
 }\if{html}{\out{</div>}}

--- a/man/col_vals_in_set.Rd
+++ b/man/col_vals_in_set.Rd
@@ -40,10 +40,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{set}{\emph{Set of values}
 
@@ -96,12 +97,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_vals_in_set.Rd
+++ b/man/col_vals_in_set.Rd
@@ -316,7 +316,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_vals_in_set:
-   columns: vars(a)
+   columns: c(a)
    set:
    - 1.0
    - 2.0

--- a/man/col_vals_in_set.Rd
+++ b/man/col_vals_in_set.Rd
@@ -199,12 +199,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names, the result will be an expansion of
-validation steps to that number of column names (e.g., \code{vars(col_a, col_b)}
-will result in the entry of two validation steps). Aside from column names in
-quotes and in \code{vars()}, \strong{tidyselect} helper functions are available for
-specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{contains()},
-\code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Preconditions}{

--- a/man/col_vals_in_set.Rd
+++ b/man/col_vals_in_set.Rd
@@ -283,6 +283,23 @@ quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_vals_increasing.Rd
+++ b/man/col_vals_increasing.Rd
@@ -234,12 +234,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names to \code{columns}, the result will be an
-expansion of validation steps to that number of column names (e.g.,
-\code{vars(col_a, col_b)} will result in the entry of two validation steps). Aside
-from column names in quotes and in \code{vars()}, \strong{tidyselect} helper functions
-are available for specifying columns. They are: \code{starts_with()},
-\code{ends_with()}, \code{contains()}, \code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Missing Values}{

--- a/man/col_vals_increasing.Rd
+++ b/man/col_vals_increasing.Rd
@@ -345,7 +345,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_vals_increasing(
-    columns = vars(a),
+    columns = a,
     allow_stationary = TRUE,
     decreasing_tol = 0.5,
     na_pass = TRUE,
@@ -417,7 +417,7 @@ to \code{TRUE}). We'll determine if this validation has any failing test units
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = game_revenue) \%>\%
   col_vals_increasing(
-    columns = vars(session_start),
+    columns = session_start,
     allow_stationary = TRUE
   ) \%>\%
   interrogate()
@@ -442,7 +442,7 @@ behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{game_revenue \%>\%
   col_vals_increasing(
-    columns = vars(session_start),
+    columns = session_start,
     allow_stationary = TRUE
   ) \%>\%
   dplyr::select(session_start) \%>\%
@@ -462,7 +462,7 @@ time. This is primarily used in \strong{testthat} tests.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_increasing(
   game_revenue,
-  columns = vars(session_start),
+  columns = session_start,
   allow_stationary = TRUE
 )
 }\if{html}{\out{</div>}}
@@ -475,7 +475,7 @@ us.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{game_revenue \%>\%
   test_col_vals_increasing(
-    columns = vars(session_start),
+    columns = session_start,
     allow_stationary = TRUE
   )
 #> [1] TRUE

--- a/man/col_vals_increasing.Rd
+++ b/man/col_vals_increasing.Rd
@@ -326,6 +326,23 @@ quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_vals_increasing.Rd
+++ b/man/col_vals_increasing.Rd
@@ -52,10 +52,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{allow_stationary}{\emph{Allowance for stationary pauses in values}
 
@@ -128,12 +129,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_vals_increasing.Rd
+++ b/man/col_vals_increasing.Rd
@@ -361,7 +361,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_vals_increasing:
-    columns: vars(a)
+    columns: c(a)
     allow_stationary: true
     decreasing_tol: 0.5
     na_pass: true

--- a/man/col_vals_lt.Rd
+++ b/man/col_vals_lt.Rd
@@ -218,12 +218,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names to \code{columns}, the result will be an
-expansion of validation steps to that number of column names (e.g.,
-\code{vars(col_a, col_b)} will result in the entry of two validation steps). Aside
-from column names in quotes and in \code{vars()}, \strong{tidyselect} helper functions
-are available for specifying columns. They are: \code{starts_with()},
-\code{ends_with()}, \code{contains()}, \code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Missing Values}{

--- a/man/col_vals_lt.Rd
+++ b/man/col_vals_lt.Rd
@@ -329,7 +329,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_vals_lt(
-    columns = vars(a),
+    columns = a,
     value = 1,
     na_pass = TRUE,
     preconditions = ~ . \%>\% dplyr::filter(a < 10),
@@ -399,7 +399,7 @@ units, one for each row).
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = tbl) \%>\%
-  col_vals_lt(columns = vars(c), value = 5) \%>\%
+  col_vals_lt(columns = c, value = 5) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -421,7 +421,7 @@ through but should \code{stop()} if there is a single test unit failing. The
 behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% 
-  col_vals_lt(columns = vars(c), value = 5) \%>\%
+  col_vals_lt(columns = c, value = 5) \%>\%
   dplyr::pull(c)
 #> [1] 1 1 1 2 3 4
 }\if{html}{\out{</div>}}
@@ -432,7 +432,7 @@ behavior of side effects can be customized with the \code{actions} option.
 With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_lt(tbl, columns = vars(c), value = 5)
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_lt(tbl, columns = c, value = 5)
 }\if{html}{\out{</div>}}
 }
 
@@ -441,7 +441,7 @@ time. This is primarily used in \strong{testthat} tests.
 With the \verb{test_*()} form, we should get a single logical value returned to
 us.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{test_col_vals_lt(tbl, columns = vars(c), value = 5)
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{test_col_vals_lt(tbl, columns = c, value = 5)
 #> [1] TRUE
 }\if{html}{\out{</div>}}
 }

--- a/man/col_vals_lt.Rd
+++ b/man/col_vals_lt.Rd
@@ -49,10 +49,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{value}{\emph{Value for comparison}
 
@@ -113,12 +114,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_vals_lt.Rd
+++ b/man/col_vals_lt.Rd
@@ -310,6 +310,23 @@ quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_vals_lt.Rd
+++ b/man/col_vals_lt.Rd
@@ -344,7 +344,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_vals_lt:
-    columns: vars(a)
+    columns: c(a)
     value: 1.0
     na_pass: true
     preconditions: ~. \%>\% dplyr::filter(a < 10)

--- a/man/col_vals_lte.Rd
+++ b/man/col_vals_lte.Rd
@@ -330,7 +330,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_vals_lte(
-    columns = vars(a),
+    columns = a,
     value = 1,
     na_pass = TRUE,
     preconditions = ~ . \%>\% dplyr::filter(a < 10),
@@ -400,7 +400,7 @@ Validate that values in column \code{c} are all less than or equal to the value 
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = tbl) \%>\%
-  col_vals_lte(columns = vars(c), value = 4) \%>\%
+  col_vals_lte(columns = c, value = 4) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -422,7 +422,7 @@ through but should \code{stop()} if there is a single test unit failing. The
 behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% 
-  col_vals_lte(columns = vars(c), value = 4) \%>\%
+  col_vals_lte(columns = c, value = 4) \%>\%
   dplyr::pull(c)
 #> [1] 1 1 1 2 3 4
 }\if{html}{\out{</div>}}
@@ -433,7 +433,7 @@ behavior of side effects can be customized with the \code{actions} option.
 With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_lte(tbl, columns = vars(c), value = 4)
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_lte(tbl, columns = c, value = 4)
 }\if{html}{\out{</div>}}
 }
 
@@ -442,7 +442,7 @@ time. This is primarily used in \strong{testthat} tests.
 With the \verb{test_*()} form, we should get a single logical value returned to
 us.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{test_col_vals_lte(tbl, columns = vars(c), value = 4)
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{test_col_vals_lte(tbl, columns = c, value = 4)
 #> [1] TRUE
 }\if{html}{\out{</div>}}
 }

--- a/man/col_vals_lte.Rd
+++ b/man/col_vals_lte.Rd
@@ -311,6 +311,23 @@ quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_vals_lte.Rd
+++ b/man/col_vals_lte.Rd
@@ -219,12 +219,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names to \code{columns}, the result will be an
-expansion of validation steps to that number of column names (e.g.,
-\code{vars(col_a, col_b)} will result in the entry of two validation steps). Aside
-from column names in quotes and in \code{vars()}, \strong{tidyselect} helper functions
-are available for specifying columns. They are: \code{starts_with()},
-\code{ends_with()}, \code{contains()}, \code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Missing Values}{

--- a/man/col_vals_lte.Rd
+++ b/man/col_vals_lte.Rd
@@ -50,10 +50,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{value}{\emph{Value for comparison}
 
@@ -114,12 +115,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_vals_lte.Rd
+++ b/man/col_vals_lte.Rd
@@ -345,7 +345,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_vals_lte:
-    columns: vars(a)
+    columns: c(a)
     value: 1.0
     na_pass: true
     preconditions: ~. \%>\% dplyr::filter(a < 10)

--- a/man/col_vals_make_set.Rd
+++ b/man/col_vals_make_set.Rd
@@ -209,12 +209,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names, the result will be an expansion of
-validation steps to that number of column names (e.g., \code{vars(col_a, col_b)}
-will result in the entry of two validation steps). Aside from column names in
-quotes and in \code{vars()}, \strong{tidyselect} helper functions are available for
-specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{contains()},
-\code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Preconditions}{

--- a/man/col_vals_make_set.Rd
+++ b/man/col_vals_make_set.Rd
@@ -312,7 +312,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_vals_make_set(
-    columns = vars(a),
+    columns = a,
     set = c(1, 2, 3, 4),
     preconditions = ~ . \%>\% dplyr::filter(a < 10),
     segments = b ~ c("group_1", "group_2"),
@@ -382,7 +382,7 @@ failing test units (there are 4 test units).
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = small_table) \%>\%
   col_vals_make_set(
-    columns = vars(f), set = c("low", "mid", "high")
+    columns = f, set = c("low", "mid", "high")
   ) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
@@ -406,7 +406,7 @@ behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
   col_vals_make_set(
-    columns = vars(f), set = c("low", "mid", "high")
+    columns = f, set = c("low", "mid", "high")
   ) \%>\%
   dplyr::pull(f) \%>\%
   unique()
@@ -421,7 +421,7 @@ time. This is primarily used in \strong{testthat} tests.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_make_set(
   small_table,
-  columns = vars(f), set = c("low", "mid", "high")
+  columns = f, set = c("low", "mid", "high")
 )
 }\if{html}{\out{</div>}}
 }
@@ -433,7 +433,7 @@ us.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
   test_col_vals_make_set(
-    columns = vars(f), set = c("low", "mid", "high")
+    columns = f, set = c("low", "mid", "high")
   )
 #> [1] TRUE
 }\if{html}{\out{</div>}}

--- a/man/col_vals_make_set.Rd
+++ b/man/col_vals_make_set.Rd
@@ -326,7 +326,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_vals_make_set:
-   columns: vars(a)
+   columns: c(a)
    set:
    - 1.0
    - 2.0

--- a/man/col_vals_make_set.Rd
+++ b/man/col_vals_make_set.Rd
@@ -293,6 +293,23 @@ quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_vals_make_set.Rd
+++ b/man/col_vals_make_set.Rd
@@ -46,10 +46,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{set}{\emph{Set of values}
 
@@ -102,12 +103,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_vals_make_subset.Rd
+++ b/man/col_vals_make_subset.Rd
@@ -205,12 +205,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names, the result will be an expansion of
-validation steps to that number of column names (e.g., \code{vars(col_a, col_b)}
-will result in the entry of two validation steps). Aside from column names in
-quotes and in \code{vars()}, \strong{tidyselect} helper functions are available for
-specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{contains()},
-\code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Preconditions}{

--- a/man/col_vals_make_subset.Rd
+++ b/man/col_vals_make_subset.Rd
@@ -308,7 +308,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_vals_make_subset(
-    columns = vars(a),
+    columns = a,
     set = c(1, 2, 3, 4),
     preconditions = ~ . \%>\% dplyr::filter(a < 10),
     segments = b ~ c("group_1", "group_2"),
@@ -379,7 +379,7 @@ units (there are 2 test units, one per element in the \code{set}).
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = small_table) \%>\%
   col_vals_make_subset(
-    columns = vars(f), set = c("low", "high")
+    columns = f, set = c("low", "high")
   ) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
@@ -403,7 +403,7 @@ behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
   col_vals_make_subset(
-    columns = vars(f), set = c("low", "high")
+    columns = f, set = c("low", "high")
   ) \%>\%
   dplyr::pull(f) \%>\%
   unique()
@@ -418,7 +418,7 @@ time. This is primarily used in \strong{testthat} tests.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_make_subset(
   small_table,
-  columns = vars(f), set = c("low", "high")
+  columns = f, set = c("low", "high")
 )
 }\if{html}{\out{</div>}}
 }
@@ -430,7 +430,7 @@ us.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
   test_col_vals_make_subset(
-    columns = vars(f), set = c("low", "high")
+    columns = f, set = c("low", "high")
   )
 #> [1] TRUE
 }\if{html}{\out{</div>}}

--- a/man/col_vals_make_subset.Rd
+++ b/man/col_vals_make_subset.Rd
@@ -289,6 +289,23 @@ quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_vals_make_subset.Rd
+++ b/man/col_vals_make_subset.Rd
@@ -322,7 +322,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_vals_make_subset:
-   columns: vars(a)
+   columns: c(a)
    set:
    - 1.0
    - 2.0

--- a/man/col_vals_make_subset.Rd
+++ b/man/col_vals_make_subset.Rd
@@ -46,10 +46,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{set}{\emph{Set of values}
 
@@ -102,12 +103,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_vals_not_between.Rd
+++ b/man/col_vals_not_between.Rd
@@ -358,7 +358,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_vals_not_between(
-    columns = vars(a),
+    columns = a,
     left = 1,
     right = 2,
     inclusive = c(TRUE, FALSE),
@@ -434,7 +434,7 @@ units (there are 13 test units, one for each row).
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = small_table) \%>\%
   col_vals_not_between(
-    columns = vars(c),
+    columns = c,
     left = 10, right = 20,
     na_pass = TRUE
   ) \%>\%
@@ -460,7 +460,7 @@ behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
   col_vals_not_between(
-    columns = vars(c),
+    columns = c,
     left = 10, right = 20,
     na_pass = TRUE
   ) \%>\%
@@ -475,7 +475,7 @@ With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_not_between(
-  small_table, columns = vars(c),
+  small_table, columns = c,
   left = 10, right = 20,
   na_pass = TRUE
 )
@@ -489,7 +489,7 @@ us.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
   test_col_vals_not_between(
-    columns = vars(c),
+    columns = c,
     left = 10, right = 20,
     na_pass = TRUE
   )
@@ -506,7 +506,7 @@ In changing the lower bound to be \code{9} and making it non-inclusive, we get
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
   test_col_vals_not_between(
-    columns = vars(c),
+    columns = c,
     left = 9, right = 20,
     inclusive = c(FALSE, TRUE),
     na_pass = TRUE

--- a/man/col_vals_not_between.Rd
+++ b/man/col_vals_not_between.Rd
@@ -339,6 +339,23 @@ quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_vals_not_between.Rd
+++ b/man/col_vals_not_between.Rd
@@ -55,10 +55,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{left}{\emph{Definition of left bound}
 
@@ -136,12 +137,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_vals_not_between.Rd
+++ b/man/col_vals_not_between.Rd
@@ -247,12 +247,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names to \code{columns}, the result will be an
-expansion of validation steps to that number of column names (e.g.,
-\code{vars(col_a, col_b)} will result in the entry of two validation steps). Aside
-from column names in quotes and in \code{vars()}, \strong{tidyselect} helper functions
-are available for specifying columns. They are: \code{starts_with()},
-\code{ends_with()}, \code{contains()}, \code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Missing Values}{

--- a/man/col_vals_not_between.Rd
+++ b/man/col_vals_not_between.Rd
@@ -375,7 +375,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_vals_not_between:
-    columns: vars(a)
+    columns: c(a)
     left: 1.0
     right: 2.0
     inclusive:

--- a/man/col_vals_not_equal.Rd
+++ b/man/col_vals_not_equal.Rd
@@ -308,6 +308,23 @@ quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_vals_not_equal.Rd
+++ b/man/col_vals_not_equal.Rd
@@ -216,12 +216,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names, the result will be an expansion of
-validation steps to that number of column names (e.g., \code{vars(col_a, col_b)}
-will result in the entry of two validation steps). Aside from column names in
-quotes and in \code{vars()}, \strong{tidyselect} helper functions are available for
-specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{contains()},
-\code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Missing Values}{

--- a/man/col_vals_not_equal.Rd
+++ b/man/col_vals_not_equal.Rd
@@ -49,10 +49,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{value}{\emph{Value for comparison}
 
@@ -113,12 +114,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_vals_not_equal.Rd
+++ b/man/col_vals_not_equal.Rd
@@ -327,7 +327,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_vals_not_equal(
-    columns = vars(a),
+    columns = a,
     value = 1,
     na_pass = TRUE,
     preconditions = ~ . \%>\% dplyr::filter(a < 10),
@@ -397,7 +397,7 @@ test units, one for each row).
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = tbl) \%>\%
-  col_vals_not_equal(columns = vars(a), value = 6) \%>\%
+  col_vals_not_equal(columns = a, value = 6) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -419,7 +419,7 @@ through but should \code{stop()} if there is a single test unit failing. The
 behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% 
-  col_vals_not_equal(columns = vars(a), value = 6) \%>\%
+  col_vals_not_equal(columns = a, value = 6) \%>\%
   dplyr::pull(a)
 #> [1] 5 5 5 5 5 5
 }\if{html}{\out{</div>}}
@@ -430,7 +430,7 @@ behavior of side effects can be customized with the \code{actions} option.
 With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_not_equal(tbl, columns = vars(a), value = 6)
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_not_equal(tbl, columns = a, value = 6)
 }\if{html}{\out{</div>}}
 }
 
@@ -439,7 +439,7 @@ time. This is primarily used in \strong{testthat} tests.
 With the \verb{test_*()} form, we should get a single logical value returned to
 us.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{test_col_vals_not_equal(tbl, columns = vars(a), value = 6)
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{test_col_vals_not_equal(tbl, columns = a, value = 6)
 #> [1] TRUE
 }\if{html}{\out{</div>}}
 }

--- a/man/col_vals_not_equal.Rd
+++ b/man/col_vals_not_equal.Rd
@@ -342,7 +342,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_vals_not_equal:
-    columns: vars(a)
+    columns: c(a)
     value: 1.0
     na_pass: true
     preconditions: ~. \%>\% dplyr::filter(a < 10)

--- a/man/col_vals_not_in_set.Rd
+++ b/man/col_vals_not_in_set.Rd
@@ -205,12 +205,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names, the result will be an expansion of
-validation steps to that number of column names (e.g., \code{vars(col_a, col_b)}
-will result in the entry of two validation steps). Aside from column names in
-quotes and in \code{vars()}, \strong{tidyselect} helper functions are available for
-specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{contains()},
-\code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Preconditions}{

--- a/man/col_vals_not_in_set.Rd
+++ b/man/col_vals_not_in_set.Rd
@@ -308,7 +308,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_vals_not_in_set(
-    columns = vars(a),
+    columns = a,
     set = c(1, 2, 3, 4),
     preconditions = ~ . \%>\% dplyr::filter(a < 10),
     segments = b ~ c("group_1", "group_2"),
@@ -359,7 +359,7 @@ and \code{highs}. We'll determine if this validation has any failing test units
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = small_table) \%>\%
   col_vals_not_in_set(
-    columns = vars(f), set = c("lows", "mids", "highs")
+    columns = f, set = c("lows", "mids", "highs")
   ) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
@@ -383,7 +383,7 @@ behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{small_table \%>\%
   col_vals_not_in_set(
-    columns = vars(f), set = c("lows", "mids", "highs")
+    columns = f, set = c("lows", "mids", "highs")
   ) \%>\%
   dplyr::pull(f) \%>\%
   unique()
@@ -397,7 +397,7 @@ time. This is primarily used in \strong{testthat} tests.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_not_in_set(
   small_table,
-  columns = vars(f), set = c("lows", "mids", "highs")
+  columns = f, set = c("lows", "mids", "highs")
 )
 }\if{html}{\out{</div>}}
 }
@@ -409,7 +409,7 @@ us.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
   test_col_vals_not_in_set(
-    columns = vars(f), set = c("lows", "mids", "highs")
+    columns = f, set = c("lows", "mids", "highs")
   )
 #> [1] TRUE
 }\if{html}{\out{</div>}}

--- a/man/col_vals_not_in_set.Rd
+++ b/man/col_vals_not_in_set.Rd
@@ -289,6 +289,23 @@ quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_vals_not_in_set.Rd
+++ b/man/col_vals_not_in_set.Rd
@@ -46,10 +46,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{set}{\emph{Set of values}
 
@@ -102,12 +103,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_vals_not_in_set.Rd
+++ b/man/col_vals_not_in_set.Rd
@@ -322,7 +322,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_vals_not_in_set:
-   columns: vars(a)
+   columns: c(a)
    set:
    - 1.0
    - 2.0

--- a/man/col_vals_not_null.Rd
+++ b/man/col_vals_not_null.Rd
@@ -270,6 +270,23 @@ quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_vals_not_null.Rd
+++ b/man/col_vals_not_null.Rd
@@ -302,7 +302,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_vals_not_null:
-    columns: vars(a)
+    columns: c(a)
     preconditions: ~. \%>\% dplyr::filter(a < 10)
     segments: b ~ c("group_1", "group_2")
     actions:

--- a/man/col_vals_not_null.Rd
+++ b/man/col_vals_not_null.Rd
@@ -186,12 +186,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names, the result will be an expansion of
-validation steps to that number of column names (e.g., \code{vars(col_a, col_b)}
-will result in the entry of two validation steps). Aside from column names in
-quotes and in \code{vars()}, \strong{tidyselect} helper functions are available for
-specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{contains()},
-\code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Preconditions}{

--- a/man/col_vals_not_null.Rd
+++ b/man/col_vals_not_null.Rd
@@ -33,10 +33,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{preconditions}{\emph{Input table modification prior to validation}
 
@@ -82,12 +83,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_vals_not_null.Rd
+++ b/man/col_vals_not_null.Rd
@@ -289,7 +289,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_vals_not_null(
-    columns = vars(a),
+    columns = a,
     preconditions = ~ . \%>\% dplyr::filter(a < 10),
     segments = b ~ c("group_1", "group_2"),
     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
@@ -353,7 +353,7 @@ row).
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = tbl) \%>\%
-  col_vals_not_null(columns = vars(b)) \%>\%
+  col_vals_not_null(columns = b) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -375,7 +375,7 @@ through but should \code{stop()} if there is a single test unit failing. The
 behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\%
-  col_vals_not_null(columns = vars(b)) \%>\%
+  col_vals_not_null(columns = b) \%>\%
   dplyr::pull(b)
 #> [1] 7 1 0 0 0
 }\if{html}{\out{</div>}}
@@ -386,7 +386,7 @@ behavior of side effects can be customized with the \code{actions} option.
 With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_not_null(tbl, columns = vars(b))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_not_null(tbl, columns = b)
 }\if{html}{\out{</div>}}
 }
 
@@ -395,7 +395,7 @@ time. This is primarily used in \strong{testthat} tests.
 With the \verb{test_*()} form, we should get a single logical value returned to
 us.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% test_col_vals_not_null(columns = vars(b))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% test_col_vals_not_null(columns = b)
 #> [1] TRUE
 }\if{html}{\out{</div>}}
 }

--- a/man/col_vals_null.Rd
+++ b/man/col_vals_null.Rd
@@ -301,7 +301,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_vals_null:
-    columns: vars(a)
+    columns: c(a)
     preconditions: ~. \%>\% dplyr::filter(a < 10)
     segments: b ~ c("group_1", "group_2")
     actions:

--- a/man/col_vals_null.Rd
+++ b/man/col_vals_null.Rd
@@ -288,7 +288,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_vals_null(
-    columns = vars(a),
+    columns = a,
     preconditions = ~ . \%>\% dplyr::filter(a < 10),
     segments = b ~ c("group_1", "group_2"),
     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
@@ -352,7 +352,7 @@ row).
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = tbl) \%>\%
-  col_vals_null(columns = vars(c)) \%>\%
+  col_vals_null(columns = c) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -374,7 +374,7 @@ through but should \code{stop()} if there is a single test unit failing. The
 behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\%
-  col_vals_null(columns = vars(c)) \%>\%
+  col_vals_null(columns = c) \%>\%
   dplyr::pull(c)
 #> [1] NA NA NA NA NA
 }\if{html}{\out{</div>}}
@@ -385,7 +385,7 @@ behavior of side effects can be customized with the \code{actions} option.
 With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_null(tbl, columns = vars(c))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_null(tbl, columns = c)
 }\if{html}{\out{</div>}}
 }
 
@@ -394,7 +394,7 @@ time. This is primarily used in \strong{testthat} tests.
 With the \verb{test_*()} form, we should get a single logical value returned to
 us.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% test_col_vals_null(columns = vars(c))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% test_col_vals_null(columns = c)
 #> [1] TRUE
 }\if{html}{\out{</div>}}
 }

--- a/man/col_vals_null.Rd
+++ b/man/col_vals_null.Rd
@@ -33,10 +33,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{preconditions}{\emph{Input table modification prior to validation}
 
@@ -82,12 +83,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_vals_null.Rd
+++ b/man/col_vals_null.Rd
@@ -269,6 +269,23 @@ quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_vals_null.Rd
+++ b/man/col_vals_null.Rd
@@ -185,12 +185,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names, the result will be an expansion of
-validation steps to that number of column names (e.g., \code{vars(col_a, col_b)}
-will result in the entry of two validation steps). Aside from column names in
-quotes and in \code{vars()}, \strong{tidyselect} helper functions are available for
-specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{contains()},
-\code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Preconditions}{

--- a/man/col_vals_regex.Rd
+++ b/man/col_vals_regex.Rd
@@ -326,7 +326,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{agent \%>\% 
   col_vals_regex(
-    columns = vars(a),
+    columns = a,
     regex = "[0-9]-[a-z]\{3\}-[0-9]\{3\}",
     na_pass = TRUE,
     preconditions = ~ . \%>\% dplyr::filter(a < 10),
@@ -399,7 +399,7 @@ units, one for each row).
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = small_table) \%>\%
-  col_vals_regex(columns = vars(b), regex = pattern) \%>\%
+  col_vals_regex(columns = b, regex = pattern) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -421,7 +421,7 @@ through but should \code{stop()} if there is a single test unit failing. The
 behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\%
-  col_vals_regex(columns = vars(b), regex = pattern) \%>\%
+  col_vals_regex(columns = b, regex = pattern) \%>\%
   dplyr::slice(1:5)
 #> # A tibble: 5 x 8
 #>   date_time           date           a b             c      d e     f    
@@ -439,7 +439,7 @@ behavior of side effects can be customized with the \code{actions} option.
 With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_regex(small_table, columns = vars(b), regex = pattern)
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_regex(small_table, columns = b, regex = pattern)
 }\if{html}{\out{</div>}}
 }
 
@@ -448,7 +448,7 @@ time. This is primarily used in \strong{testthat} tests.
 With the \verb{test_*()} form, we should get a single logical value returned to
 us.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\% test_col_vals_regex(columns = vars(b), regex = pattern)
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{small_table \%>\% test_col_vals_regex(columns = b, regex = pattern)
 #> [1] TRUE
 }\if{html}{\out{</div>}}
 }

--- a/man/col_vals_regex.Rd
+++ b/man/col_vals_regex.Rd
@@ -49,10 +49,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{regex}{\emph{Regex pattern}
 
@@ -112,12 +113,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/col_vals_regex.Rd
+++ b/man/col_vals_regex.Rd
@@ -215,12 +215,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names, the result will be an expansion of
-validation steps to that number of column names (e.g., \code{vars(col_a, col_b)}
-will result in the entry of two validation steps). Aside from column names in
-quotes and in \code{vars()}, \strong{tidyselect} helper functions are available for
-specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{contains()},
-\code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Missing Values}{

--- a/man/col_vals_regex.Rd
+++ b/man/col_vals_regex.Rd
@@ -341,7 +341,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_vals_regex:
-    columns: vars(a)
+    columns: c(a)
     regex: '[0-9]-[a-z]\{3\}-[0-9]\{3\}'
     na_pass: true
     preconditions: ~. \%>\% dplyr::filter(a < 10)

--- a/man/col_vals_regex.Rd
+++ b/man/col_vals_regex.Rd
@@ -307,6 +307,23 @@ quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_vals_within_spec.Rd
+++ b/man/col_vals_within_spec.Rd
@@ -268,12 +268,17 @@ Only a single \code{spec} value should be provided per function call.
 \section{Column Names}{
 
 
-If providing multiple column names, the result will be an expansion of
-validation steps to that number of column names (e.g., \code{vars(col_a, col_b)}
-will result in the entry of two validation steps). Aside from column names in
-quotes and in \code{vars()}, \strong{tidyselect} helper functions are available for
-specifying columns. They are: \code{starts_with()}, \code{ends_with()}, \code{contains()},
-\code{matches()}, and \code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Missing Values}{

--- a/man/col_vals_within_spec.Rd
+++ b/man/col_vals_within_spec.Rd
@@ -360,6 +360,23 @@ quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/col_vals_within_spec.Rd
+++ b/man/col_vals_within_spec.Rd
@@ -379,7 +379,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   col_vals_within_spec(
-    columns = vars(a),
+    columns = a,
     spec = "email",
     na_pass = TRUE,
     preconditions = ~ . \%>\% dplyr::filter(b < 10),
@@ -447,7 +447,7 @@ units, one for each row).
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = spec_slice) \%>\%
   col_vals_within_spec(
-    columns = vars(email_addresses),
+    columns = email_addresses,
     spec = "email"
   ) \%>\%
   interrogate()
@@ -472,7 +472,7 @@ behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{spec_slice \%>\%
   col_vals_within_spec(
-    columns = vars(email_addresses),
+    columns = email_addresses,
     spec = "email"
   ) \%>\%
   dplyr::select(email_addresses)
@@ -494,7 +494,7 @@ time. This is primarily used in \strong{testthat} tests.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_col_vals_within_spec(
   spec_slice,
-  columns = vars(email_addresses),
+  columns = email_addresses,
   spec = "email"
 )
 }\if{html}{\out{</div>}}
@@ -507,7 +507,7 @@ us.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{spec_slice \%>\%
   test_col_vals_within_spec(
-    columns = vars(email_addresses),
+    columns = email_addresses,
     spec = "email"
   )
 #> [1] TRUE

--- a/man/col_vals_within_spec.Rd
+++ b/man/col_vals_within_spec.Rd
@@ -394,7 +394,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - col_vals_within_spec:
-    columns: vars(a)
+    columns: c(a)
     spec: email
     na_pass: true
     preconditions: ~. \%>\% dplyr::filter(b < 10)

--- a/man/col_vals_within_spec.Rd
+++ b/man/col_vals_within_spec.Rd
@@ -49,10 +49,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{spec}{\emph{Specification type}
 
@@ -113,12 +114,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/conjointly.Rd
+++ b/man/conjointly.Rd
@@ -217,12 +217,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names in any of the supplied validation steps,
-the result will be an expansion of sub-validation steps to that number of
-column names. Aside from column names in quotes and in \code{vars()},
-\strong{tidyselect} helper functions are available for specifying columns. They
-are: \code{starts_with()}, \code{ends_with()}, \code{contains()}, \code{matches()}, and
-\code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Preconditions}{

--- a/man/conjointly.Rd
+++ b/man/conjointly.Rd
@@ -51,7 +51,7 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 A collection one-sided formulas that consist of validation functions that
 validate row units (the \verb{col_vals_*()} series), column existence
 (\code{\link[=col_exists]{col_exists()}}), or column type (the \verb{col_is_*()} series). An example of
-this is \verb{~ col_vals_gte(., vars(a), 5.5), ~ col_vals_not_null(., vars(b)}).}
+this is \verb{~ col_vals_gte(., a, 5.5), ~ col_vals_not_null(., b}).}
 
 \item{.list}{\emph{Alternative to \code{...}}
 
@@ -321,9 +321,9 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   conjointly(
-    ~ col_vals_lt(., columns = vars(a), value = 8),
-    ~ col_vals_gt(., columns = vars(c), value = vars(a)),
-    ~ col_vals_not_null(., columns = vars(b)),
+    ~ col_vals_lt(., columns = a, value = 8),
+    ~ col_vals_gt(., columns = c, value = vars(a)),
+    ~ col_vals_not_null(., columns = b),
     preconditions = ~ . \%>\% dplyr::filter(a < 10),
     segments = b ~ c("group_1", "group_2"),
     actions = action_levels(warn_at = 0.1, stop_at = 0.2), 
@@ -337,9 +337,9 @@ YAML representation:
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - conjointly:
     fns:
-    - ~col_vals_lt(., columns = vars(a), value = 8)
-    - ~col_vals_gt(., columns = vars(c), value = vars(a))
-    - ~col_vals_not_null(., columns = vars(b))
+    - ~col_vals_lt(., columns = a, value = 8)
+    - ~col_vals_gt(., columns = c, value = vars(a))
+    - ~col_vals_not_null(., columns = b)
     preconditions: ~. \%>\% dplyr::filter(a < 10)
     segments: b ~ c("group_1", "group_2")
     actions:
@@ -391,9 +391,9 @@ each row).
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = tbl) \%>\%
   conjointly(
-    ~ col_vals_lt(., columns = vars(a), value = 8),
-    ~ col_vals_gt(., columns = vars(c), value = vars(a)),
-    ~ col_vals_not_null(., columns = vars(b))
+    ~ col_vals_lt(., columns = a, value = 8),
+    ~ col_vals_gt(., columns = c, value = vars(a)),
+    ~ col_vals_not_null(., columns = b)
     ) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
@@ -422,9 +422,9 @@ behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\%
   conjointly(
-    ~ col_vals_lt(., columns = vars(a), value = 8),
-    ~ col_vals_gt(., columns = vars(c), value = vars(a)),
-    ~ col_vals_not_null(., columns = vars(b))
+    ~ col_vals_lt(., columns = a, value = 8),
+    ~ col_vals_gt(., columns = c, value = vars(a)),
+    ~ col_vals_not_null(., columns = b)
   )
 #> # A tibble: 3 x 3
 #>       a     b     c
@@ -442,9 +442,9 @@ time. This is primarily used in \strong{testthat} tests.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_conjointly(
   tbl,
-  ~ col_vals_lt(., columns = vars(a), value = 8),
-  ~ col_vals_gt(., columns = vars(c), value = vars(a)),
-  ~ col_vals_not_null(., columns = vars(b))
+  ~ col_vals_lt(., columns = a, value = 8),
+  ~ col_vals_gt(., columns = c, value = vars(a)),
+  ~ col_vals_not_null(., columns = b)
 )
 }\if{html}{\out{</div>}}
 }
@@ -456,9 +456,9 @@ us.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\%
   test_conjointly(
-    ~ col_vals_lt(., columns = vars(a), value = 8),
-    ~ col_vals_gt(., columns = vars(c), value = vars(a)),
-    ~ col_vals_not_null(., columns = vars(b))
+    ~ col_vals_lt(., columns = a, value = 8),
+    ~ col_vals_gt(., columns = c, value = vars(a)),
+    ~ col_vals_not_null(., columns = b)
   )
 #> [1] TRUE
 }\if{html}{\out{</div>}}

--- a/man/conjointly.Rd
+++ b/man/conjointly.Rd
@@ -103,12 +103,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/conjointly.Rd
+++ b/man/conjointly.Rd
@@ -301,6 +301,22 @@ quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/create_agent.Rd
+++ b/man/create_agent.Rd
@@ -412,16 +412,16 @@ to actually perform the validations and gather intel.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   agent \%>\% 
-  col_exists(columns = vars(date, date_time)) \%>\%
+  col_exists(columns = date, date_time) \%>\%
   col_vals_regex(
-    columns = vars(b),
+    columns = b,
     regex = "[0-9]-[a-z]\{3\}-[0-9]\{3\}"
   ) \%>\%
   rows_distinct() \%>\%
-  col_vals_gt(columns = vars(d), value = 100) \%>\%
-  col_vals_lte(columns = vars(c), value = 5) \%>\%
+  col_vals_gt(columns = d, value = 100) \%>\%
+  col_vals_lte(columns = c, value = 5) \%>\%
   col_vals_between(
-    columns = vars(c),
+    columns = c,
     left = vars(a), right = vars(d),
     na_pass = TRUE
   ) \%>\%

--- a/man/create_multiagent.Rd
+++ b/man/create_multiagent.Rd
@@ -110,7 +110,7 @@ First up, is \code{agent_1}:
     tbl_name = "tbl_1",
     label = "Example table 1."
   ) \%>\%
-  col_vals_gt(columns = vars(a), value = 4) \%>\%
+  col_vals_gt(columns = a, value = 4) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -122,7 +122,7 @@ Then, \code{agent_2}:
     tbl_name = "tbl_2",
     label = "Example table 2."
   ) \%>\%
-  col_is_character(columns = vars(b)) \%>\%
+  col_is_character(columns = b) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 

--- a/man/deactivate_steps.Rd
+++ b/man/deactivate_steps.Rd
@@ -51,9 +51,9 @@ agent_1 <-
     tbl_name = "small_table",
     label = "An example."
   ) \%>\%
-  col_exists(columns = vars(date)) \%>\%
+  col_exists(columns = date) \%>\%
   col_vals_regex(
-    columns = vars(b),
+    columns = b,
     regex = "[0-9]-[a-z]{3}-[0-9]"
   ) \%>\%
   interrogate()

--- a/man/draft_validation.Rd
+++ b/man/draft_validation.Rd
@@ -170,116 +170,116 @@ agent <-
   ) \%>\%
   # Expect that column `name` is of type: character
   col_is_character(
-    columns = vars(name)
+    columns = name
   ) \%>\%
   # Expect that column `year` is of type: numeric
   col_is_numeric(
-    columns = vars(year)
+    columns = year
   ) \%>\%
   # Expect that values in `year` should be between `1975` and `2020`
   col_vals_between(
-    columns = vars(year),
+    columns = year,
     left = 1975,
     right = 2020
   ) \%>\%
   # Expect that column `month` is of type: numeric
   col_is_numeric(
-    columns = vars(month)
+    columns = month
   ) \%>\%
   # Expect that values in `month` should be between `1` and `12`
   col_vals_between(
-    columns = vars(month),
+    columns = month,
     left = 1,
     right = 12
   ) \%>\%
   # Expect that column `day` is of type: integer
   col_is_integer(
-    columns = vars(day)
+    columns = day
   ) \%>\%
   # Expect that values in `day` should be between `1` and `31`
   col_vals_between(
-    columns = vars(day),
+    columns = day,
     left = 1,
     right = 31
   ) \%>\%
   # Expect that column `hour` is of type: numeric
   col_is_numeric(
-    columns = vars(hour)
+    columns = hour
   ) \%>\%
   # Expect that values in `hour` should be between `0` and `23`
   col_vals_between(
-    columns = vars(hour),
+    columns = hour,
     left = 0,
     right = 23
   ) \%>\%
   # Expect that column `lat` is of type: numeric
   col_is_numeric(
-    columns = vars(lat)
+    columns = lat
   ) \%>\%
   # Expect that values in `lat` should be between `-90` and `90`
   col_vals_between(
-    columns = vars(lat),
+    columns = lat,
     left = -90,
     right = 90
   ) \%>\%
   # Expect that column `long` is of type: numeric
   col_is_numeric(
-    columns = vars(long)
+    columns = long
   ) \%>\%
   # Expect that values in `long` should be between `-180` and `180`
   col_vals_between(
-    columns = vars(long),
+    columns = long,
     left = -180,
     right = 180
   ) \%>\%
   # Expect that column `status` is of type: character
   col_is_character(
-    columns = vars(status)
+    columns = status
   ) \%>\%
   # Expect that column `category` is of type: factor
   col_is_factor(
-    columns = vars(category)
+    columns = category
   ) \%>\%
   # Expect that column `wind` is of type: integer
   col_is_integer(
-    columns = vars(wind)
+    columns = wind
   ) \%>\%
   # Expect that values in `wind` should be between `10` and `160`
   col_vals_between(
-    columns = vars(wind),
+    columns = wind,
     left = 10,
     right = 160
   ) \%>\%
   # Expect that column `pressure` is of type: integer
   col_is_integer(
-    columns = vars(pressure)
+    columns = pressure
   ) \%>\%
   # Expect that values in `pressure` should be between `882` and `1022`
   col_vals_between(
-    columns = vars(pressure),
+    columns = pressure,
     left = 882,
     right = 1022
   ) \%>\%
   # Expect that column `tropicalstorm_force_diameter` is of type: integer
   col_is_integer(
-    columns = vars(tropicalstorm_force_diameter)
+    columns = tropicalstorm_force_diameter
   ) \%>\%
   # Expect that values in `tropicalstorm_force_diameter` should be between
   # `0` and `870`
   col_vals_between(
-    columns = vars(tropicalstorm_force_diameter),
+    columns = tropicalstorm_force_diameter,
     left = 0,
     right = 870,
     na_pass = TRUE
   ) \%>\%
   # Expect that column `hurricane_force_diameter` is of type: integer
   col_is_integer(
-    columns = vars(hurricane_force_diameter)
+    columns = hurricane_force_diameter
   ) \%>\%
   # Expect that values in `hurricane_force_diameter` should be between
   # `0` and `300`
   col_vals_between(
-    columns = vars(hurricane_force_diameter),
+    columns = hurricane_force_diameter,
     left = 0,
     right = 300,
     na_pass = TRUE

--- a/man/email_blast.Rd
+++ b/man/email_blast.Rd
@@ -88,8 +88,8 @@ R statement:
     )
   )
 ) \%>\%
-  col_vals_gt(vars(a), 1) \%>\%
-  col_vals_lt(vars(a), 7) 
+  col_vals_gt(a, 1) \%>\%
+  col_vals_lt(a, 7) 
 }\if{html}{\out{</div>}}
 
 YAML representation:
@@ -110,10 +110,10 @@ end_fns: ~email_blast(x, to = "joe_public@example.com",
 embed_report: true
 steps:
 - col_vals_gt:
-    columns: vars(a)
+    columns: c(a)
     value: 1.0
 - col_vals_lt:
-    columns: vars(a)
+    columns: c(a)
     value: 7.0
 }\if{html}{\out{</div>}}
 }
@@ -170,8 +170,8 @@ interrogation of data in \code{small_table}:
       )
     )
   ) \%>\%
-  col_vals_gt(vars(a), value = 1) \%>\%
-  col_vals_lt(vars(a), value = 7) \%>\%
+  col_vals_gt(a, value = 1) \%>\%
+  col_vals_lt(a, value = 7) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 

--- a/man/email_create.Rd
+++ b/man/email_create.Rd
@@ -62,8 +62,8 @@ email just by printing \code{email_object}. It should appear in the Viewer.
     label = "An example.",
     actions = al
   ) \%>\%
-  col_vals_gt(vars(a), value = 1) \%>\%
-  col_vals_lt(vars(a), value = 7) \%>\%
+  col_vals_gt(a, value = 1) \%>\%
+  col_vals_lt(a, value = 7) \%>\%
   interrogate() \%>\%
   email_create()
   

--- a/man/export_report.Rd
+++ b/man/export_report.Rd
@@ -88,14 +88,14 @@ many validation functions as we want. Then, we \code{\link[=interrogate]{interro
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   agent \%>\% 
-  col_exists(columns = vars(date, date_time)) \%>\%
+  col_exists(columns = c(date, date_time)) \%>\%
   col_vals_regex(
-    columns = vars(b),
+    columns = b,
     regex = "[0-9]-[a-z]\{3\}-[0-9]\{3\}"
   ) \%>\%
   rows_distinct() \%>\%
-  col_vals_gt(columns = vars(d), value = 100) \%>\%
-  col_vals_lte(columns = vars(c), value = 5) \%>\%
+  col_vals_gt(columns = d, value = 100) \%>\%
+  col_vals_lte(columns = c, value = 5) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -147,7 +147,7 @@ integrated into the text.
     fn = snip_lowest(column = "a")
   ) \%>\%
   info_columns(
-    columns = vars(a),
+    columns = a,
     info = "From \{low_a\} to \{high_a\}."
   ) \%>\%
   info_columns(

--- a/man/file_tbl.Rd
+++ b/man/file_tbl.Rd
@@ -115,7 +115,7 @@ A different strategy is to provide the data-reading function call directly to
       col_types = "TDdcddlc"
     )
   ) \%>\%
-  col_vals_gt(columns = vars(a), value = 0)
+  col_vals_gt(columns = a, value = 0)
 }\if{html}{\out{</div>}}
 
 All of the file-reading instructions are encapsulated in the \code{tbl} expression
@@ -142,7 +142,7 @@ gets the same CSV file from the GitHub repository for the pointblank package.
     tbl_name = "small_table",
     label = "`file_tbl()` example.",
   ) \%>\%
-  col_vals_gt(columns = vars(a), value = 0) \%>\%
+  col_vals_gt(columns = a, value = 0) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 

--- a/man/from_github.Rd
+++ b/man/from_github.Rd
@@ -65,7 +65,7 @@ where GitHub URLs for raw user content are needed.
 #       col_types = "TDdcddlc"
 #     )
 #   ) \%>\%
-#   col_vals_gt(vars(a), 0) \%>\%
+#   col_vals_gt(a, 0) \%>\%
 #   interrogate()
 
 # The `from_github()` helper function is

--- a/man/get_agent_report.Rd
+++ b/man/get_agent_report.Rd
@@ -211,7 +211,7 @@ greater than \code{4}.
     tbl_name = "small_table",
     label = "An example."
   ) \%>\%
-  col_vals_gt(columns = vars(a), value = 4) \%>\%
+  col_vals_gt(columns = a, value = 4) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 

--- a/man/get_agent_x_list.Rd
+++ b/man/get_agent_x_list.Rd
@@ -136,8 +136,8 @@ validation step functions, then interrogate.
     tbl = tbl,
     actions = al
   ) \%>\%
-  col_vals_gt(columns = vars(a), value = 7) \%>\%
-  col_is_numeric(columns = vars(a)) \%>\%
+  col_vals_gt(columns = a, value = 7) \%>\%
+  col_is_numeric(columns = a) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 

--- a/man/get_data_extracts.Rd
+++ b/man/get_data_extracts.Rd
@@ -63,7 +63,7 @@ part of the \code{small_table} object. Use \code{\link[=interrogate]{interrogate
       dplyr::select(a:f),
     label = "`get_data_extracts()`"
   ) \%>\%
-  col_vals_gt(vars(d), value = 1000) \%>\%
+  col_vals_gt(d, value = 1000) \%>\%
   col_vals_between(
     columns = c,
     left = vars(a), right = vars(d),

--- a/man/get_data_extracts.Rd
+++ b/man/get_data_extracts.Rd
@@ -65,7 +65,7 @@ part of the \code{small_table} object. Use \code{\link[=interrogate]{interrogate
   ) \%>\%
   col_vals_gt(vars(d), value = 1000) \%>\%
   col_vals_between(
-    columns = vars(c),
+    columns = c,
     left = vars(a), right = vars(d),
     na_pass = TRUE
   ) \%>\%

--- a/man/get_multiagent_report.Rd
+++ b/man/get_multiagent_report.Rd
@@ -158,32 +158,32 @@ steps are created and the agent will interrogate the \code{small_table}.
     actions = al
   ) \%>\%
   col_vals_gt(
-    columns = vars(date_time),
+    columns = date_time,
     value = vars(date),
     na_pass = TRUE
   ) \%>\%
   col_vals_gt(
-    columns = vars(b), 
+    columns = b, 
     value = vars(g),
     na_pass = TRUE
   ) \%>\%
   rows_distinct() \%>\%
   col_vals_equal(
-    columns = vars(d), 
+    columns = d, 
     value = vars(d),
     na_pass = TRUE
   ) \%>\%
   col_vals_between(
-    columns = vars(c), 
+    columns = c, 
     left = vars(a), right = vars(d)
   ) \%>\%
   col_vals_not_between(
-    columns = vars(c),
+    columns = c,
     left = 10, right = 20,
     na_pass = TRUE
   ) \%>\%
-  rows_distinct(columns = vars(d, e, f)) \%>\%
-  col_is_integer(columns = vars(a)) \%>\%
+  rows_distinct(columns = d, e, f) \%>\%
+  col_is_integer(columns = a) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -192,9 +192,9 @@ two more (the last of which is inactive).
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent_2 <- 
   agent_1 \%>\%
-  col_exists(columns = vars(date, date_time)) \%>\%
+  col_exists(columns = date, date_time) \%>\%
   col_vals_regex(
-    columns = vars(b), 
+    columns = b, 
     regex = "[0-9]-[a-z]\{3\}-[0-9]\{3\}",
     active = FALSE
   ) \%>\%
@@ -207,7 +207,7 @@ one, and deactivates the first.
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent_3 <- 
   agent_2 \%>\%
   col_vals_in_set(
-    columns = vars(f),
+    columns = f,
     set = c("low", "mid", "high")
   ) \%>\%
   remove_steps(i = 5) \%>\%

--- a/man/get_sundered_data.Rd
+++ b/man/get_sundered_data.Rd
@@ -84,9 +84,9 @@ validation plan into action.
       dplyr::select(a:f),
     label = "`get_sundered_data()`"
   ) \%>\%
-  col_vals_gt(columns = vars(d), value = 1000) \%>\%
+  col_vals_gt(columns = d, value = 1000) \%>\%
   col_vals_between(
-    columns = vars(c),
+    columns = c,
     left = vars(a), right = vars(d),
     na_pass = TRUE
   ) \%>\%

--- a/man/get_tt_param.Rd
+++ b/man/get_tt_param.Rd
@@ -94,7 +94,7 @@ the first quarter of the year, we can supply a value from \code{stats_tbl} to
     keep = "right"
   ) \%>\%
   test_col_vals_lte(
-    columns = vars(session_duration), 
+    columns = session_duration, 
     value = get_tt_param(
       tbl = stats_tbl,
       param = "max",

--- a/man/has_columns.Rd
+++ b/man/has_columns.Rd
@@ -110,16 +110,16 @@ statement there we would get an evaluation failure in the agent report).
     tbl_name = "small_table"
   ) \%>\%
   col_vals_gt(
-    columns = vars(c), value = vars(a),
+    columns = c, value = vars(a),
     active = ~ . \%>\% has_columns(vars(a, c))
   ) \%>\%
   col_vals_lt(
-    columns = vars(h), value = vars(d),
+    columns = h, value = vars(d),
     preconditions = ~ . \%>\% dplyr::mutate(h = d - a),
     active = ~ . \%>\% has_columns(vars(a, d))
   ) \%>\%
   col_is_character(
-    columns = vars(j),
+    columns = j,
     active = ~ . \%>\% has_columns("j")
   ) \%>\%
   interrogate()

--- a/man/incorporate.Rd
+++ b/man/incorporate.Rd
@@ -76,7 +76,7 @@ use \code{incorporate()} to work the snippets into the info text.
     fn = ~ . \%>\% ncol()
   ) \%>\%
   info_columns(
-    columns = vars(a),
+    columns = a,
     info = "In the range of 1 to 10. ((SIMPLE))"
   ) \%>\%
   info_columns(

--- a/man/info_columns.Rd
+++ b/man/info_columns.Rd
@@ -126,7 +126,7 @@ informant \%>\%
     info = "*info text* 3. Statistics: \{snippet_1\}."
   ) \%>\%
   info_columns(
-    columns = vars(date, date_time),
+    columns = c(date, date_time),
     info = "UTC time."
   )
 
@@ -185,7 +185,7 @@ existing if it lands in the same area).
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{informant <-
   informant \%>\%
   info_columns(
-    columns = vars(a),
+    columns = a,
     info = "In the range of 1 to 10. ((SIMPLE))"
   ) \%>\%
   info_columns(

--- a/man/info_snippet.Rd
+++ b/man/info_snippet.Rd
@@ -135,7 +135,7 @@ the highest value in that column).
     fn = snip_highest(column = "a")
   ) \%>\%
   info_columns(
-    columns = vars(a),
+    columns = a,
     info = "In the range of 1 to \{max_a\}. ((SIMPLE))"
   ) \%>\%
   info_columns(

--- a/man/interrogate.Rd
+++ b/man/interrogate.Rd
@@ -106,7 +106,7 @@ process.
     tbl = tbl,
     label = "`interrogate()` example"
   ) \%>\%
-  col_vals_gt(columns = vars(a), value = 5) \%>\%
+  col_vals_gt(columns = a, value = 5) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 

--- a/man/log4r_step.Rd
+++ b/man/log4r_step.Rd
@@ -129,8 +129,8 @@ then \code{\link[=interrogate]{interrogate()}} the data.
     label = "An example.",
     actions = al
   ) \%>\%
-  col_vals_gt(columns = vars(d), 300) \%>\%
-  col_vals_in_set(columns = vars(f), c("low", "high")) \%>\%
+  col_vals_gt(columns = d, 300) \%>\%
+  col_vals_in_set(columns = f, c("low", "high")) \%>\%
   interrogate()
 
 agent

--- a/man/remove_steps.Rd
+++ b/man/remove_steps.Rd
@@ -51,9 +51,9 @@ agent_1 <-
     tbl_name = "small_table",
     label = "An example."
   ) \%>\%
-  col_exists(columns = vars(date)) \%>\%
+  col_exists(columns = date) \%>\%
   col_vals_regex(
-    columns = vars(b),
+    columns = b,
     regex = "[0-9]-[a-z]{3}-[0-9]"
   ) \%>\%
   interrogate()

--- a/man/row_count_match.Rd
+++ b/man/row_count_match.Rd
@@ -101,12 +101,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/row_count_match.Rd
+++ b/man/row_count_match.Rd
@@ -271,6 +271,22 @@ depending on the situation (the first produces a warning, the other
 \code{stop()}s).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/rows_complete.Rd
+++ b/man/rows_complete.Rd
@@ -43,7 +43,7 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<tidy-select>} // \strong{required}
+\verb{<tidy-select>} // \emph{default:} \code{everything()}
 
 A column-selecting expression, as one would use inside \code{dplyr::select()}.
 Specifies the column (or a set of columns) to which this validation should

--- a/man/rows_complete.Rd
+++ b/man/rows_complete.Rd
@@ -8,7 +8,7 @@
 \usage{
 rows_complete(
   x,
-  columns = NULL,
+  columns = tidyselect::everything(),
   preconditions = NULL,
   segments = NULL,
   actions = NULL,
@@ -20,12 +20,17 @@ rows_complete(
 
 expect_rows_complete(
   object,
-  columns = NULL,
+  columns = tidyselect::everything(),
   preconditions = NULL,
   threshold = 1
 )
 
-test_rows_complete(object, columns = NULL, preconditions = NULL, threshold = 1)
+test_rows_complete(
+  object,
+  columns = tidyselect::everything(),
+  preconditions = NULL,
+  threshold = 1
+)
 }
 \arguments{
 \item{x}{\emph{A pointblank agent or a data table}
@@ -38,10 +43,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{preconditions}{\emph{Input table modification prior to validation}
 
@@ -87,12 +93,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/rows_complete.Rd
+++ b/man/rows_complete.Rd
@@ -281,7 +281,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   rows_complete(
-    columns = vars(a, b),
+    columns = a, b,
     preconditions = ~ . \%>\% dplyr::filter(a < 10),
     segments = b ~ c("group_1", "group_2"),
     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
@@ -343,7 +343,7 @@ only complete rows (i.e., all rows have no \code{NA} values).
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = tbl) \%>\%
-  rows_complete(columns = vars(a, b)) \%>\%
+  rows_complete(columns = c(a, b)) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -365,7 +365,7 @@ through but should \code{stop()} if there is a single test unit failing. The
 behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\%
-  rows_complete(columns = vars(a, b)) \%>\%
+  rows_complete(columns = c(a, b)) \%>\%
   dplyr::pull(a)
 #> [1] 5 7 6 5 8 7
 }\if{html}{\out{</div>}}
@@ -376,7 +376,7 @@ behavior of side effects can be customized with the \code{actions} option.
 With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_rows_complete(tbl, columns = vars(a, b))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_rows_complete(tbl, columns = c(a, b))
 }\if{html}{\out{</div>}}
 }
 
@@ -385,7 +385,7 @@ time. This is primarily used in \strong{testthat} tests.
 With the \verb{test_*()} form, we should get a single logical value returned to
 us.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{test_rows_complete(tbl, columns = vars(a, b))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{test_rows_complete(tbl, columns = c(a, b))
 #> [1] TRUE
 }\if{html}{\out{</div>}}
 }

--- a/man/rows_complete.Rd
+++ b/man/rows_complete.Rd
@@ -281,7 +281,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   rows_complete(
-    columns = a, b,
+    columns = c(a, b),
     preconditions = ~ . \%>\% dplyr::filter(a < 10),
     segments = b ~ c("group_1", "group_2"),
     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
@@ -294,7 +294,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - rows_complete:
-    columns: vars(a, b)
+    columns: c(a, b)
     preconditions: ~. \%>\% dplyr::filter(a < 10)
     segments: b ~ c("group_1", "group_2")
     actions:

--- a/man/rows_complete.Rd
+++ b/man/rows_complete.Rd
@@ -262,6 +262,23 @@ warning when a quarter of the total test units fails, the other \code{stop()}s a
 the same threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/rows_distinct.Rd
+++ b/man/rows_distinct.Rd
@@ -43,7 +43,7 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<tidy-select>} // \strong{required}
+\verb{<tidy-select>} // \emph{default:} \code{everything()}
 
 A column-selecting expression, as one would use inside \code{dplyr::select()}.
 Specifies the column (or a set of columns) to which this validation should

--- a/man/rows_distinct.Rd
+++ b/man/rows_distinct.Rd
@@ -295,7 +295,7 @@ YAML representation:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{steps:
 - rows_distinct:
-    columns: vars(a, b)
+    columns: c(a, b)
     preconditions: ~. \%>\% dplyr::filter(a < 10)
     segments: b ~ c("group_1", "group_2")
     actions:

--- a/man/rows_distinct.Rd
+++ b/man/rows_distinct.Rd
@@ -8,7 +8,7 @@
 \usage{
 rows_distinct(
   x,
-  columns = NULL,
+  columns = tidyselect::everything(),
   preconditions = NULL,
   segments = NULL,
   actions = NULL,
@@ -20,12 +20,17 @@ rows_distinct(
 
 expect_rows_distinct(
   object,
-  columns = NULL,
+  columns = tidyselect::everything(),
   preconditions = NULL,
   threshold = 1
 )
 
-test_rows_distinct(object, columns = NULL, preconditions = NULL, threshold = 1)
+test_rows_distinct(
+  object,
+  columns = tidyselect::everything(),
+  preconditions = NULL,
+  threshold = 1
+)
 }
 \arguments{
 \item{x}{\emph{A pointblank agent or a data table}
@@ -38,10 +43,11 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 
 \item{columns}{\emph{The target columns}
 
-\verb{<column-targeting expression>} // \strong{required}
+\verb{<tidy-select>} // \strong{required}
 
-The column (or a set of columns, provided as a character vector) to which
-this validation should be applied.}
+A column-selecting expression, as one would use inside \code{dplyr::select()}.
+Specifies the column (or a set of columns) to which this validation should
+be applied. See the \emph{Column Names} section for more information.}
 
 \item{preconditions}{\emph{Input table modification prior to validation}
 
@@ -87,12 +93,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/rows_distinct.Rd
+++ b/man/rows_distinct.Rd
@@ -263,6 +263,23 @@ warning when a quarter of the total test units fails, the other \code{stop()}s a
 the same threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.col}"}: The current column name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/rows_distinct.Rd
+++ b/man/rows_distinct.Rd
@@ -282,7 +282,7 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   rows_distinct(
-    columns = vars(a, b),
+    columns = c(a, b),
     preconditions = ~ . \%>\% dplyr::filter(a < 10),
     segments = b ~ c("group_1", "group_2"),
     actions = action_levels(warn_at = 0.1, stop_at = 0.2),
@@ -344,7 +344,7 @@ duplicate rows (i.e., all rows are distinct).
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   create_agent(tbl = tbl) \%>\%
-  rows_distinct(columns = vars(a, b)) \%>\%
+  rows_distinct(columns = c(a, b)) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -366,7 +366,7 @@ through but should \code{stop()} if there is a single test unit failing. The
 behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\%
-  rows_distinct(columns = vars(a, b)) \%>\%
+  rows_distinct(columns = c(a, b)) \%>\%
   dplyr::pull(a)
 #> [1] 5 7 6 5 8 7
 }\if{html}{\out{</div>}}
@@ -377,7 +377,7 @@ behavior of side effects can be customized with the \code{actions} option.
 With the \verb{expect_*()} form, we would typically perform one validation at a
 time. This is primarily used in \strong{testthat} tests.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_rows_distinct(tbl, columns = vars(a, b))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_rows_distinct(tbl, columns = c(a, b))
 }\if{html}{\out{</div>}}
 }
 
@@ -386,7 +386,7 @@ time. This is primarily used in \strong{testthat} tests.
 With the \verb{test_*()} form, we should get a single logical value returned to
 us.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{test_rows_distinct(tbl, columns = vars(a, b))
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{test_rows_distinct(tbl, columns = c(a, b))
 #> [1] TRUE
 }\if{html}{\out{</div>}}
 }

--- a/man/serially.Rd
+++ b/man/serially.Rd
@@ -55,7 +55,7 @@ within the series. A finishing validation function call (e.g.,
 \code{\link[=col_vals_increasing]{col_vals_increasing()}}, etc.) can optionally be inserted at the end of the
 series, serving as a validation step that only undergoes interrogation if
 the prior tests adequately pass. An example of this is
-\verb{~ test_column_exists(., vars(a)), ~ col_vals_not_null(., vars(a))}).}
+\verb{~ test_column_exists(., a), ~ col_vals_not_null(., a)}).}
 
 \item{.list}{\emph{Alternative to \code{...}}
 
@@ -191,9 +191,9 @@ or any \code{segments})
 
 Here's an example of how to arrange expressions:
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{~ test_col_exists(., columns = vars(count)),
-~ test_col_is_numeric(., columns = vars(count)),
-~ col_vals_gt(., columns = vars(count), value = 2)
+\if{html}{\out{<div class="sourceCode">}}\preformatted{~ test_col_exists(., columns = count),
+~ test_col_is_numeric(., columns = count),
+~ col_vals_gt(., columns = count, value = 2)
 }\if{html}{\out{</div>}}
 
 This series concentrates on the column called \code{count} and first checks
@@ -306,9 +306,9 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   serially(
-    ~ col_vals_lt(., columns = vars(a), value = 8),
-    ~ col_vals_gt(., columns = vars(c), value = vars(a)),
-    ~ col_vals_not_null(., columns = vars(b)),
+    ~ col_vals_lt(., columns = a, value = 8),
+    ~ col_vals_gt(., columns = c, value = vars(a)),
+    ~ col_vals_not_null(., columns = b),
     preconditions = ~ . \%>\% dplyr::filter(a < 10),
     actions = action_levels(warn_at = 0.1, stop_at = 0.2), 
     label = "The `serially()` step.",
@@ -321,9 +321,9 @@ YAML representation:
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - serially:
     fns:
-    - ~col_vals_lt(., columns = vars(a), value = 8)
-    - ~col_vals_gt(., columns = vars(c), value = vars(a))
-    - ~col_vals_not_null(., vars(b))
+    - ~col_vals_lt(., columns = a, value = 8)
+    - ~col_vals_gt(., columns = c, value = vars(a))
+    - ~col_vals_not_null(., b)
     preconditions: ~. \%>\% dplyr::filter(a < 10)
     actions:
       warn_fraction: 0.1
@@ -375,9 +375,9 @@ validation).
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent_1 <-
   create_agent(tbl = tbl) \%>\%
   serially(
-    ~ test_col_is_numeric(., columns = vars(a, b)),
-    ~ test_col_vals_not_null(., columns = vars(a, b)),
-    ~ col_vals_gt(., columns = vars(b), value = vars(a))
+    ~ test_col_is_numeric(., columns = c(a, b)),
+    ~ test_col_vals_not_null(., columns = c(a, b)),
+    ~ col_vals_gt(., columns = b, value = vars(a))
     ) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
@@ -401,8 +401,8 @@ serial tests are performed.
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent_2 <-
   create_agent(tbl = tbl) \%>\%
   serially(
-    ~ test_col_is_numeric(., columns = vars(a, b)),
-    ~ test_col_vals_not_null(., columns = vars(a, b))
+    ~ test_col_is_numeric(., columns = c(a, b)),
+    ~ test_col_vals_not_null(., columns = c(a, b))
   ) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
@@ -424,9 +424,9 @@ behavior of side effects can be customized with the \code{actions} option.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\%
   serially(
-    ~ test_col_is_numeric(., columns = vars(a, b)),
-    ~ test_col_vals_not_null(., columns = vars(a, b)),
-    ~ col_vals_gt(., columns = vars(b), value = vars(a))
+    ~ test_col_is_numeric(., columns = c(a, b)),
+    ~ test_col_vals_not_null(., columns = c(a, b)),
+    ~ col_vals_gt(., columns = b, value = vars(a))
   )
 #> # A tibble: 3 x 3
 #>       a     b     c
@@ -444,9 +444,9 @@ time. This is primarily used in \strong{testthat} tests.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{expect_serially(
   tbl,
-  ~ test_col_is_numeric(., columns = vars(a, b)),
-  ~ test_col_vals_not_null(., columns = vars(a, b)),
-  ~ col_vals_gt(., columns = vars(b), value = vars(a))
+  ~ test_col_is_numeric(., columns = c(a, b)),
+  ~ test_col_vals_not_null(., columns = c(a, b)),
+  ~ col_vals_gt(., columns = b, value = vars(a))
 )
 }\if{html}{\out{</div>}}
 }
@@ -458,9 +458,9 @@ us.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\%
   test_serially(
-    ~ test_col_is_numeric(., columns = vars(a, b)),
-    ~ test_col_vals_not_null(., columns = vars(a, b)),
-    ~ col_vals_gt(., columns = vars(b), value = vars(a))
+    ~ test_col_is_numeric(., columns = c(a, b)),
+    ~ test_col_vals_not_null(., columns = c(a, b)),
+    ~ col_vals_gt(., columns = b, value = vars(a))
   )
 #> [1] TRUE
 }\if{html}{\out{</div>}}

--- a/man/serially.Rd
+++ b/man/serially.Rd
@@ -306,8 +306,8 @@ R statement:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
   serially(
-    ~ col_vals_lt(., columns = a, value = 8),
-    ~ col_vals_gt(., columns = c, value = vars(a)),
+    ~ test_col_vals_lt(., columns = a, value = 8),
+    ~ test_col_vals_gt(., columns = c, value = vars(a)),
     ~ col_vals_not_null(., columns = b),
     preconditions = ~ . \%>\% dplyr::filter(a < 10),
     actions = action_levels(warn_at = 0.1, stop_at = 0.2), 
@@ -321,9 +321,9 @@ YAML representation:
 \if{html}{\out{<div class="sourceCode yaml">}}\preformatted{steps:
 - serially:
     fns:
-    - ~col_vals_lt(., columns = a, value = 8)
-    - ~col_vals_gt(., columns = c, value = vars(a))
-    - ~col_vals_not_null(., b)
+    - ~test_col_vals_lt(., columns = a, value = 8)
+    - ~test_col_vals_gt(., columns = c, value = vars(a))
+    - ~col_vals_not_null(., columns = b)
     preconditions: ~. \%>\% dplyr::filter(a < 10)
     actions:
       warn_fraction: 0.1

--- a/man/serially.Rd
+++ b/man/serially.Rd
@@ -235,12 +235,17 @@ formally tested (so be mindful of this when using unsupported backends with
 \section{Column Names}{
 
 
-If providing multiple column names in any of the supplied validation steps,
-the result will be an expansion of sub-validation steps to that number of
-column names. Aside from column names in quotes and in \code{vars()},
-\strong{tidyselect} helper functions are available for specifying columns. They
-are: \code{starts_with()}, \code{ends_with()}, \code{contains()}, \code{matches()}, and
-\code{everything()}.
+\code{columns} may be a single column (as symbol \code{a} or string \code{"a"}) or a vector
+of columns (\code{c(a, b, c)} or \code{c("a", "b", "c")}). \code{{tidyselect}} helpers
+are also supported, such as \code{contains("date")} and \code{where(is.double)}. If
+passing an \emph{external vector} of columns, it should be wrapped in \code{all_of()}.
+
+When multiple columns are selected by \code{columns}, the result will be an
+expansion of validation steps to that number of columns (e.g.,
+\code{c(col_a, col_b)} will result in the entry of two validation steps).
+
+Previously, columns could be specified in \code{vars()}. This continues to work,
+but \code{c()} offers the same capability and supersedes \code{vars()} in \code{columns}.
 }
 
 \section{Preconditions}{

--- a/man/serially.Rd
+++ b/man/serially.Rd
@@ -97,12 +97,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/serially.Rd
+++ b/man/serially.Rd
@@ -286,6 +286,20 @@ quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/set_tbl.Rd
+++ b/man/set_tbl.Rd
@@ -71,9 +71,9 @@ Apply the actions, add some validation steps and then interrogate the data.
     label = "An example.",
     actions = al
   ) \%>\%
-  col_exists(columns = vars(date, date_time)) \%>\%
+  col_exists(columns = c(date, date_time)) \%>\%
   col_vals_regex(
-    columns = vars(b),
+    columns = b,
     regex = "[0-9]-[a-z]\{3\}-[0-9]\{3\}"
   ) \%>\%
   rows_distinct() \%>\%

--- a/man/specially.Rd
+++ b/man/specially.Rd
@@ -210,6 +210,20 @@ quarter of the total test units fails, the other \code{stop()}s at the same
 threshold level).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/specially.Rd
+++ b/man/specially.Rd
@@ -72,12 +72,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/tbl_match.Rd
+++ b/man/tbl_match.Rd
@@ -86,12 +86,13 @@ produce (influenced by the number of \code{columns} provided), (2) be an ID
 string not used in any previous validation step, and (3) be a vector with
 unique values.}
 
-\item{label}{\emph{An optional label for the validation step}
+\item{label}{\emph{Optional label for the validation step}
 
-\verb{scalar<character>} // \emph{default:} \code{NULL} (\code{optional})
+\verb{vector<character>} // \emph{default:} \code{NULL} (\code{optional})
 
-An optional label for the validation step. This label appears in the
-\emph{agent} report and, for the best appearance, it should be kept quite short.}
+Optional label for the validation step. This label appears in the \emph{agent}
+report and, for the best appearance, it should be kept quite short. See
+the \emph{Labels} section for more information.}
 
 \item{brief}{\emph{Brief description for the validation step}
 

--- a/man/tbl_match.Rd
+++ b/man/tbl_match.Rd
@@ -246,6 +246,22 @@ depending on the situation (the first produces a warning, the other
 \code{stop()}s).
 }
 
+\section{Labels}{
+
+
+\code{label} may be a single string or a character vector that matches the number
+of expanded steps. \code{label} also supports \code{{glue}} syntax and exposes the
+following dynamic variables contextualized to the current step:
+\itemize{
+\item \code{"{.step}"}: The validation step name
+\item \code{"{.seg_col}"}: The current segment's column name
+\item \code{"{.seg_val}"}: The current segment's value/group
+}
+
+The glue context also supports ordinary expressions for further flexibility
+(e.g., \code{"{toupper(.step)}"}) as long as they return a length-1 string.
+}
+
 \section{Briefs}{
 
 

--- a/man/tbl_source.Rd
+++ b/man/tbl_source.Rd
@@ -55,7 +55,7 @@ some validation steps, and interrogate the table shortly thereafter.
     label = "`tbl_source()` example",
     actions = action_levels(warn_at = 0.10)
   ) \%>\% 
-  col_exists(columns = vars(date, date_time)) \%>\%
+  col_exists(columns = c(date, date_time)) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 

--- a/man/tbl_store.Rd
+++ b/man/tbl_store.Rd
@@ -91,7 +91,7 @@ to YAML:
   label = "An example that uses a table store.",
   actions = action_levels(warn_at = 0.10)
 ) \%>\% 
-  col_exists(vars(date, date_time)) \%>\%
+  col_exists(c(date, date_time)) \%>\%
   write_yaml()
 }\if{html}{\out{</div>}}
 
@@ -105,7 +105,7 @@ actions:
 locale: en
 steps:
   - col_exists:
-    columns: vars(date, date_time)
+    columns: c(date, date_time)
 }\if{html}{\out{</div>}}
 
 Now, whenever the \code{sml_table_high} table needs to be validated, it can be

--- a/man/tt_string_info.Rd
+++ b/man/tt_string_info.Rd
@@ -52,11 +52,11 @@ numbers of characters (\code{15} and \code{24}, respectively) throughout the tab
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tt_string_info(tbl = game_revenue) \%>\%
   col_vals_equal(
-    columns = vars(player_id),
+    columns = player_id,
     value = 15
   ) \%>\%
   col_vals_equal(
-    columns = vars(session_id),
+    columns = session_id,
     value = 24
   )
 #> # A tibble: 3 x 7
@@ -75,7 +75,7 @@ of the \code{small_table} dataset is no greater than \code{4}.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tt_string_info(tbl = small_table) \%>\%
   test_col_vals_lte(
-    columns = vars(f),
+    columns = f,
     value = 4
   )
 #> [1] TRUE

--- a/man/tt_summary_stats.Rd
+++ b/man/tt_summary_stats.Rd
@@ -65,7 +65,7 @@ ensure that the maximum revenue for individual purchases in the
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tt_summary_stats(tbl = game_revenue) \%>\%
   col_vals_lt(
-    columns = vars(item_revenue),
+    columns = item_revenue,
     value = 150,
     segments = .param. ~ "max"
   )
@@ -92,7 +92,7 @@ that the median revenue is somewhere between $8 and $12.
   dplyr::filter(item_type == "iap") \%>\%
   tt_summary_stats() \%>\%
   col_vals_between(
-    columns = vars(item_revenue),
+    columns = item_revenue,
     left = 8, right = 12,
     segments = .param. ~ "med"
   )
@@ -132,7 +132,7 @@ step that isolates the row of the median statistic.
   rows_complete() \%>\%
   rows_distinct() \%>\%
   col_vals_between(
-    columns = vars(item_revenue),
+    columns = item_revenue,
     left = 8, right = 12,
     preconditions = ~ . \%>\%
       dplyr::filter(item_type == "iap") \%>\%

--- a/man/tt_tbl_colnames.Rd
+++ b/man/tt_tbl_colnames.Rd
@@ -55,7 +55,7 @@ table. Here, we check that \code{game_revenue} table, included in the
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tt_tbl_colnames(tbl = game_revenue) \%>\%
   test_col_vals_make_subset(
-    columns = vars(value),
+    columns = value,
     set = c("acquisition", "country")
   )
 #> [1] TRUE
@@ -70,7 +70,7 @@ combination of \code{tt_tbl_colnames()}, then \code{\link[=tt_string_info]{tt_st
   tt_tbl_colnames() \%>\%
   tt_string_info() \%>\%
   test_col_vals_lt(
-    columns = vars(value),
+    columns = value,
     value = 15
   )
 #> [1] FALSE

--- a/man/tt_tbl_dims.Rd
+++ b/man/tt_tbl_dims.Rd
@@ -44,7 +44,7 @@ dimensions. Here, we check that \code{game_revenue} has at least \code{1500} row
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tt_tbl_dims(tbl = game_revenue) \%>\%
   dplyr::filter(.param. == "rows") \%>\%
   test_col_vals_gt(
-    columns = vars(value),
+    columns = value,
     value = 1500
   )
 #> [1] TRUE
@@ -56,7 +56,7 @@ We can check \code{small_table} to ensure that number of columns is less than
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tt_tbl_dims(tbl = small_table) \%>\%
   dplyr::filter(.param. == "columns") \%>\%
   test_col_vals_lt(
-    columns = vars(value),
+    columns = value,
     value = 10
   )
 #> [1] TRUE

--- a/man/write_testthat_file.Rd
+++ b/man/write_testthat_file.Rd
@@ -124,7 +124,7 @@ test_that("column `date_time` exists", \{
   
   expect_col_exists(
     tbl,
-    columns = vars(date_time),
+    columns = date_time,
     threshold = 1
   ) 
 \})
@@ -133,7 +133,7 @@ test_that("values in `c` should be <= `5`", \{
   
   expect_col_vals_lte(
     tbl,
-    columns = vars(c),
+    columns = c,
     value = 5,
     threshold = 0.25
   ) 
@@ -150,8 +150,8 @@ agent <-
     tbl = ~ small_table,
     actions = action_levels(stop_at = 0.25)
   ) \%>\%
-  col_exists(vars(date_time)) \%>\%
-  col_vals_lte(vars(c), value = 5)
+  col_exists(date_time) \%>\%
+  col_vals_lte(c, value = 5)
   
 write_testthat_file(
   agent = agent,
@@ -209,13 +209,13 @@ bit more useful after interrogation.
     label = "An example.",
     actions = al
   ) \%>\%
-  col_exists(vars(date, date_time)) \%>\%
+  col_exists(c(date, date_time)) \%>\%
   col_vals_regex(
-    vars(b),
+    b,
     regex = "[0-9]-[a-z]\{3\}-[0-9]\{3\}"
   ) \%>\%
-  col_vals_gt(vars(d), value = 100) \%>\%
-  col_vals_lte(vars(c), value = 5) \%>\%
+  col_vals_gt(d, value = 100) \%>\%
+  col_vals_lte(c, value = 5) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -246,7 +246,7 @@ test_that("column `date` exists", \{
   
   expect_col_exists(
     tbl,
-    columns = vars(date),
+    columns = date,
     threshold = 1
   ) 
 \})
@@ -255,7 +255,7 @@ test_that("column `date_time` exists", \{
   
   expect_col_exists(
     tbl,
-    columns = vars(date_time),
+    columns = date_time,
     threshold = 1
   ) 
 \})
@@ -265,7 +265,7 @@ test_that("values in `b` should match the regular expression:
   
   expect_col_vals_regex(
     tbl,
-    columns = vars(b),
+    columns = b,
     regex = "[0-9]-[a-z]\{3\}-[0-9]\{3\}",
     threshold = 0.25
   ) 
@@ -275,7 +275,7 @@ test_that("values in `d` should be > `100`", \{
   
   expect_col_vals_gt(
     tbl,
-    columns = vars(d),
+    columns = d,
     value = 100,
     threshold = 0.25
   ) 
@@ -285,7 +285,7 @@ test_that("values in `c` should be <= `5`", \{
   
   expect_col_vals_lte(
     tbl,
-    columns = vars(c),
+    columns = c,
     value = 5,
     threshold = 0.25
   ) 

--- a/man/x_write_disk.Rd
+++ b/man/x_write_disk.Rd
@@ -122,14 +122,14 @@ using as many validation functions as we want. After that, use
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   agent \%>\% 
-  col_exists(columns = vars(date, date_time)) \%>\%
+  col_exists(columns = c(date, date_time)) \%>\%
   col_vals_regex(
-    columns = vars(b),
+    columns = b,
     regex = "[0-9]-[a-z]\{3\}-[0-9]\{3\}"
   ) \%>\%
   rows_distinct() \%>\%
-  col_vals_gt(columns = vars(d), value = 100) \%>\%
-  col_vals_lte(columns = vars(c), value = 5) \%>\%
+  col_vals_gt(columns = d, value = 100) \%>\%
+  col_vals_lte(columns = c, value = 5) \%>\%
   interrogate()
 }\if{html}{\out{</div>}}
 
@@ -184,7 +184,7 @@ integrated into the text.
     fn = snip_lowest(column = "a")
   ) \%>\%
   info_columns(
-    columns = vars(a),
+    columns = a,
     info = "From \{low_a\} to \{high_a\}."
   ) \%>\%
   info_columns(
@@ -226,13 +226,13 @@ validation steps, and \code{\link[=interrogate]{interrogate()}}.
     actions = al
   ) \%>\%
   col_vals_gt(
-    columns = vars(b),
+    columns = b,
     value = vars(g),
     na_pass = TRUE,
     label = "b > g"
   ) \%>\%
   col_is_character(
-    columns = vars(b, f),
+    columns = c(b, f),
     label = "Verifying character-type columns" 
   ) \%>\%
   interrogate()

--- a/man/x_write_disk.Rd
+++ b/man/x_write_disk.Rd
@@ -227,7 +227,7 @@ validation steps, and \code{\link[=interrogate]{interrogate()}}.
   ) \%>\%
   col_vals_gt(
     columns = b,
-    value = vars(g),
+    value = g,
     na_pass = TRUE,
     label = "b > g"
   ) \%>\%

--- a/man/yaml_agent_show_exprs.Rd
+++ b/man/yaml_agent_show_exprs.Rd
@@ -46,14 +46,14 @@ retrieval of the target table.
       notify_at = 0.35
     )
   ) \%>\%
-  col_exists(columns = vars(date, date_time)) \%>\%
+  col_exists(columns = c(date, date_time)) \%>\%
   col_vals_regex(
-    columns = vars(b),
+    columns = b,
     regex = "[0-9]-[a-z]\{3\}-[0-9]\{3\}"
   ) \%>\%
   rows_distinct() \%>\%
-  col_vals_gt(columns = vars(d), value = 100) \%>\%
-  col_vals_lte(columns = vars(c), value = 5)
+  col_vals_gt(columns = d, value = 100) \%>\%
+  col_vals_lte(columns = c, value = 5)
 }\if{html}{\out{</div>}}
 
 The agent can be written to a \strong{pointblank} YAML file with \code{\link[=yaml_write]{yaml_write()}}.
@@ -95,19 +95,19 @@ we can use \code{yaml_agent_show_exprs()}.
   label = "A simple example with the `small_table`."
 ) \%>\%
   col_exists(
-    columns = vars(date, date_time)
+    columns = c(date, date_time)
   ) \%>\%
   col_vals_regex(
-    columns = vars(b),
+    columns = b,
     regex = "[0-9]-[a-z]\{3\}-[0-9]\{3\}"
   ) \%>\%
   rows_distinct() \%>\%
   col_vals_gt(
-    columns = vars(d),
+    columns = d,
     value = 100
   ) \%>\%
   col_vals_lte(
-    columns = vars(c),
+    columns = c,
     value = 5
   ) 
 }\if{html}{\out{</div>}}

--- a/man/yaml_agent_string.Rd
+++ b/man/yaml_agent_string.Rd
@@ -17,10 +17,9 @@ provided in \code{agent}.}
 \item{path}{An optional path to the YAML file (combined with \code{filename}).}
 
 \item{expanded}{Should the written validation expressions for an \emph{agent} be
-expanded such that \strong{tidyselect} and \code{\link[=vars]{vars()}} expressions for columns are
-evaluated, yielding a validation function per column? By default, this is
-\code{FALSE} so expressions as written will be retained in the YAML
-representation.}
+expanded such that \strong{tidyselect} expressions for columns are evaluated,
+yielding a validation function per column? By default, this is \code{FALSE}
+so expressions as written will be retained in the YAML representation.}
 }
 \value{
 Nothing is returned. Instead, text is printed to the console.

--- a/man/yaml_write.Rd
+++ b/man/yaml_write.Rd
@@ -144,14 +144,14 @@ using as many validation functions as we want.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{agent <-
   agent \%>\% 
-  col_exists(columns = vars(date, date_time)) \%>\%
+  col_exists(columns = c(date, date_time)) \%>\%
   col_vals_regex(
-    columns = vars(b),
+    columns = b,
     regex = "[0-9]-[a-z]\{3\}-[0-9]\{3\}"
   ) \%>\%
   rows_distinct() \%>\%
-  col_vals_gt(columns = vars(d), value = 100) \%>\%
-  col_vals_lte(columns = vars(c), value = 5)
+  col_vals_gt(columns = d, value = 100) \%>\%
+  col_vals_lte(columns = c, value = 5)
 }\if{html}{\out{</div>}}
 
 The agent can be written to a \strong{pointblank}-readable YAML file with the
@@ -280,7 +280,7 @@ using as many \verb{info_*()} functions as we want.
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{informant <- 
   informant \%>\%
   info_columns(
-    columns = vars(a),
+    columns = a,
     info = "In the range of 1 to 10. (SIMPLE)"
   ) \%>\%
   info_columns(
@@ -288,7 +288,7 @@ using as many \verb{info_*()} functions as we want.
     info = "Time-based values (e.g., `Sys.time()`)."
   ) \%>\%
   info_columns(
-    columns = "date",
+    columns = date,
     info = "The date part of `date_time`. (CALC)"
   )
 }\if{html}{\out{</div>}}

--- a/man/yaml_write.Rd
+++ b/man/yaml_write.Rd
@@ -180,17 +180,17 @@ actions:
   notify_fraction: 0.35
 steps:
 - col_exists:
-    columns: vars(date, date_time)
+    columns: c(date, date_time)
 - col_vals_regex:
     columns: vars(b)
     regex: '[0-9]-[a-z]\{3\}-[0-9]\{3\}'
 - rows_distinct:
     columns: ~
 - col_vals_gt:
-    columns: vars(d)
+    columns: c(d)
     value: 100.0
 - col_vals_lte:
-    columns: vars(c)
+    columns: c(c)
     value: 5.0
 }\if{html}{\out{</div>}}
 

--- a/man/yaml_write.Rd
+++ b/man/yaml_write.Rd
@@ -54,9 +54,9 @@ An optional path to which the YAML file should be saved (combined with
 \verb{scalar<logical>} // \emph{default:} \code{FALSE}
 
 Should the written validation expressions for an \emph{agent} be expanded such
-that \strong{tidyselect} and \code{\link[=vars]{vars()}} expressions for columns are evaluated,
-yielding a validation function per column? By default, this is \code{FALSE} so
-expressions as written will be retained in the YAML representation.}
+that \strong{tidyselect} expressions for columns are evaluated, yielding a
+validation function per column? By default, this is \code{FALSE} so expressions
+as written will be retained in the YAML representation.}
 
 \item{quiet}{\emph{Inform (or not) upon file writing}
 
@@ -182,7 +182,7 @@ steps:
 - col_exists:
     columns: c(date, date_time)
 - col_vals_regex:
-    columns: vars(b)
+    columns: c(b)
     regex: '[0-9]-[a-z]\{3\}-[0-9]\{3\}'
 - rows_distinct:
     columns: ~

--- a/tests/testthat/test-tidyselect-yaml_columns.R
+++ b/tests/testthat/test-tidyselect-yaml_columns.R
@@ -1,0 +1,32 @@
+test_that("explicit c()-expr make the yaml roundtrip", {
+  
+  agent_pre <- create_agent(~ small_table) %>% 
+    col_vals_lt(
+      columns = c(a, c),
+      value = 8
+    )
+  
+  agent_yaml <- tempfile()
+  yaml_write(agent_pre, expanded = FALSE, filename = agent_yaml)
+  # Writes to c()-expr
+  expect_true(any(grepl("columns: c(a, c)", readLines(agent_yaml), fixed = TRUE)))
+  
+  agent_post <- yaml_read_agent(agent_yaml)
+  # yaml_agent_string(agent_post, expanded = FALSE)
+  
+  expect_identical(
+    as_agent_yaml_list(agent_pre, expanded = FALSE),
+    as_agent_yaml_list(agent_post, expanded = FALSE)
+  )
+  expect_identical(
+    agent_pre %>% interrogate() %>% get_agent_report(display_table = FALSE),
+    agent_post %>% interrogate() %>% get_agent_report(display_table = FALSE)
+  )
+  
+  # Defaults writing to c()-expr
+  expect_message(
+    create_agent(~ small_table) %>% col_exists(a) %>% yaml_agent_string(),
+    "columns: c\\(a\\)"
+  )
+  
+})

--- a/tests/testthat/test-tidyselect-yaml_columns.R
+++ b/tests/testthat/test-tidyselect-yaml_columns.R
@@ -30,3 +30,29 @@ test_that("explicit c()-expr make the yaml roundtrip", {
   )
   
 })
+
+test_that("everything() default in `rows_*()` makes yaml roundtrip", {
+  
+  agent_distinct <- create_agent(~ small_table) %>% 
+    rows_distinct()
+  agent_complete <- create_agent(~ small_table) %>% 
+    rows_complete()
+  
+  expect_message(yaml_agent_string(agent_distinct), "columns: everything\\(\\)")
+  expect_message(yaml_agent_string(agent_complete), "columns: everything\\(\\)")
+  
+  agent_yaml <- tempfile()
+  # everything() makes yaml round trip for `rows_distinct()`
+  yaml_write(agent_distinct, expanded = FALSE, filename = agent_yaml)
+  expect_identical(
+    as_agent_yaml_list(agent_distinct, expanded = FALSE),
+    as_agent_yaml_list(yaml_read_agent(agent_yaml), expanded = FALSE)
+  )
+  # everything() makes yaml round trip for `rows_complete()`
+  yaml_write(agent_complete, expanded = FALSE, filename = agent_yaml)
+  expect_identical(
+    as_agent_yaml_list(agent_complete, expanded = FALSE),
+    as_agent_yaml_list(yaml_read_agent(agent_yaml), expanded = FALSE)
+  )
+
+})

--- a/tests/testthat/test-tidyselect_integration.R
+++ b/tests/testthat/test-tidyselect_integration.R
@@ -241,3 +241,30 @@ test_that("c()-expr works for serially", {
   )
   
 })
+
+test_that("explicit c()-expr make the yaml roundtrip", {
+  
+  agent_pre <- create_agent(~ small_table) %>% 
+    col_vals_lt(
+      columns = c(a, c),
+      value = 8
+    )
+  
+  agent_yaml <- tempfile()
+  yaml_write(agent_pre, expanded = FALSE, filename = agent_yaml)
+  # Writes to c()-expr
+  expect_true(any(grepl("columns: c(a, c)", readLines(agent_yaml), fixed = TRUE)))
+  
+  agent_post <- yaml_read_agent(agent_yaml)
+  # yaml_agent_string(agent_post, expanded = FALSE)
+  
+  expect_identical(
+    as_agent_yaml_list(agent_pre, expanded = FALSE),
+    as_agent_yaml_list(agent_post, expanded = FALSE)
+  )
+  expect_identical(
+    agent_pre %>% interrogate() %>% get_agent_report(display_table = FALSE),
+    agent_post %>% interrogate() %>% get_agent_report(display_table = FALSE)
+  )
+  
+})

--- a/tests/testthat/test-tidyselect_integration.R
+++ b/tests/testthat/test-tidyselect_integration.R
@@ -146,3 +146,37 @@ test_that("'NULL = select everything' behavior in rows_*() validation functions"
   expect_equal(nrow(df_interrogated$validation_set), 2L)
   
 })
+
+test_that("c()-expr works for serially", {
+  
+  # Example from `serially()` docs
+  tbl <-
+    dplyr::tibble(
+      a = c(5, 2, 6),
+      b = c(6, 4, 9),
+      c = c(1, 2, 3)
+    )
+  agent_1 <-
+    create_agent(tbl = tbl) %>%
+    serially(
+      ~ test_col_is_numeric(., columns = vars(a, b)),
+      ~ test_col_vals_not_null(., columns = vars(a, b)),
+      ~ col_vals_gt(., columns = vars(b), value = vars(a))
+    ) %>%
+    interrogate()
+  expect_no_error({
+    agent_1_c <-
+      create_agent(tbl = tbl) %>%
+      serially(
+        ~ test_col_is_numeric(., columns = c(a, b)),
+        ~ test_col_vals_not_null(., columns = c(a, b)),
+        ~ col_vals_gt(., columns = b, value = vars(a))
+      ) %>%
+      interrogate()
+  })
+  expect_identical(
+    get_agent_report(agent_1, display_table = FALSE)$n_pass,
+    get_agent_report(agent_1_c, display_table = FALSE)$n_pass
+  )
+  
+})

--- a/tests/testthat/test-tidyselect_integration.R
+++ b/tests/testthat/test-tidyselect_integration.R
@@ -241,36 +241,3 @@ test_that("c()-expr works for serially", {
   )
   
 })
-
-test_that("explicit c()-expr make the yaml roundtrip", {
-  
-  agent_pre <- create_agent(~ small_table) %>% 
-    col_vals_lt(
-      columns = c(a, c),
-      value = 8
-    )
-  
-  agent_yaml <- tempfile()
-  yaml_write(agent_pre, expanded = FALSE, filename = agent_yaml)
-  # Writes to c()-expr
-  expect_true(any(grepl("columns: c(a, c)", readLines(agent_yaml), fixed = TRUE)))
-  
-  agent_post <- yaml_read_agent(agent_yaml)
-  # yaml_agent_string(agent_post, expanded = FALSE)
-  
-  expect_identical(
-    as_agent_yaml_list(agent_pre, expanded = FALSE),
-    as_agent_yaml_list(agent_post, expanded = FALSE)
-  )
-  expect_identical(
-    agent_pre %>% interrogate() %>% get_agent_report(display_table = FALSE),
-    agent_post %>% interrogate() %>% get_agent_report(display_table = FALSE)
-  )
-  
-  # Defaults writing to c()-expr
-  testthat::expect_message(
-    create_agent(~ small_table) %>% col_exists(a) %>% yaml_agent_string(),
-    "columns: c\\(a\\)"
-  )
-  
-})

--- a/tests/testthat/test-tidyselect_integration.R
+++ b/tests/testthat/test-tidyselect_integration.R
@@ -114,8 +114,7 @@ test_that("'NULL = select everything' behavior in rows_*() validation functions"
     
 })
 
-# tidyselect coverage for `col_exists()`
-test_that("'NULL = select everything' behavior in rows_*() validation functions", {
+test_that("tidyselect coverage for `col_exists()`", {
   
   # Reprex from (#433)
   df <- tibble::tibble(
@@ -144,6 +143,68 @@ test_that("'NULL = select everything' behavior in rows_*() validation functions"
       interrogate()
   })
   expect_equal(nrow(df_interrogated$validation_set), 2L)
+  
+})
+
+test_that("error/failure patterns for `col_exists`", {
+  
+  # Selecting non-existent columns signals failure
+  expect_error(expect_failure({
+    small_table %>% 
+      col_exists("z")
+  }))
+  expect_failure({
+    small_table %>% 
+      expect_col_exists("z")
+  })
+  
+  # 0-column *tidyselect selection* should error
+  expect_error({
+    small_table %>% 
+      col_exists(starts_with("z"))
+  })
+  expect_error({
+    small_table %>% 
+      expect_col_exists("z")
+  })
+  
+  # Unrelated evaluation errors should be chained and rethrown
+  expect_error({
+    small_table %>% 
+      col_exists(stop("Error!"))
+  }, "Error!")
+  expect_error({
+    small_table %>% 
+      expect_col_exists(stop("Error!"))
+  }, "Error!")
+  expect_error({
+    small_table %>% 
+      test_col_exists(stop("Error!"))
+  }, "Error!")
+  
+  # Test should return FALSE for 0-column and non-existent column
+  expect_false({
+    small_table %>% 
+      test_col_exists("z")
+  })
+  expect_false({
+    small_table %>% 
+      test_col_exists("z")
+  })
+  
+  # No failure/error during validation
+  expect_no_error({
+    agent_nonexist_col <- create_agent(small_table) %>% 
+      col_exists("z") %>% 
+      interrogate()
+  })
+  expect_false(all_passed(agent_nonexist_col))
+  expect_no_error({
+    agent_tidyselect_0col <- create_agent(small_table) %>% 
+      col_exists(starts_with("z")) %>% 
+      interrogate()
+  })
+  expect_false(all_passed(agent_nonexist_col))
   
 })
 

--- a/tests/testthat/test-tidyselect_integration.R
+++ b/tests/testthat/test-tidyselect_integration.R
@@ -267,4 +267,10 @@ test_that("explicit c()-expr make the yaml roundtrip", {
     agent_post %>% interrogate() %>% get_agent_report(display_table = FALSE)
   )
   
+  # Defaults writing to c()-expr
+  testthat::expect_message(
+    create_agent(~ small_table) %>% col_exists(a) %>% yaml_agent_string(),
+    "columns: c\\(a\\)"
+  )
+  
 })

--- a/tests/testthat/test-tidyselect_integration.R
+++ b/tests/testthat/test-tidyselect_integration.R
@@ -158,12 +158,12 @@ test_that("error/failure patterns for `col_exists`", {
       expect_col_exists("z")
   })
   
-  # 0-column *tidyselect selection* should error
-  expect_error({
+  # 0-column tidyselect selection signals failure
+  expect_error(expect_failure({
     small_table %>% 
       col_exists(starts_with("z"))
-  })
-  expect_error({
+  }))
+  expect_failure({
     small_table %>% 
       expect_col_exists("z")
   })
@@ -204,7 +204,7 @@ test_that("error/failure patterns for `col_exists`", {
       col_exists(starts_with("z")) %>% 
       interrogate()
   })
-  expect_false(all_passed(agent_nonexist_col))
+  expect_false(all_passed(agent_tidyselect_0col))
   
 })
 

--- a/tests/testthat/test-yaml.R
+++ b/tests/testthat/test-yaml.R
@@ -800,19 +800,19 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
   
   expect_equal(
     get_oneline_expr_str(agent %>% rows_distinct()),
-    "rows_distinct(columns = c(date_time, date, a, b, c, d, e, f))"
+    "rows_distinct(columns = everything())"
   )
   expect_equal(
     get_oneline_expr_str(agent %>% rows_distinct(columns = vars(a, b))),
-    "rows_distinct(columns = c(a, b))"
+    "rows_distinct(columns = vars(a, b))"
   )
   expect_equal(
     get_oneline_expr_str(agent %>% rows_distinct(columns = vars(a, b), preconditions = ~ . %>% dplyr::filter(a > 0))),
-    "rows_distinct(columns = c(a, b),preconditions = ~. %>% dplyr::filter(a > 0))"
+    "rows_distinct(columns = vars(a, b),preconditions = ~. %>% dplyr::filter(a > 0))"
   )
   expect_equal(
     get_oneline_expr_str(agent %>% rows_distinct(columns = vars(a, b), label = "my_label")),
-    "rows_distinct(columns = c(a, b),label = \"my_label\")"
+    "rows_distinct(columns = vars(a, b),label = \"my_label\")"
   )
   
   #

--- a/tests/testthat/test-yaml.R
+++ b/tests/testthat/test-yaml.R
@@ -800,19 +800,19 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
   
   expect_equal(
     get_oneline_expr_str(agent %>% rows_distinct()),
-    "rows_distinct(columns = vars(date_time, date, a, b, c, d, e, f))"
+    "rows_distinct(columns = c(date_time, date, a, b, c, d, e, f))"
   )
   expect_equal(
     get_oneline_expr_str(agent %>% rows_distinct(columns = vars(a, b))),
-    "rows_distinct(columns = vars(a, b))"
+    "rows_distinct(columns = c(a, b))"
   )
   expect_equal(
     get_oneline_expr_str(agent %>% rows_distinct(columns = vars(a, b), preconditions = ~ . %>% dplyr::filter(a > 0))),
-    "rows_distinct(columns = vars(a, b),preconditions = ~. %>% dplyr::filter(a > 0))"
+    "rows_distinct(columns = c(a, b),preconditions = ~. %>% dplyr::filter(a > 0))"
   )
   expect_equal(
     get_oneline_expr_str(agent %>% rows_distinct(columns = vars(a, b), label = "my_label")),
-    "rows_distinct(columns = vars(a, b),label = \"my_label\")"
+    "rows_distinct(columns = c(a, b),label = \"my_label\")"
   )
   
   #
@@ -888,3 +888,4 @@ test_that("Individual validation steps make the YAML round-trip successfully", {
     "col_schema_match(schema = col_schema(a = \"integer\",b = \"character\"),label = \"my_label\")"
   )
 })
+


### PR DESCRIPTION
# Summary

This will be a series of (mostly) documentation-related changes complementing the two recent PRs:
- #493
- #495

Below is the (evolving) roadmap for this PR. Please feel free to interject at any point!

## 1) Chore

- [x] Remove the usage of `vars()` for column selection in docs. `vars(a)` becomes `a` and `vars(a, b)` becomes `c(a, b)`. 
- [x] Clean up capturing user-expression in `columns` in validation functions: the input should only be `enquo()`-ed once
- [x] Remove/refactor some utilities no longer used:
  - [x] `as_vars_fn()` (now `as_c_fn()`)
- Note any missing gaps in the newly introduced features and add to (3)
- Catch and fix any bugs spotted in the process
  - [x] resolving `c()`-expr column selection inside `serially()` is too eager
  - [x] `serially()` YAML section example doesn't run: "Error: There must be at least one `test_*()` function call in `serially()`."
  - [x] `col_exists()` allows all kinds of evaluation errors to go through, not just user-specified selection of non-existent columns

## 2) Documentation

- [x] Document tidyselect in `columns` param
- [x] Document (more complete) tidyselect in Column Names section
- [x] Document glue syntax in `label` param
- [x] Document multi-length vector support in `label` param

Copy pastes:

- [x] Make special `columns` param docs for `rows_*()` functions, making `everything()` the default
- [x] Edit Column Names section in individual function docs
- [x] Add Labels section in individual function docs
  - Only show the relevant a subset of glue variables for each function

## 3) Feature completeness (more of a wishlist)

- [x] refactor `get_column_text()` for writing `columns` expr to yaml
- [x] yaml functions should now write columns as `c(a)` instead of `vars(a)` if user only specifies `columns = a`
  - [x] test consumption of `columns: c(a)` and `columns: c(a, b)`
- Rest are too big/out of scope and moved to section X

## 4) Finishing touches

### News items
- [x] glue syntax in `label`
- [x] more complete tidyselect in `columns`
- [x] note beginning of deprecation process for `vars()` in `columns` (?)
- [x] encourage users to wrap the input to `columns` in `all_of()` if it's an external vector (like in `dplyr::select()`)

### Additional tests
- [x] test examples embedded in sections
- [x] ensure all tests pass
- [x] ensure pkgdown builds

## X) Bigger refactoring tasks that should be handled outside of this PR 

- yaml should default to reading/writing `columns` as expression
- Remove/refactor some utilities no longer used:
  - `uses_tidyselect()`
  - `exported_tidyselect_fns()`
- `has_columns()` currently relies on `columns = vars(...)` and could benefit from tidyselect (same situation as `col_exists()`, just more lightweight)
- `info_columns()` does not allow tidyselect expressions over column type/values like `where(is.character)` when `tbl` is loaded lazily.

# Related GitHub Issues and PRs

- Ref: #493, #495

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/pointblank/blob/main/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/pointblank/tree/main/tests/testthat) for any new functionality.
