### PR TITLE
Don't resolve columns with tidyselect when `tbl` cannot be materialized

### DIFF
--- a/R/utils-tidyselect.R
+++ b/R/utils-tidyselect.R
@@ -36,12 +36,12 @@ resolve_columns <- function(x, var_expr, preconditions = NULL, ...,
 apply_preconditions_for_cols <- function(x, preconditions) {
   # Extract tbl
   tbl <- if (is_ptblank_agent(x)) {
-    get_tbl_object(x)
+    tryCatch(get_tbl_object(x), error = function(...) NULL)
   } else if (is_a_table_object(x)) {
     x
   }
   # Apply preconditions
-  if (!is.null(preconditions)) {
+  if (!is.null(tbl) && !is.null(preconditions)) {
     tbl <- apply_preconditions(tbl = tbl, preconditions = preconditions)
   }
   tbl

--- a/R/utils-tidyselect.R
+++ b/R/utils-tidyselect.R
@@ -1,12 +1,17 @@
 resolve_columns <- function(x, var_expr, preconditions = NULL, ...,
                             call = rlang::caller_env()) {
   
+  # If columns is just character vector, pass it through
+  if (rlang::is_character(rlang::quo_get_expr(var_expr))) {
+    return(rlang::eval_tidy(var_expr))
+  }
+  
   # Materialize table and apply preconditions for tidyselect
   tbl <- apply_preconditions_for_cols(x, preconditions)
   
   # If tbl cannot (yet) materialize, don't attempt tidyselect and return early
   if (is.null(tbl)) {
-    return(resolve_columns_notidyselect(var_expr))
+    return(resolve_columns_notidyselect(var_expr, call = call))
   }
   
   # Attempt tidyselect

--- a/R/utils-tidyselect.R
+++ b/R/utils-tidyselect.R
@@ -73,7 +73,7 @@ apply_preconditions_for_cols <- function(x, preconditions) {
     x
   }
   # Apply preconditions
-  if (!is.null(tbl) && !is.null(preconditions)) {
+  if (!rlang::is_error(tbl) && !is.null(preconditions)) {
     tbl <- apply_preconditions(tbl = tbl, preconditions = preconditions)
   }
   tbl

--- a/R/utils-tidyselect.R
+++ b/R/utils-tidyselect.R
@@ -1,8 +1,15 @@
 resolve_columns <- function(x, var_expr, preconditions = NULL, ...,
                             call = rlang::caller_env()) {
   
+  # Materialize table and apply preconditions for tidyselect
   tbl <- apply_preconditions_for_cols(x, preconditions)
   
+  # If tbl cannot (yet) materialize, don't attempt tidyselect and return early
+  if (is.null(tbl)) {
+    return(resolve_columns_notidyselect(var_expr))
+  }
+  
+  # Attempt tidyselect
   out <- tryCatch(
     expr = resolve_columns_internal(tbl, var_expr, ..., call = call),
     error = function(cnd) cnd
@@ -30,6 +37,25 @@ resolve_columns <- function(x, var_expr, preconditions = NULL, ...,
   
   out
   
+}
+
+resolve_columns_notidyselect <- function(var_expr, call) {
+  # Error if attempting to tidyselect on a lazy tbl that cannot materialize
+  var_str <- rlang::expr_deparse(rlang::quo_get_expr(var_expr))
+  if (any(sapply(names(tidyselect::vars_select_helpers), grepl, var_str))) {
+    rlang::abort(
+      "Cannot use tidyselect helpers for an undefined lazy tbl.",
+      call = call
+    )
+  }
+  
+  # Force column selection to character vector
+  if (rlang::quo_is_symbol(var_expr)) {
+    var_expr <- rlang::as_name(var_expr)
+  } else if (rlang::quo_is_call(var_expr, c("vars", "c"))) {
+    var_expr <- rlang::quo_set_expr(var_expr, vars_to_c(var_expr))
+  }
+  rlang::eval_tidy(var_expr)
 }
 
 # Apply the preconditions function and resolve to data frame for tidyselect


### PR DESCRIPTION
## Summary

`{tidyselect}` requires a data frame present in order to resolve the column selections against. Therefore, this PR ensures that when `create_agent(tbl = )` receives a table that cannot (yet) materialize, the validation steps dont't/can't use tidyselect.

This preserves `v0.11` behavior, where use of tidyselect triggers materialization of the tbl and thus always errors if tbl cannot (yet) materialize:

```r
# remotes::install_github("rstudio/pointblank@v0.11.0")
create_agent(~blah) %>% rows_distinct(columns = starts_with("x"))
#> Error: object 'blah' not found
``` 

In the PR, this now errors with a slightly more informative message:

```r
create_agent(~blah) %>% rows_distinct(columns = starts_with("x"))
#> Error in `rows_distinct()`:
#> ! Cannot use tidyselect helpers for an undefined lazy tbl.
#> Caused by error:
#> ! object 'blah' not found
#> Run `rlang::last_trace()` to see where the error occurred.
```

Relatedly, the PR also allows the bypassing of tidyselect when tidyselect is not strictly necessary (e.g., when `columns` is a character vector). This resolves #528 by not forwarding the `c(...)` character vector to tidyselect at all.

```r
agent1 <- create_agent(~undefined_df) |>
  col_exists(c("cyl", "vs", "am", "gear", "carb"))
get_agent_report(agent1, display_table = FALSE)[, 1:3]
#> # A tibble: 5 × 3
#>       i type       columns
#>   <int> <chr>      <chr>  
#> 1     1 col_exists cyl    
#> 2     2 col_exists vs     
#> 3     3 col_exists am     
#> 4     4 col_exists gear   
#> 5     5 col_exists carb
```

In sum, `{tidyselect}` support in columns is a lot more limited when the `tbl` cannot be materialized, but this is inevitable. This behavior already existed in `v0.11` and it's just a genuine tradeoff users will have to make if they want an extreme version of laziness for their `tbl`.

## Remaining consideration with `rows_distinct()`

Unfortunately, there is one regression with `rows_distinct()`, because in `v0.12` we have the `columns = everything()` default, whereas in `v0.11` we had the `columns = NULL` default. When the `tbl` cannot be materialized, `rows_distinct()` errors on `v0.12` but passes through in `v0.11`.

More concretely put, this used to work in `v0.11` but not anymore in `v0.12`:

```r
agent <- create_agent(~x) %>% 
  rows_distinct()
x <- mtcars
interrogate(agent)
```

This behavior actually doesn't have anything to do with `{tidyselect}` though: `rows_distinct()` is exceptional in that `columns = NULL` becomes `distinct({{ NULL }})` in `interrogate()`, and `distinct(NULL)` happens to have a special behavior of checking for row-level distinctness across all columns. In other words, `NULL` is never resolved to a column selection, which is also why `rows_distinct()` used to not show anything in the `columns` column of the agent report.

**I have yet to add this behavior of `rows_distinct()` back in**. Adding back support for this should be simple (we'd just intercept `everything()` and pass down `NULL` instead) - it'd just require being explicit about this exceptionalism of `rows_distinct()` in the code.

Also, just to reiterate, this extreme laziness will always work if `columns` is supplied as character vector or `vars()`; it's just the dynamic tidyselect expression that requires `tbl` to be materialize-able.

Let me know what you think!