### PR TITLE
Check for Quarto environment before using workaround

### DIFF
--- a/R/get_agent_report.R
+++ b/R/get_agent_report.R
@@ -1967,14 +1967,14 @@ get_agent_report <- function(
   # nocov end
   
   # Quarto rendering workaround
-  agent_report <- gt::fmt(agent_report, fns = identity)
+  if (check_quarto()) {
+    agent_report <- gt::fmt(agent_report, fns = identity)
+  }
   
   agent_report
-  
 }
 
-get_default_title_text <- function(report_type,
-                                   lang) {
+get_default_title_text <- function(report_type, lang) {
   
   if (report_type == "informant") {
     title_text <- 

--- a/R/get_informant_report.R
+++ b/R/get_informant_report.R
@@ -679,10 +679,11 @@ get_informant_report <- function(
   # nocov end
   
   # Quarto rendering workaround
-  gt_informant_report <- gt::fmt(gt_informant_report, fns = identity)
+  if (check_quarto()) {
+    gt_informant_report <- gt::fmt(gt_informant_report, fns = identity)
+  }
   
   gt_informant_report
-  
 }
 
 add_to_tbl <- function(tbl, item, group) {

--- a/R/get_multiagent_report.R
+++ b/R/get_multiagent_report.R
@@ -916,10 +916,11 @@ get_multiagent_report <- function(
   class(report_tbl) <- c("ptblank_multiagent_report.wide", class(report_tbl))
   
   # Quarto rendering workaround
-  report_tbl <- gt::fmt(report_tbl, fns = identity)
+  if (check_quarto()) {
+    report_tbl <- gt::fmt(report_tbl, fns = identity)
+  }
   
   report_tbl
-  
 }
 
 generate_cell_content <- function(

--- a/R/utils-output.R
+++ b/R/utils-output.R
@@ -165,4 +165,8 @@ get_rds_tbl_info_files_tbl <- function(rds_tbl, tbl_name) {
   rds_tbl[rds_tbl$tbl_name == tbl_name, "information_files"][[1]][[1]]
 }
 
+check_quarto <- function() {
+  Sys.getenv("QUARTO_BIN_PATH") != ""
+}
+
 # nocov end


### PR DESCRIPTION
This slightly amends the work done in https://github.com/rstudio/pointblank/pull/520 that protects against Quarto rendering. All that is added is a check for whether the rendering is occurring in a Quarto environment (through an environment variable check). If this check succeeds, then the `gt` workaround is applied.

Did this mainly because the rendering for the informant report automatically treats the table cells as having Markdown text and, until the larger problem is fixed, this at least restores the Markdown conversion outside of the Quarto context.