### PR TITLE
Preserve classes when reading from `validation_set$values`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - Fixed a regression in `col_vals_*()` functions, where `vars("col")` was evaluating to the string `"col"`. Behavior of `vars("col")` is now aligned back with `vars(col)` - both evaluate to the column name `col`.
 
+- Warnings/errors arising from comparing `columns` to a `value` of different class (for example, comparing a datetime column to a date value `Sys.Date()` instead of another datetime value `Sys.time()`) are now signalled appropriately at `interrogate()`.
+
 # pointblank 0.12.1
 
 - Ensured that the column string is a symbol before constructing the expression for the `col_vals_*()` functions.

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -1436,10 +1436,10 @@ interrogate_set <- function(
       }
       
       extra_variables <- 
-        base::setdiff(table_col_distinct_values, set)
+        table_col_distinct_values[!table_col_distinct_values %in% set]
       
       table_col_distinct_set <-
-        base::intersect(table_col_distinct_values, set)
+        table_col_distinct_values[table_col_distinct_values %in% set]
 
       dplyr::bind_rows(
         dplyr::tibble(set_element = as.character(set)) %>%
@@ -1511,7 +1511,7 @@ interrogate_set <- function(
       }
       
       table_col_distinct_set <-
-        base::intersect(table_col_distinct_values, set)
+        table_col_distinct_values[table_col_distinct_values %in% set]
       
       dplyr::tibble(set_element = as.character(set)) %>%
         dplyr::left_join(

--- a/R/utils.R
+++ b/R/utils.R
@@ -171,7 +171,7 @@ get_values_at_idx <- function(agent, idx) {
   
   # Expressions (via `col_vals_expr()`) and functions (via `specially()`)
   # can get the old `unlist()` treatment
-  if (rlang::is_expression(values[[1]]) | rlang::is_function(values[[1]])) {
+  if (rlang::is_expression(values[[1]]) || rlang::is_function(values[[1]])) {
     values <- unlist(values, recursive = FALSE)
   } else {
     # In other cases (e.g., `values`, `left`, `right`), flatten with subsetting

--- a/R/utils.R
+++ b/R/utils.R
@@ -165,7 +165,21 @@ get_column_as_sym_at_idx <- function(agent, idx) {
 }
 
 get_values_at_idx <- function(agent, idx) {
-  agent$validation_set[[idx, "values"]] %>% unlist(recursive = FALSE)
+  
+  # Get list-column element (`values` is always a length-1 list)
+  values <- agent$validation_set[[idx, "values"]]
+  
+  # Expressions (via `col_vals_expr()`) and functions (via `specially()`)
+  # can get the old `unlist()` treatment
+  if (rlang::is_expression(values[[1]]) | rlang::is_function(values[[1]])) {
+    values <- unlist(values, recursive = FALSE)
+  } else {
+    # In other cases (e.g., `values`, `left`, `right`), flatten with subsetting
+    # to preserve class
+    values <- values[[1]]
+  }
+  
+  values
 }
 
 get_column_na_pass_at_idx <- function(agent, idx) {

--- a/tests/testthat/test-interrogate_simple.R
+++ b/tests/testthat/test-interrogate_simple.R
@@ -2133,3 +2133,25 @@ test_that("vars(col) and vars('col') both evaluate to tbl column", {
   expect_true(test_col_vals_gt(df, x, vars("y")))
 
 })
+
+test_that("class preserved in `value`", {
+  
+  # A custom class with a `==` method that simply errors
+  custom_val <- structure(1L, class = "pb-test-custom-class")
+  registerS3method(
+    "==", "pb-test-custom-class", function(x, ...) stop("Bad class for `==`")
+  )
+  
+  # We expect error (class preserved) vs. TRUE (class stripped)
+  expect_error(custom_val == 1L)
+  expect_true(unclass(custom_val) == 1L)
+  
+  # Error is correctly thrown and safely caught at interrogate
+  expect_no_error({
+    agent <- create_agent(data.frame(col = custom_val)) %>% 
+      col_vals_equal(columns = col, value = 1L) %>% 
+      interrogate()
+  })
+  expect_true(agent$validation_set$eval_error)
+  
+})


### PR DESCRIPTION
# Summary

This PR preserves the class of `value` where possible. Two consequences:

1) When `value` and `column` are not of the same class (and thus their interaction is not well defined), the associated warning/error now gets to be produced at `interrogate()`, which shows up at interrogate/report. Using a modified reprex from #536:

```r
# NOTE: {lubridate} not loaded for this chunk
devtools::load_all()

df <- data.frame(
  date = Sys.Date() + 1,
  datetime = Sys.time() + 1
)

agent_base_loaded <- create_agent(df) |> 
  col_vals_lte(datetime, Sys.Date()) |> 
  col_vals_lte(date, Sys.Date()) |>
  interrogate(show_step_label = TRUE)
#> 
#> ── Interrogation Started - there are 2 steps ──────────────────────────────────
#> ℹ Step 1: an evaluation issue requires attention (WARNING).
#> ✔ Step 2: OK.
#> 
#> ── Interrogation Completed ────────────────────────────────────────────────────

agent_base_loaded$validation_set$capture_stack[[1]]$warning
#> <warning/rlang_warning>
#> Warning:
#> There was 1 warning in `dplyr::mutate()`.
#> ℹ In argument: `pb_is_good_ = datetime <= structure(19887, class = "Date")`.
#> Caused by warning:
#> ! Incompatible methods ("Ops.POSIXt", "Ops.Date") for "<="
```

2. When methods are defined for the class, they get used by pointblank at `interrogate()`. So if we define the same agent *after* `{lubridate}` has been loaded, we get the more sensible behavior for comparing datetime to date:

```r
library(lubridate)

# Loading lubridate puts the custom method `<=.POSIXt` on the search path,
# which overrides the problematic `Ops.POSIXt` method from base
sloop::s3_dispatch(df$datetime <= Sys.Date())
#>    <=.POSIXct
#> => <=.POSIXt
#>    <=.default
#>    Ops.POSIXct
#> -> Ops.POSIXt
#>    Ops.default
#> -> <= (internal)

# This is picked up on evaluation - datetime can now be compared with date without warning
agent_lubridate_loaded <- create_agent(df) |> 
  col_vals_lte(datetime, Sys.Date()) |> 
  col_vals_lte(date, Sys.Date()) |>
  interrogate(show_step_label = TRUE)
#> 
#> ── Interrogation Started - there are 2 steps ──────────────────────────────────
#> ✔ Step 1: OK.
#> ✔ Step 2: OK.
#> 
#> ── Interrogation Completed ────────────────────────────────────────────────────
```

# Implementational details

This PR ensures that reading from `validation_set$values` in the internal function `get_values_at_idx()` preserves class of the values. This is done by simply replacing `unlist(recursive = FALSE)` with subsetting `[[1]]` to this avoids the attribute-stripping behavior of `unlist()`:

```r
unlist(list(Sys.Date()), recursive = FALSE)
#> [1] 19887
```

Relatedly, the PR also includes a small surgery on `interrogate_set()` to avoid set operation functions since those strip attributes as well. These have been refactored to use subsetting (`x[x %in% y]`, etc.).

```r
intersect(Sys.Date() + 1:2, Sys.Date() + 2:3)
#> [1] 19889
```

# Related GitHub Issues and PRs

- Ref: #536, #537

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/pointblank/blob/main/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/pointblank/tree/main/tests/testthat) for any new functionality.
