### PR TITLE
bugfix custom title for small agent

### DIFF
--- a/R/get_agent_report.R
+++ b/R/get_agent_report.R
@@ -1896,9 +1896,7 @@ get_agent_report <- function(
       agent_report <- 
         agent_report %>%
         gt::tab_header(
-          title = get_lsv(text = c(
-            "agent_report", "pointblank_validation_title_text"
-          ))[[lang]],
+          title = title_text,
           subtitle = gt::md(
             paste0(agent_label_styled, " ", table_type, " <br><br>")
           )

--- a/R/get_agent_report.R
+++ b/R/get_agent_report.R
@@ -775,6 +775,7 @@ get_agent_report <- function(
                   `margin-top` = "0",
                   `margin-bottom` = "0",
                   `font-family` = "monospace",
+                  `font-size` = "10px",
                   `white-space` = "nowrap",
                   `text-overflow` = "ellipsis",
                   overflow = "hidden",


### PR DESCRIPTION
This PR ensures that agents always show the same `title` regardless of `size`. The PR simply uses the already-processed `title_text` variable for small agents, instead of overriding it with the default title

https://github.com/rstudio/pointblank/blob/27f2d15e807483866c8cb9e314a7bc1b2581d270/R/get_agent_report.R#L483-L490

Reprex from #456

```r
devtools::load_all()
tbl <- dplyr::tibble(a = c(5, 7, 8, 5))
agent <-
  create_agent(
    tbl = tbl,
    tbl_name = "small_table",
    label = "An example."
  ) %>%
  col_vals_gt(columns = vars(a), value = 4) %>%
  interrogate()

get_agent_report(
  agent = agent,
  title = "a custom title",
  size = "small"
)
```

![image](https://github.com/rstudio/pointblank/assets/52832839/e5af080d-c746-40a6-98be-614b20e60e3d)
