### PR TITLE
Ensure column string is symbol before constructing expression for `col_vals_*()` functions

### DIFF
--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -1086,10 +1086,6 @@ interrogate_comparison <- function(
   # Normalize a column in `vars()` to a `name` object
   if (inherits(value, "list")) {
     value <- value[1][[1]] %>% rlang::get_expr()
-  } else {
-    if (is.character(value)) {
-      value <- paste0("'", value, "'")
-    }
   }
   
   # Obtain the target column as a label

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -1132,20 +1132,20 @@ tbl_val_comparison <- function(
   )
   
   # Construct a string-based expression for the validation
-  expression <- paste(column, operator, value)
+  expression <- call(operator, as.symbol(column), value)
   
   if (is_tbl_mssql(table)) {
     
     table %>%
       dplyr::mutate(pb_is_good_ = dplyr::case_when(
-        !!rlang::parse_expr(expression) ~ 1,
+        !!expression ~ 1,
         TRUE ~ 0
       ))
     
   } else {
     
     table %>%
-      dplyr::mutate(pb_is_good_ = !!rlang::parse_expr(expression)) %>%
+      dplyr::mutate(pb_is_good_ = !!expression) %>%
       dplyr::mutate(pb_is_good_ = dplyr::case_when(
         is.na(pb_is_good_) ~ na_pass,
         TRUE ~ pb_is_good_


### PR DESCRIPTION
Resolves #530 

This PR preserves columns as symbols in the internal `tbl_val_comparison()` function.

Instead of creating an expression out of this string:

```r
"column name < 1000"
```

We now immediately evaluate to the correct expression, using `call()`:

```r
`column name` < 1000
```

Reprex:

```r
agent <- mtcars |> 
  dplyr::rename(`disp units` = disp) |>
  create_agent() |> 
  col_vals_lt(`disp units`, 1000) |>
  interrogate()
#> 
#> ── Interrogation Started - there is a single validation step ──────────────────
#> ✔ Step 1: OK.
#> 
#> ── Interrogation Completed ────────────────────────────────────────────────────
get_agent_report(agent, display_table = FALSE)
#> # A tibble: 1 × 14
#>       i type       columns values precon active eval  units n_pass f_pass W    
#>   <int> <chr>      <chr>   <chr>  <chr>  <lgl>  <chr> <dbl>  <dbl>  <dbl> <lgl>
#> 1     1 col_vals_… disp u… 1000   <NA>   TRUE   OK       32     32      1 NA   
#> # ℹ 3 more variables: S <lgl>, N <lgl>, extract <int>
```