### PR TITLE
Env scoping safeguards

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -303,13 +303,7 @@ resolve_columns_internal <- function(tbl, var_expr, ..., call) {
   }
   # Special case `vars()`-expression for backwards compatibility
   if (rlang::quo_is_call(var_expr, "vars")) {
-    # Convert to the idiomatic `c()`-expr before passing off to tidyselect
-    # * Ensure that vars() always scopes to data (`vars(a)` becomes `c("a")`)
-    vars_args <- lapply(rlang::call_args(var_expr), function(var_arg) {
-      if (rlang::is_symbol(var_arg)) rlang::as_name(var_arg) else var_arg
-    })
-    c_expr <- rlang::call2("c", !!!vars_args)
-    var_expr <- rlang::quo_set_expr(var_expr, c_expr)
+    var_expr <- rlang::quo_set_expr(var_expr, vars_to_c(var_expr))
   }
   
   # Proceed with tidyselect
@@ -321,6 +315,16 @@ resolve_columns_internal <- function(tbl, var_expr, ..., call) {
   }
   
   column
+}
+
+# Convert to the idiomatic `c()`-expr before passing off to tidyselect
+# + ensure that vars() always scopes symbols to data (vars(a) -> c("a"))
+vars_to_c <- function(var_expr) {
+  var_args <- lapply(rlang::call_args(var_expr), function(var_arg) {
+    if (rlang::is_symbol(var_arg)) rlang::as_name(var_arg) else var_arg
+  })
+  c_expr <- rlang::call2("c", !!!var_args)
+  c_expr
 }
 
 resolve_label <- function(label, columns = "", segments = "") {

--- a/R/utils.R
+++ b/R/utils.R
@@ -259,6 +259,10 @@ resolve_columns <- function(x, var_expr, preconditions = NULL, ...,
     } else {
       # Else (mid-planning): grab columns attempted to subset
       fail <- out$i
+      # If failure is due to scoping a bad object in the env, re-throw error
+      if (!is.character(fail) && !rlang::is_integerish(fail)) {
+        rlang::cnd_signal(out)
+      }
       success <- resolve_columns_possible(tbl, var_expr)
       out <- c(success, fail) %||% NA_character_
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -299,8 +299,12 @@ resolve_columns_internal <- function(tbl, var_expr, ..., call) {
   }
   # Special case `vars()`-expression for backwards compatibility
   if (rlang::quo_is_call(var_expr, "vars")) {
-    # Convert to the idiomatic `c()`-expr
-    c_expr <- rlang::call2("c", !!!rlang::call_args(var_expr))
+    # Convert to the idiomatic `c()`-expr before passing off to tidyselect
+    # * Ensure that vars() always scopes to data (`vars(a)` becomes `c("a")`)
+    vars_args <- lapply(rlang::call_args(var_expr), function(var_arg) {
+      if (rlang::is_symbol(var_arg)) rlang::as_name(var_arg) else var_arg
+    })
+    c_expr <- rlang::call2("c", !!!vars_args)
     var_expr <- rlang::quo_set_expr(var_expr, c_expr)
   }
   

--- a/tests/testthat/test-tidyselect_fails_safely.R
+++ b/tests/testthat/test-tidyselect_fails_safely.R
@@ -1,4 +1,5 @@
 agent <- create_agent(small_table)
+z <- rlang::missing_arg()
 nonexistent_col <- "z"
 
 test_that("tidyselect errors signaled at report, not during development of validation plan", {

--- a/tests/testthat/test-tidyselect_fails_safely_batch.R
+++ b/tests/testthat/test-tidyselect_fails_safely_batch.R
@@ -1,4 +1,5 @@
 agent <- create_agent(tbl = small_table[, c("a", "b", "c")])
+z <- rlang::missing_arg()
 mixed_cols <- c("a", "z")
 
 # Column selection expressions to test


### PR DESCRIPTION
Small patch to strengthen safeguards for accidentally tidyselecting an env variable that has the same name as a non-existent column.

These used to error for both `c()` and `vars()` (and still do), but are now more informative and caught earlier in `resolve_columns()`, by rethrowing the tidyselect error:

``` r
# Bad object
z <- quote(dont + pick + me)

# Rethrows tidyselect "must be num/char, not X" error
small_table %>% 
  col_vals_not_null(z)
#> Error in `col_vals_not_null()`:
#> ! Can't subset columns with `z`.
#> ✖ `z` must be numeric or character, not a call.

# `vars()` doesn't look up to env to resolve symbols to begin with
small_table %>% 
  col_vals_not_null(vars(z))
#> Error in `col_vals_not_null()`:
#> ! Can't subset columns that don't exist.
#> ✖ Column `z` doesn't exist.

# You can still scope env from `vars()` if symbol is part of a helper
# for backwards compatibility with old tidyselect
small_table %>% 
  col_vals_not_null(vars(starts_with(z)))
#> Error in `col_vals_not_null()`:
#> ! Problem while evaluating `starts_with(z)`.
#> Caused by error in `check_match()`:
#> ! `match` must be a character vector of non empty strings.

z <- "date"
small_table %>% 
  test_col_vals_not_null(vars(starts_with(z))) 
#> [1] TRUE
```
