### PR TITLE
Transition to `rlang::list2()` for collecting dots in user-facing functions

### DIFF
--- a/R/col_schema_match.R
+++ b/R/col_schema_match.R
@@ -617,7 +617,7 @@ col_schema <- function(
   
   db_col_types <- match.arg(.db_col_types)
 
-  x <- list(...)
+  x <- rlang::list2(...)
 
   # Transform SQL column types to lowercase to allow
   # both uppercase and lowercase conventions while

--- a/R/create_multiagent.R
+++ b/R/create_multiagent.R
@@ -159,7 +159,7 @@ create_multiagent <- function(
     locale = NULL
 ) {
   
-  agent_list <- list(...)
+  agent_list <- rlang::list2(...)
   if (!all(sapply(agent_list, is_ptblank_agent))) {
     rlang::abort("All components of `...` must be an agent")
   }

--- a/R/info_add.R
+++ b/R/info_add.R
@@ -193,7 +193,7 @@ info_tabular <- function(
     ...
 ) {
   
-  metadata_items <- list(...)
+  metadata_items <- rlang::list2(...)
   
   metadata <- x
   
@@ -442,7 +442,7 @@ info_columns <- function(
   # Capture the `columns` expression
   columns <- rlang::enquo(columns)
   
-  metadata_items <- list(...)
+  metadata_items <- rlang::list2(...)
   
   metadata <- x
   
@@ -892,7 +892,7 @@ info_section <- function(
     ...
 ) {
   
-  metadata_items <- list(...)
+  metadata_items <- rlang::list2(...)
   
   metadata <- x
   

--- a/R/validate_rmd.R
+++ b/R/validate_rmd.R
@@ -641,7 +641,7 @@ knitr_chunk_hook <- function(x, options) {
 #' @export
 stop_if_not <- function(...) {
   
-  res <- list(...)
+  res <- rlang::list2(...)
   
   n <- length(res)
   


### PR DESCRIPTION
This PR simply replaces 6 cases of collecting dots with `list(...)` in user-facing functions. This allows users to splice with `!!!` (#552) and also name arguments programmatically with `:=` (which I think could be useful for `col_schema()`)