### PR TITLE
tidyselect in readme and vignettes

### DIFF
--- a/R/incorporate.R
+++ b/R/incorporate.R
@@ -83,7 +83,7 @@
 #'     info = "Time-based values (e.g., `Sys.time()`)."
 #'   ) %>%
 #'   info_columns(
-#'     columns = "date",
+#'     columns = date,
 #'     info = "The date part of `date_time`. ((CALC))"
 #'   ) %>%
 #'   info_section(

--- a/R/info_add.R
+++ b/R/info_add.R
@@ -331,15 +331,15 @@ info_tabular <- function(
 #' # R statement
 #' informant %>% 
 #'   info_columns(
-#'     columns = "date_time",
+#'     columns = date_time,
 #'     info = "*info text* 1."
 #'   ) %>%
 #'   info_columns(
-#'     columns = "date",
+#'     columns = date,
 #'     info = "*info text* 2."
 #'   ) %>%
 #'   info_columns(
-#'     columns = "item_count",
+#'     columns = item_count,
 #'     info = "*info text* 3. Statistics: {snippet_1}."
 #'   ) %>%
 #'   info_columns(
@@ -409,7 +409,7 @@ info_tabular <- function(
 #'     info = "Time-based values (e.g., `Sys.time()`)."
 #'   ) %>%
 #'   info_columns(
-#'     columns = "date",
+#'     columns = date,
 #'     info = "The date part of `date_time`. ((CALC))"
 #'   )
 #' ```
@@ -609,11 +609,11 @@ info_columns <- function(
 #' informant <-
 #'   informant %>%
 #'   info_columns(
-#'     columns = "item_revenue",
+#'     columns = item_revenue,
 #'     info = "Revenue reported in USD."
 #'   ) %>%
 #'   info_columns(
-#'     columns = "acquisition",
+#'     columns = acquisition,
 #'     `top list` = "{top5_aq}"
 #'   ) %>%
 #'   info_snippet(
@@ -1013,7 +1013,7 @@ info_section <- function(
 #' # R statement
 #' informant %>% 
 #'   info_columns(
-#'     columns = "date_time",
+#'     columns = date_time,
 #'     `Latest Date` = "The latest date is {latest_date}."
 #'   ) %>%
 #'   info_snippet(
@@ -1076,7 +1076,7 @@ info_section <- function(
 #'     info = "Time-based values (e.g., `Sys.time()`)."
 #'   ) %>%
 #'   info_columns(
-#'     columns = "date",
+#'     columns = date,
 #'     info = "The date part of `date_time`. ((CALC))"
 #'   ) %>%
 #'   info_section(
@@ -1264,7 +1264,7 @@ info_snippet <- function(
 #'     label = "An example."
 #'   ) %>% 
 #'   info_columns(
-#'     columns = "f",
+#'     columns = f,
 #'     `Items` = "This column contains {values_f}."
 #'   ) %>%
 #'   info_snippet(
@@ -1495,7 +1495,7 @@ snip_list <- function(
 #'     label = "An example."
 #'   ) %>% 
 #'   info_columns(
-#'     columns = "d",
+#'     columns = d,
 #'     `Stats` = "Stats (fivenum): {stats_d}."
 #'   ) %>%
 #'   info_snippet(
@@ -1574,7 +1574,7 @@ snip_stats <- function(
 #'     label = "An example."
 #'   ) %>% 
 #'   info_columns(
-#'     columns = "a",
+#'     columns = a,
 #'     `Lowest Value` = "Lowest value is {lowest_a}."
 #'   ) %>%
 #'   info_snippet(
@@ -1648,7 +1648,7 @@ snip_lowest <- function(column) {
 #'     label = "An example."
 #'   ) %>% 
 #'   info_columns(
-#'     columns = "a",
+#'     columns = a,
 #'     `Highest Value` = "Highest value is {highest_a}."
 #'   ) %>%
 #'   info_snippet(

--- a/R/object_ops.R
+++ b/R/object_ops.R
@@ -205,7 +205,7 @@
 #'     info = "Time-based values."
 #'   ) %>%
 #'   info_columns(
-#'     columns = "date",
+#'     columns = date,
 #'     info = "The date part of `date_time`."
 #'   ) %>%
 #'   incorporate()
@@ -680,7 +680,7 @@ x_read_disk <- function(
 #'     info = "Time-based values."
 #'   ) %>%
 #'   info_columns(
-#'     columns = "date",
+#'     columns = date,
 #'     info = "The date part of `date_time`."
 #'   ) %>%
 #'   incorporate()

--- a/README.md
+++ b/README.md
@@ -141,14 +141,14 @@ dplyr::tibble(
     b = c(6, 1, 0, 6,  0, 7)
   ) %>%
   col_vals_between(
-    vars(a), 1, 9,
+    a, 1, 9,
     na_pass = TRUE
   ) %>%
   col_vals_lt(
-    vars(c), 12,
+    c, 12,
     preconditions = ~ . %>% dplyr::mutate(c = a + b)
   ) %>%
-  col_is_numeric(vars(a, b))
+  col_is_numeric(c(a, b))
 ```
 
     Error: Exceedance of failed test units where values in `c` should have been < `12`.
@@ -169,17 +169,17 @@ dplyr::tibble(
     b = c(6, 1, 0, 6,  0, 7)
   ) %>%
   col_vals_between(
-    vars(a), 1, 9,
+    a, 1, 9,
     na_pass = TRUE,
     actions = warn_on_fail()
   ) %>%
   col_vals_lt(
-    vars(c), 12,
+    c, 12,
     preconditions = ~ . %>% dplyr::mutate(c = a + b),
     actions = warn_on_fail()
   ) %>%
   col_is_numeric(
-    vars(a, b),
+    c(a, b),
     actions = warn_on_fail()
   )
 ```
@@ -267,19 +267,19 @@ informant <-
     `README` pages. Column names are `a` and `b`. ((Cool stuff))"
   ) %>%
   info_columns(
-    columns = "a",
+    columns = a,
     info = "This column has an `NA` value. [[Watch out!]]<<color: red;>>"
   ) %>%
   info_columns(
-    columns = "a",
+    columns = a,
     info = "Mean value is `{a_mean}`."
   ) %>%
   info_columns(
-    columns = "b",
+    columns = b,
     info = "Like column `a`. The lowest value is `{b_lowest}`."
   ) %>%
   info_columns(
-    columns = "b",
+    columns = b,
     info = "The highest value is `{b_highest}`."
   ) %>%
   info_snippet(

--- a/vignettes/INFO-1.Rmd
+++ b/vignettes/INFO-1.Rmd
@@ -71,7 +71,7 @@ informant <-
     description = "This table is included in the **pointblank** pkg."
   ) %>%
   info_columns(
-    columns = "date_time",
+    columns = date_time,
     info = "This column is full of timestamps."
   ) %>%
   info_section(
@@ -97,7 +97,7 @@ The `info_tabular()` function adds information to the **TABLE** section. We use 
 
 ```{r eval=FALSE}
 informant %>% 
-  info_tabular(`🔄 updates` = "This table is not regularly updated.")
+  info_tabular("🔄 updates" = "This table is not regularly updated.")
 ```
 
 <div style="text-align: center;"><img src="https://silly-jackson-b3dec8.netlify.app/informant_report_4.png"
@@ -128,24 +128,24 @@ informant_pp <-
     label = "The `penguins` dataset from the **palmerpenguins** 📦."
   ) %>% 
   info_columns(
-    columns = "species",
+    columns = species,
     `ℹ️` = "A factor denoting penguin species (*Adélie*, *Chinstrap*, and *Gentoo*)."
   ) %>%
   info_columns(
-    columns = "island",
+    columns = island,
     `ℹ️` = "A factor denoting island in Palmer Archipelago, Antarctica
     (*Biscoe*, *Dream*, or *Torgersen*)."
   ) %>%
   info_columns(
-    columns = "bill_length_mm",
+    columns = bill_length_mm,
     `ℹ️` = "A number denoting bill length"
   ) %>%
   info_columns(
-    columns = "bill_depth_mm",
+    columns = bill_depth_mm,
     `ℹ️` = "A number denoting bill depth"
   ) %>%
   info_columns(
-    columns = "flipper_length_mm",
+    columns = flipper_length_mm,
     `ℹ️` = "An integer denoting flipper length"
   ) %>%
   info_columns(
@@ -153,15 +153,15 @@ informant_pp <-
     `ℹ️` = "(in units of millimeters)."
   ) %>%
   info_columns(
-    columns = "body_mass_g",
+    columns = body_mass_g,
     `ℹ️` = "An integer denoting body mass (grams)."
   ) %>%
   info_columns(
-    columns = "sex",
+    columns = sex,
     `ℹ️` = "A factor denoting penguin sex (`\"female\"`, `\"male\"`)."
   ) %>%
   info_columns(
-    columns = "year",
+    columns = year,
     `ℹ️` = "The study year (e.g., `2007`, `2008`, `2009`)."
   )
 

--- a/vignettes/INFO-2.Rmd
+++ b/vignettes/INFO-2.Rmd
@@ -44,7 +44,7 @@ The `small_table` dataset is associated with the `informant` as the target table
 informant <- 
   informant %>%
   info_columns(
-    columns = vars(d),
+    columns = d,
     info = "This column contains fairly large numbers (much larger than
     those numbers in column `a`. The mean value is {mean_d}, which is
     far greater than any number in that other column."
@@ -76,7 +76,7 @@ informant <-
     fn = ~ . %>% .$d %>% mean() %>% round(1)
   ) %>%
     info_columns(
-    columns = vars(d),
+    columns = d,
     info = "This column contains fairly large numbers (much larger than
     those numbers in column `a`. The mean value is {mean_d}, which is
     far greater than any number in that other column."
@@ -181,11 +181,11 @@ informant_pp <-
     label = "The `penguins` dataset from the **palmerpenguins** 📦."
   ) %>% 
   info_columns(
-    columns = "species",
+    columns = species,
     `ℹ️` = "A factor denoting penguin species ({species_snippet})."
   ) %>%
   info_columns(
-    columns = "island",
+    columns = island,
     `ℹ️` = "A factor denoting island in Palmer Archipelago, Antarctica
     ({island_snippet})."
   ) %>%
@@ -216,7 +216,7 @@ This also works for numeric values. Let's use `snip_list()` to provide a text sn
 informant_pp <-
   informant_pp %>%
   info_columns(
-    columns = "year",
+    columns = year,
     `ℹ️` = "The study year ({year_snippet})."
   ) %>%
   info_snippet(
@@ -244,16 +244,16 @@ We can get the lowest and highest values from a column and inject those formatte
 informant_pp <-
   informant_pp %>%
   info_columns(
-    columns = "bill_length_mm",
+    columns = bill_length_mm,
     `ℹ️` = "A number denoting bill length"
   ) %>%
   info_columns(
-    columns = "bill_depth_mm",
+    columns = bill_depth_mm,
     `ℹ️` = "A number denoting bill depth (in the range of
     {min_depth} to {max_depth} millimeters)."
   ) %>%
   info_columns(
-    columns = "flipper_length_mm",
+    columns = flipper_length_mm,
     `ℹ️` = "An integer denoting flipper length"
   ) %>%
   info_columns(
@@ -261,7 +261,7 @@ informant_pp <-
     `ℹ️` = "(in units of millimeters)."
   ) %>%
   info_columns(
-    columns = "flipper_length_mm",
+    columns = flipper_length_mm,
     `ℹ️` = "Largest observed is {largest_flipper_length} mm."
   ) %>%
   info_snippet(
@@ -338,7 +338,7 @@ We can take portions of text and present them as labels. These will help you cal
 informant_pp <-
   informant_pp %>%
   info_columns(
-    columns = vars(body_mass_g), 
+    columns = body_mass_g, 
     `ℹ️` = "An integer denoting body mass."
   ) %>%
   info_columns(
@@ -396,7 +396,7 @@ Continuing with our **palmerpenguins** reporting, we'll add some more *info text
 informant_pp <-
   informant_pp %>%
   info_columns(
-    columns = vars(sex), 
+    columns = sex, 
     `ℹ️` = "A [[factor]]<<text-decoration: underline;>> 
     denoting penguin sex (female or male)."
   ) %>%

--- a/vignettes/VALID-I.Rmd
+++ b/vignettes/VALID-I.Rmd
@@ -82,11 +82,11 @@ agent <-
     tbl_name = "small_table",
     label = "VALID-I Example No. 1"
   ) %>%
-  col_is_posix(vars(date_time)) %>%
-  col_vals_in_set(vars(f), set = c("low", "mid", "high")) %>%
-  col_vals_lt(vars(a), value = 10) %>%
-  col_vals_regex(vars(b), regex = "^[0-9]-[a-z]{3}-[0-9]{3}$") %>%
-  col_vals_between(vars(d), left = 0, right = 5000) %>%
+  col_is_posix(date_time) %>%
+  col_vals_in_set(f, set = c("low", "mid", "high")) %>%
+  col_vals_lt(a, value = 10) %>%
+  col_vals_regex(b, regex = "^[0-9]-[a-z]{3}-[0-9]{3}$") %>%
+  col_vals_between(d, left = 0, right = 5000) %>%
   interrogate()
 ```
 
@@ -147,11 +147,11 @@ agent <-
     label = "VALID-I Example No. 2",
     actions = al
   ) %>%
-  col_is_posix(vars(date_time)) %>%
-  col_vals_in_set(vars(f), set = c("low", "mid")) %>%
-  col_vals_lt(vars(a), value = 7) %>%
-  col_vals_regex(vars(b), regex = "^[0-9]-[a-w]{3}-[2-9]{3}$") %>%
-  col_vals_between(vars(d), left = 0, right = 4000) %>%
+  col_is_posix(date_time) %>%
+  col_vals_in_set(f, set = c("low", "mid")) %>%
+  col_vals_lt(a, value = 7) %>%
+  col_vals_regex(b, regex = "^[0-9]-[a-w]{3}-[2-9]{3}$") %>%
+  col_vals_between(d, left = 0, right = 4000) %>%
   interrogate()
 ```
 
@@ -204,11 +204,11 @@ agent <-
     label = "VALID-I Example No. 3",
     actions = al
   ) %>%
-  col_is_posix(vars(date_time)) %>%
-  col_vals_in_set(vars(f), set = c("low", "mid")) %>%
-  col_vals_lt(vars(a), value = 7) %>%
-  col_vals_regex(vars(b), regex = "^[0-9]-[a-w]{3}-[2-9]{3}$") %>%
-  col_vals_between(vars(d), left = 0, right = 4000) %>%
+  col_is_posix(date_time) %>%
+  col_vals_in_set(f, set = c("low", "mid")) %>%
+  col_vals_lt(a, value = 7) %>%
+  col_vals_regex(b, regex = "^[0-9]-[a-w]{3}-[2-9]{3}$") %>%
+  col_vals_between(d, left = 0, right = 4000) %>%
   interrogate()
 ```
 
@@ -267,7 +267,7 @@ The message in the console shows us what's available in `x`, with some indicatio
 glue::glue(
   "In Step {x$i}, there were {x$n} test units and {x$f_failed * 100}% \\
   failed. STOP condition met: {tolower(x$stop)}."
-  )
+)
 ```
 
 ```

--- a/vignettes/VALID-II.Rmd
+++ b/vignettes/VALID-II.Rmd
@@ -19,11 +19,11 @@ Let's adapt an example used in the [*VALID-I: Data Quality Reporting Workflow*](
 
 ```{r error=TRUE, paged.print=FALSE}
 small_table %>%
-  col_is_posix(vars(date_time)) %>%
-  col_vals_in_set(vars(f), set = c("low", "mid", "high")) %>%
-  col_vals_lt(vars(a), value = 10) %>%
-  col_vals_regex(vars(b), regex = "^[0-9]-[a-z]{3}-[0-9]{3}$") %>%
-  col_vals_between(vars(d), left = 0, right = 5000)
+  col_is_posix(date_time) %>%
+  col_vals_in_set(f, set = c("low", "mid", "high")) %>%
+  col_vals_lt(a, value = 10) %>%
+  col_vals_regex(b, regex = "^[0-9]-[a-z]{3}-[0-9]{3}$") %>%
+  col_vals_between(d, left = 0, right = 5000)
 ```
 
 In terms of the expressions used in the pipeline, you might notice that the `create_agent()` and `interrogate()` functions are absent. This is due to the secondary role of the validation functions, where they can operate directly and immediately on the data, acting as a sort of filter. If all validations in this pipeline pass (i.e., there are no failing test units in any of the validation steps), then the `small_table` data is returned. Otherwise, as it's currently written, a stoppage will occur on any such failure.
@@ -41,23 +41,23 @@ There are two helper functions that are convenient for this workflow: `warn_on_f
 ```{r error=TRUE, paged.print=FALSE}
 small_table %>%
   col_is_posix(
-    vars(date_time),
+    date_time,
     actions = stop_on_fail(stop_at = 1)
   ) %>%
   col_vals_in_set(
-    vars(f), set = c("low", "mid", "high"),
+    f, set = c("low", "mid", "high"),
     actions = stop_on_fail(stop_at = 1)
   ) %>%
   col_vals_lt(
-    vars(a), value = 10,
+    a, value = 10,
     actions = stop_on_fail(stop_at = 1)
   ) %>%
   col_vals_regex(
-    vars(b), regex = "^[0-9]-[a-z]{3}-[0-9]{3}$",
+    b, regex = "^[0-9]-[a-z]{3}-[0-9]{3}$",
     actions = stop_on_fail(stop_at = 1)
   ) %>%
   col_vals_between(
-    vars(d), left = 0, right = 5000,
+    d, left = 0, right = 5000,
     actions = stop_on_fail(stop_at = 1)
   )
 ```
@@ -67,23 +67,23 @@ If we want to instead issue warnings, perhaps with less stringent failure thresh
 ```{r warn=TRUE, paged.print=FALSE}
 small_table %>%
   col_is_posix(
-    vars(date_time),
+    date_time,
     actions = warn_on_fail()
   ) %>%
   col_vals_in_set(
-    vars(f), set = c("low", "mid", "high"),
+    f, set = c("low", "mid", "high"),
     actions = warn_on_fail(warn_at = 0.2)
   ) %>%
   col_vals_lt(
-    vars(a), value = 10,
+    a, value = 10,
     actions = warn_on_fail(warn_at = 3)
   ) %>%
   col_vals_regex(
-    vars(b), regex = "^[0-9]-[a-z]{3}-[0-9]{3}$",
+    b, regex = "^[0-9]-[a-z]{3}-[0-9]{3}$",
     actions = warn_on_fail(warn_at = 0.2)
   ) %>%
   col_vals_between(
-    vars(d), left = 0, right = 5000,
+    d, left = 0, right = 5000,
     actions = warn_on_fail(warn_at = 1)
   )
 ```
@@ -122,11 +122,11 @@ Finally, we will apply this object to every validation function call in the expr
 
 ```{r error=TRUE, paged.print=FALSE}
 small_table %>%
-  col_is_posix(vars(date_time), actions = al) %>%
-  col_vals_in_set(vars(f), set = c("low", "mid"), actions = al) %>%
-  col_vals_lt(vars(a), value = 7, actions = al) %>%
-  col_vals_regex(vars(b), regex = "^[0-9]-[a-w]{3}-[2-9]{3}$", actions = al) %>%
-  col_vals_between(vars(d), left = 0, right = 4000, actions = al)
+  col_is_posix(date_time, actions = al) %>%
+  col_vals_in_set(f, set = c("low", "mid"), actions = al) %>%
+  col_vals_lt(a, value = 7, actions = al) %>%
+  col_vals_regex(b, regex = "^[0-9]-[a-w]{3}-[2-9]{3}$", actions = al) %>%
+  col_vals_between(d, left = 0, right = 4000, actions = al)
 ```
 
 In addition to an error and a warning, the `log4r_step()` function used for the `NOTIFY` condition generates, in this case, a new `"pb_log_file"` text file for logs. We can examine it with `readLines()`; it has a single entry that relates to `Step 1` (the `col_vals_in_set()` step):

--- a/vignettes/VALID-III.Rmd
+++ b/vignettes/VALID-III.Rmd
@@ -66,7 +66,7 @@ There is no **testthat** function that tests for values between two values. The 
 The **pointblank** version of this task makes for a more succinct and understandable expectation expression:
 
 ```{r}
-expect_col_vals_between(small_table, vars(c), 2, 9, na_pass = TRUE)
+expect_col_vals_between(small_table, c, 2, 9, na_pass = TRUE)
 ```
 
 The arguments in the `expect_col_vals_between()` give us everything we need to check tabular data without having to do subsetting and perform other transformations. There are a few added benefits. Should data come from a data source other than a local data frame, the SQL expressions are handled internally and they have been tested extensively across all the supported database types and in Spark DataFrames as well.

--- a/vignettes/VALID-IV.Rmd
+++ b/vignettes/VALID-IV.Rmd
@@ -223,19 +223,19 @@ If you'd like to test your **pointblank** validation skill, guess whether each o
 
 
 ```{r echo=FALSE, eval=FALSE}
-small_table %>% test_col_is_logical(vars(e))
+small_table %>% test_col_is_logical(e)
 ```
 
 ```{r echo=FALSE, eval=FALSE}
-small_table %>% test_col_vals_between(vars(c), left = 1, right = 10)
+small_table %>% test_col_vals_between(c, left = 1, right = 10)
 ```
 
 ```{r echo=FALSE, eval=FALSE}
-small_table %>% test_col_vals_between(vars(c), left = 0, right = vars(d), na_pass = TRUE, threshold = 0.5)
+small_table %>% test_col_vals_between(c, left = 0, right = vars(d), na_pass = TRUE, threshold = 0.5)
 ```
 
 ```{r echo=FALSE, eval=FALSE}
-small_table %>% test_col_vals_between(vars(c), left = 0, right = vars(d), na_pass = TRUE, threshold = 3)
+small_table %>% test_col_vals_between(c, left = 0, right = vars(d), na_pass = TRUE, threshold = 3)
 ```
 
 ```{r echo=FALSE, eval=FALSE}
@@ -243,21 +243,21 @@ small_table %>% test_col_schema_match(col_schema(.tbl = small_table_sqlite()))
 ```
 
 ```{r echo=FALSE, eval=FALSE}
-small_table %>% test_col_vals_in_set(vars(a), set = 1:10)
+small_table %>% test_col_vals_in_set(a, set = 1:10)
 ```
 
 ```{r echo=FALSE, eval=FALSE}
-small_table %>% test_col_vals_regex(vars(b), regex = ".-[a-z]{3}.*")
+small_table %>% test_col_vals_regex(b, regex = ".-[a-z]{3}.*")
 ```
 
 ```{r echo=FALSE, eval=FALSE}
-small_table %>% test_col_exists(columns = "g")
+small_table %>% test_col_exists(g)
 ```
 
 ```{r echo=FALSE, eval=FALSE}
 small_table %>% 
   test_col_vals_gt(
-    vars(z), value = vars(a),
+    z, value = vars(a),
     preconditions = ~ . %>% dplyr::mutate(z = c + e), threshold = 0.5
   )
 ```

--- a/vignettes/VALID-VI.Rmd
+++ b/vignettes/VALID-VI.Rmd
@@ -26,8 +26,8 @@ To start things off, here's an example that uses an expression that takes the `s
 
 ```{r validate = TRUE}
 small_table %>% 
-  col_is_date("date") %>% 
-  col_vals_in_set(vars(f), set = c("low", "mid"))
+  col_is_date(date) %>% 
+  col_vals_in_set(f, set = c("low", "mid"))
 ```
 
 Clicking the above `1 validation failed.` button will reveal that the *expression* failed validation because of a validation function failing within it. If you break it down, really one validation step in the chain passed (the first one) and one failed (the second). If there were additional validation steps that would otherwise pass, we'd still get the same result and output because the failing step ends execution.
@@ -38,7 +38,7 @@ Because this workflow is meant to stop an expression from executing at the first
 
 ```{r validate = TRUE}
 col_is_date(small_table, "date")
-col_vals_in_set(small_table, vars(f), set = c("low", "mid"))
+col_vals_in_set(small_table, f, set = c("low", "mid"))
 ```
 
 It still says that `1 validation failed.` (this workflow focuses on the negatives) but pressing the button reveals that the first one passed and the second failed. This is much clearer and we don't run the risk of not evaluating validations because a validation failed earlier in a pipeline.
@@ -48,12 +48,12 @@ Here's an example where all validations in individual expressions pass, showing 
 <img src="images/code_block_3.png" />
 
 ```{r validate = TRUE}
-col_is_date(small_table, "date")
-col_is_posix(small_table, vars(date_time))
-col_vals_in_set(small_table, vars(f), set = c("low", "mid", "high"))
-col_vals_lt(small_table, vars(a), value = 10)
-col_vals_regex(small_table, vars(b), regex = "^[0-9]-[a-z]{3}-[0-9]{3}$")
-col_vals_between(small_table, vars(d), left = 0, right = 10000)
+col_is_date(small_table, date)
+col_is_posix(small_table, date_time)
+col_vals_in_set(small_table, f, set = c("low", "mid", "high"))
+col_vals_lt(small_table, a, value = 10)
+col_vals_regex(small_table, b, regex = "^[0-9]-[a-z]{3}-[0-9]{3}$")
+col_vals_between(small_table, d, left = 0, right = 10000)
 ```
 
 It's worth reminding at this point that failed validations do not stop execution of the R Markdown rendering. Otherwise you wouldn't see a document with any failing validations, and, you wouldn't know where those failed validations occurred. The expectation for this workflow is to add in the relevant validation expressions at key junctures and should any failures occur, one can fix the underlying issues until all (or enough) validations pass.
@@ -92,11 +92,11 @@ create_agent(
     label = "VALID-I Example No. 2",
     actions = al
   ) %>%
-  col_is_posix(vars(date_time)) %>%
-  col_vals_in_set(vars(f), set = c("low", "mid")) %>%
-  col_vals_lt(vars(a), value = 7) %>%
-  col_vals_regex(vars(b), regex = "^[0-9]-[a-w]{3}-[2-9]{3}$") %>%
-  col_vals_between(vars(d), left = 0, right = 4000) %>%
+  col_is_posix(date_time) %>%
+  col_vals_in_set(f, set = c("low", "mid")) %>%
+  col_vals_lt(a, value = 7) %>%
+  col_vals_regex(b, regex = "^[0-9]-[a-w]{3}-[2-9]{3}$") %>%
+  col_vals_between(d, left = 0, right = 4000) %>%
   interrogate()
 ```
 


### PR DESCRIPTION
This should standardize all uses of `columns = vars(col)` and `columns = "col"` to `columns = col` !