### PR TITLE
Add `snip_list(na_rm)` argument

### DIFF
--- a/R/info_add.R
+++ b/R/info_add.R
@@ -1231,6 +1231,12 @@ info_snippet <- function(
 #'   derived from `character` or `factor` values; numbers, dates, and logical
 #'   values won't have quotation marks. We can explicitly use quotations (or
 #'   not) with either `TRUE` or `FALSE` here.
+#'   
+#' @param na_rm *Remove NA values from list*
+#' 
+#'   `scalar<logical>` // *default:* `FALSE`
+#' 
+#'   An option for whether NA values should be counted as an item in the list.
 #' 
 #' @param lang *Reporting language*
 #' 
@@ -1301,6 +1307,7 @@ snip_list <- function(
     oxford = TRUE,
     as_code = TRUE,
     quot_str = NULL,
+    na_rm = FALSE,
     lang = NULL
 ) {
 
@@ -1376,6 +1383,7 @@ snip_list <- function(
             oxford = <<oxford>>,
             as_code = <<as_code>>,
             quot_str = <<quot_str>>,
+            na_rm = <<na_rm>>,
             lang = <<lang>>
           )",
           .open = "<<", .close = ">>"   
@@ -1406,6 +1414,7 @@ snip_list <- function(
             oxford = <<oxford>>,
             as_code = <<as_code>>,
             quot_str = <<quot_str>>,
+            na_rm = <<na_rm>>,
             lang = <<lang>>
           )",
           .open = "<<", .close = ">>"   
@@ -1435,6 +1444,7 @@ snip_list <- function(
             oxford = <<oxford>>,
             as_code = <<as_code>>,
             quot_str = <<quot_str>>,
+            na_rm = <<na_rm>>,
             lang = <<lang>>
           )",
           .open = "<<", .close = ">>"   

--- a/R/utils.R
+++ b/R/utils.R
@@ -1221,10 +1221,15 @@ pb_str_catalog <- function(
     oxford = TRUE,
     as_code = TRUE,
     quot_str = NULL,
+    na_rm = FALSE,
     lang = NULL
 ) {
   
   if (is.null(lang)) lang <- "en"
+  
+  if (na_rm) {
+    item_vector <- item_vector[!is.na(item_vector)]
+  }
   
   item_count <- length(item_vector)
 

--- a/man/snip_list.Rd
+++ b/man/snip_list.Rd
@@ -14,6 +14,7 @@ snip_list(
   oxford = TRUE,
   as_code = TRUE,
   quot_str = NULL,
+  na_rm = FALSE,
   lang = NULL
 )
 }
@@ -89,6 +90,12 @@ An option for whether list items should be set in double quotes. If \code{NULL}
 derived from \code{character} or \code{factor} values; numbers, dates, and logical
 values won't have quotation marks. We can explicitly use quotations (or
 not) with either \code{TRUE} or \code{FALSE} here.}
+
+\item{na_rm}{\emph{Remove NA values from list}
+
+\verb{scalar<logical>} // \emph{default:} \code{FALSE}
+
+An option for whether NA values should be counted as an item in the list.}
 
 \item{lang}{\emph{Reporting language}
 

--- a/tests/testthat/test-snip_fns.R
+++ b/tests/testthat/test-snip_fns.R
@@ -511,6 +511,30 @@ test_that("the `snip_list()` function works", {
       small_table
     )
   )
+  
+  # na_rm ignores NA values in list
+  expect_match(
+    run_snip(
+      snip_list(column = "f", na_rm = FALSE),
+      small_table %>% dplyr::mutate(f = ifelse(f == "high", NA, f))
+    ),
+    "NA"
+  )
+  expect_no_match(
+    run_snip(
+      snip_list(column = "f", na_rm = TRUE),
+      small_table %>% dplyr::mutate(f = ifelse(f == "high", NA, f))
+    ),
+    "NA"
+  )
+  expect_equal(
+    run_snip(
+      snip_list(column = "f", na_rm = TRUE),
+      small_table %>% dplyr::mutate(f = NA)
+    ),
+    "---"
+  )
+  
 })
 
 test_that("the `snip_stats()` function works", {


### PR DESCRIPTION
This PR adds an option to `snip_list()` to control whether `NA` values are counted as an item in the list. This is implemented in `pb_str_catalog()` which receives `na_rm` passed down from `snip_list()`.

```r
# "high" coded as NA, ignored in report with `na_rm = TRUE`
small_table %>% 
  select(f) %>% 
  mutate(f = ifelse(f == "high", NA, f)) %>% 
  create_informant() %>% 
  info_columns(
    columns = f,
    `Items` = "This column contains {values_f}."
  ) %>%
  info_snippet(
    snippet_name = "values_f",
    fn = snip_list(column = "f", na_rm = TRUE)
  ) %>% 
  incorporate()
#> 
#> ── Incorporation Started - there is a single snippet to process ───
#> ✔ Information gathered.
#> ✔ Snippets processed.
#> ✔ Information built.
#> 
#> ── Incorporation Completed ────────────────────────────────────────
```

![image](https://github.com/user-attachments/assets/a2da6689-0883-4c8b-988b-8cac4fc58fe7)
