### PR TITLE
Option to drop `tbl_checked` information

### DIFF
--- a/R/get_sundered_data.R
+++ b/R/get_sundered_data.R
@@ -268,6 +268,14 @@ get_sundered_data <- function(
     )
   }
   
+  # Stop function if `tbl_checked` is not present
+  if (!"tbl_checked" %in% colnames(agent$validation_set)) {
+    stop(
+      "`agent` is missing `tbl_checked` information required for sundering. ",
+      "See `?interrogate`."
+    )
+  }
+  
   # Get the row count of the input table
   row_count_input_tbl <- 
     input_tbl %>%

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -44,6 +44,15 @@
 #'   The default is `TRUE` and further options allow for fine control of how
 #'   these rows are collected.
 #'   
+#' @param extract_tbl_checked *Collect validation results from each step*
+#' 
+#'   `scalar<logical>` // *default:* `TRUE`
+#' 
+#'   An option to collect processed data frames produced by executing the
+#'   validation steps. This information is necessary for some functions
+#'   (e.g., `get_sundered_data()`), but may grow to a large size. To opt out
+#'   of attaching this data to the agent, set this argument to `FALSE`.
+#'   
 #' @param get_first_n *Get the first n values*
 #' 
 #'   `scalar<integer>` // *default:* `NULL` (`optional`)
@@ -143,6 +152,7 @@
 interrogate <- function(
     agent,
     extract_failed = TRUE,
+    extract_tbl_checked = TRUE,
     get_first_n = NULL,
     sample_n = NULL,
     sample_frac = NULL,
@@ -728,6 +738,11 @@ interrogate <- function(
   # Bestowing of the class `"has_intel"` to the agent, given that
   # all validation steps have been carried out
   class(agent) <- c("has_intel", "ptblank_agent")
+  
+  # Drop $tbl_checked if `extract_tbl_checked = FALSE`
+  if (!extract_tbl_checked) {
+    agent$validation_set$tbl_checked <- NULL
+  }
   
   # Add the ending time to the `agent` object
   agent$time_end <- Sys.time()

--- a/man/interrogate.Rd
+++ b/man/interrogate.Rd
@@ -7,6 +7,7 @@
 interrogate(
   agent,
   extract_failed = TRUE,
+  extract_tbl_checked = TRUE,
   get_first_n = NULL,
   sample_n = NULL,
   sample_frac = NULL,
@@ -30,6 +31,15 @@ the \code{\link[=create_agent]{create_agent()}} function.}
 An option to collect rows that didn't pass a particular validation step.
 The default is \code{TRUE} and further options allow for fine control of how
 these rows are collected.}
+
+\item{extract_tbl_checked}{\emph{Collect validation results from each step}
+
+\verb{scalar<logical>} // \emph{default:} \code{TRUE}
+
+An option to collect processed data frames produced by executing the
+validation steps. This information is necessary for some functions
+(e.g., \code{get_sundered_data()}), but may grow to a large size. To opt out
+of attaching this data to the agent, set this argument to \code{FALSE}.}
 
 \item{get_first_n}{\emph{Get the first n values}
 

--- a/tests/testthat/test-sundering.R
+++ b/tests/testthat/test-sundering.R
@@ -548,3 +548,23 @@ test_that("an error occurs if using `get_sundered_data()` when agent has no inte
       get_sundered_data()
   )
 })
+
+test_that("an error occurs if using `get_sundered_data()` when agent is missing `$tbl_checked`", {
+  
+  # Expect an error if the agent performed an interrogation
+  # with `extract_tbl_checked = FALSE`
+  expect_error(
+    create_agent(tbl = small_table) %>%
+      col_vals_gt(vars(date_time), vars(date), na_pass = TRUE) %>%
+      col_vals_gt(vars(b), vars(g), na_pass = TRUE) %>%
+      rows_distinct(vars(d, e)) %>%
+      rows_distinct(vars(a, f)) %>%
+      col_vals_gt(vars(d), 100) %>%
+      col_vals_equal(vars(d), vars(d), na_pass = TRUE) %>%
+      col_vals_between(vars(c), left = vars(a), right = vars(d), na_pass = TRUE) %>%
+      interrogate(extract_tbl_checked = FALSE) %>% 
+      get_sundered_data(),
+    "missing `tbl_checked`"
+  )
+})
+


### PR DESCRIPTION
This PR adds an argument `interrogate(extract_tbl_checked = TRUE)`. When set to `FALSE`, `interrogate()` will simply drop the `$tbl_checked` column from the validation set before returning the agent.

```
#' @param extract_tbl_checked *Collect validation results from each step*
#' 
#'   `scalar<logical>` // *default:* `TRUE`
#' 
#'   An option to collect processed data frames produced by executing the
#'   validation steps. This information is necessary for some functions
#'   (e.g., `get_sundered_data()`), but may grow to a large size. To opt out
#'   of attaching this data to the agent, set this argument to `FALSE`.
```


As a complement, `get_sundered_data()` now errors early and more informatively if it receives an agent that's missing `tbl_checked`.

```r
df <- data.frame(x = 1)
agent <- create_agent(df) |> 
  col_vals_equal(x, 1) |> 
  interrogate(extract_tbl_checked = FALSE)
#> 
#> ── Interrogation Started - there is a single validation step ───
#> ✔ Step 1: OK.
#> 
#> ── Interrogation Completed ─────────────────────────────────────

agent |>
  get_sundered_data()
#> Error in get_sundered_data(agent): `agent` is missing `tbl_checked` information required for sundering. See `?interrogate`.
```
