### PR TITLE
Interrogate step labels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,11 @@
   - `"{.seg_val}"`: The current segment's value/group
   
   These dynamic values may be useful for validations that get expanded into multiple steps.
+  
+* `interrogate()` gains two new options for printing progress in the console output:
+
+  - `progress`: Whether interrogation progress should be printed to the console (`TRUE` for interactive sessions, same as before)
+  - `show_step_label`: Whether each validation step's label value should be printed alongside the progress.
 
 ## Minor improvements and bug fixes
 

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -79,6 +79,19 @@
 #'   A value that limits the possible number of rows returned when sampling
 #'   non-passing rows using the `sample_frac` option.
 #'   
+#' @param show_step_label *Show step labels in progress*
+#' 
+#'   `scalar<logical>` // *default:* `FALSE`
+#' 
+#'   Whether to show the `label` value of each validation step in the console.
+#'
+#' @param progress *Show interrogation progress*
+#' 
+#'   `scalar<logical>` // *default:* `interactive()`
+#' 
+#'   Whether to show the progress of an agent's interrogation in the console.
+#'   Defaults to `TRUE` in interactive sessions.
+#'   
 #' @return A `ptblank_agent` object.
 #'   
 #' @section Examples:
@@ -133,7 +146,9 @@ interrogate <- function(
     get_first_n = NULL,
     sample_n = NULL,
     sample_frac = NULL,
-    sample_limit = 5000
+    sample_limit = 5000,
+    show_step_label = FALSE,
+    progress = interactive()
 ) {
   
   #
@@ -199,7 +214,7 @@ interrogate <- function(
 
   # Quieting of an agent's remarks either when the agent has the
   # special label `"::QUIET::"` or the session is non-interactive
-  if (agent$label == "::QUIET::" || !interactive()) {
+  if (agent$label == "::QUIET::" || !progress) {
     quiet <- TRUE
   } else {
     quiet <- FALSE
@@ -701,6 +716,7 @@ interrogate <- function(
       agent = agent,
       i = i,
       time_diff_s = time_diff_s,
+      show_step_label = show_step_label,
       quiet = quiet
     )
   }
@@ -795,6 +811,7 @@ create_post_step_cli_output_a <- function(
     agent,
     i,
     time_diff_s,
+    show_step_label,
     quiet
 ) {
   
@@ -831,6 +848,13 @@ create_post_step_cli_output_a <- function(
     )) %>% 
     dplyr::pull(condition)
   
+  label <- agent$validation_set[i, ]$label
+  if (show_step_label && !is.na(label)) {
+    step_label <- paste0(" — {label}")
+  } else {
+    step_label <- NULL
+  }
+  
   cli::cli_div(
     theme = list(
       span.green = list(color = "green"),
@@ -845,26 +869,33 @@ create_post_step_cli_output_a <- function(
       c(
         "Step {.field {i}}: an evaluation issue requires attention ",
         "(", interrogation_evaluation, ").",
-        print_time(time_diff_s)
+        print_time(time_diff_s),
+        step_label
       )
     )
   } else if (validation_condition == "NONE" && notify_condition == "NONE") {
     cli::cli_alert_success(
-      c("Step {.field {i}}: {.green OK}.", print_time(time_diff_s))
+      c(
+        "Step {.field {i}}: {.green OK}.",
+        print_time(time_diff_s),
+        step_label
+      )
     )
   } else if (validation_condition != "NONE" && notify_condition == "NONE") {
     if (validation_condition == "STOP") {
       cli::cli_alert_danger(
         c(
           "Step {.field {i}}: {.red STOP} condition met.",
-          print_time(time_diff_s)
+          print_time(time_diff_s),
+          step_label
         )
       )
     } else {
       cli::cli_alert_warning(
         c(
           "Step {.field {i}}: {.yellow WARNING} condition met.",
-          print_time(time_diff_s)
+          print_time(time_diff_s),
+          step_label
         )
       )
     }
@@ -874,7 +905,8 @@ create_post_step_cli_output_a <- function(
         c(
           "Step {.field {i}}: {.red STOP} and ",
           "{.blue NOTIFY} conditions met.",
-          print_time(time_diff_s)
+          print_time(time_diff_s),
+          step_label
         )
       )
     } else {
@@ -882,7 +914,8 @@ create_post_step_cli_output_a <- function(
         c(
           "Step {.field {i}}: {.yellow WARNING} and ",
           "{.blue NOTIFY} conditions met.",
-          print_time(time_diff_s)
+          print_time(time_diff_s),
+          step_label
         )
       )
     }
@@ -890,7 +923,8 @@ create_post_step_cli_output_a <- function(
     cli::cli_alert_warning(
       c(
         "Step {.field {i}}: {.blue NOTIFY} condition met.",
-        print_time(time_diff_s)
+        print_time(time_diff_s),
+        step_label
       )
     )
   }

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -850,7 +850,7 @@ create_post_step_cli_output_a <- function(
   
   label <- agent$validation_set[i, ]$label
   if (show_step_label && !is.na(label)) {
-    step_label <- paste0(" — {label}")
+    step_label <- paste0(" - {label}")
   } else {
     step_label <- NULL
   }

--- a/man/interrogate.Rd
+++ b/man/interrogate.Rd
@@ -10,7 +10,9 @@ interrogate(
   get_first_n = NULL,
   sample_n = NULL,
   sample_frac = NULL,
-  sample_limit = 5000
+  sample_limit = 5000,
+  show_step_label = FALSE,
+  progress = interactive()
 )
 }
 \arguments{
@@ -63,6 +65,19 @@ option will apply a hard limit to the returned rows.}
 
 A value that limits the possible number of rows returned when sampling
 non-passing rows using the \code{sample_frac} option.}
+
+\item{show_step_label}{\emph{Show step labels in progress}
+
+\verb{scalar<logical>} // \emph{default:} \code{FALSE}
+
+Whether to show the \code{label} value of each validation step in the console.}
+
+\item{progress}{\emph{Show interrogation progress}
+
+\verb{scalar<logical>} // \emph{default:} \code{interactive()}
+
+Whether to show the progress of an agent's interrogation in the console.
+Defaults to \code{TRUE} in interactive sessions.}
 }
 \value{
 A \code{ptblank_agent} object.


### PR DESCRIPTION
A small surgery on `interrogate()` to:
1) Toggle the printing of each step's label to the console output during interrogation (#510)
2) Expose the internal `quiet` variable to let users control whether `interrogate()` should print to console at all (now becomes `interrogate(progress = interactive())`)

Also works good with glue integration from #495 !

```r
create_agent(small_table) %>% 
  col_exists(
    columns = c(a, z),
    label = "Check that column `{.col}` exists",
    actions = action_levels(notify_at = 1)
  ) %>% 
  col_exists(
    columns = x,
    label = "`x` should really exist",
    actions = action_levels(stop_at = 1)) %>% 
  col_vals_not_null(
    columns = c:e,
    label = "Checking that {.col} is complete",
    actions = action_levels(warn_at = 1)
  ) %>% 
  interrogate(show_step_label = TRUE)
#> 
#> ── Interrogation Started - there are 6 steps ────────────────────────────────────────────────────────
#> ✔ Step 1: OK. — Check that column `a` exists
#> ! Step 2: NOTIFY condition met. — Check that column `z` exists
#> ✖ Step 3: STOP condition met. — `x` should really exist
#> ! Step 4: WARNING condition met. — Checking that c is complete
#> ✔ Step 5: OK. — Checking that d is complete
#> ✔ Step 6: OK. — Checking that e is complete
#> 
#> ── Interrogation Completed ──────────────────────────────────────────────────────────────────────────
```

Fixes: https://github.com/rstudio/pointblank/issues/510