### PR TITLE
Bugfix for `col_vals_expr()` at report

### DIFF
--- a/R/get_agent_report.R
+++ b/R/get_agent_report.R
@@ -762,7 +762,8 @@ get_agent_report <- function(
           # - in validation planning, OR
           # - the evaluation errors, OR
           # - is a col_exists() step
-          show_column_expr <- columns_expr != "NULL" &&
+          columns_expr_exists <- !is.na(columns_expr) && columns_expr != "NULL"
+          show_column_expr <- columns_expr_exists &&
             (not_interrogated || eval_error || assertion_str == "col_exists")
           # Then display the original column selection expression for debugging
           if (show_column_expr) {


### PR DESCRIPTION
This fixes a bug that I introduced in #499 with the [new feature](https://github.com/rstudio/pointblank/pull/499#issuecomment-1789985548) of the agent report falling back to displaying the column-selecting expression if no column gets selected. This broke for `col_vals_expr()` because it doesn't take a `columns` argument to begin with.

To clarify, `columns_expr` in the validation set is:
- `"NULL"` when `columns` is missing/`NULL`
- `NA_character_` when the validation function does not have a `columns` argument (this edge case for `col_vals_expr()` is now accounted for with this PR)

Now the following no longer errors:

```r
devtools::load_all()

create_agent(small_table) %>% 
  col_vals_expr(expr = expr(a > 5)) %>%
  get_agent_report()
```

(I'd actually fixed this in #505 but moving it out here to resolve it ASAP)