### PR TITLE
columns resolved against full data when available

### DIFF
--- a/R/info_add.R
+++ b/R/info_add.R
@@ -449,10 +449,14 @@ info_columns <- function(
   metadata_list <- metadata$metadata
   metadata_columns <- metadata_list$columns
   
-  x <- dplyr::as_tibble(metadata_columns %>% lapply(function(x) 1))
+  if (is.null(x$tbl)) {
+    tbl <- dplyr::as_tibble(metadata_columns %>% lapply(function(x) 1))
+  } else {
+    tbl <- x$tbl
+  }
   
   # Resolve the columns based on the expression
-  columns <- resolve_columns(x = x, var_expr = columns, preconditions = NULL)
+  columns <- resolve_columns(x = tbl, var_expr = columns)
   
   if (length(columns) == 1 && is.na(columns)) {
    


### PR DESCRIPTION
This PR allows `info_columns()` to resolve `columns` against the full data when it's available (i.e., not lazy).

Using `where()` is now possible when `create_informant` receives a data frame:

```r
create_informant(small_table) %>% 
  info_columns(
    columns = where(lubridate::is.timepoint),
    info = "Data about a time point"
  )
```

![image](https://github.com/rstudio/pointblank/assets/52832839/cfe7aefc-f95c-4eb1-98d0-2941657dfe37)

# Related GitHub Issues and PRs

- Ref: #502

# Checklist

- [ ] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [ ] I have listed any major changes in the [NEWS](https://github.com/rstudio/pointblank/blob/main/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/pointblank/tree/main/tests/testthat) for any new functionality.
