### PR TITLE
Update extra.css to avoid font too bold 

### DIFF
--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -1,5 +1,5 @@
 body {
-  font-family: ui-rounded, 'Hiragino Maru Gothic ProN', Quicksand, Comfortaa, Manjari, 'Arial Rounded MT', 'Arial Rounded MT Bold', Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  font-family: Inter, Roboto, 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', Arial, sans-serif;
 }
 
 code {


### PR DESCRIPTION
Commit similar to https://github.com/rstudio/gt/commit/e11b220eaffb75b65027bb3adabc5111175eb56b 

# Summary

The font looks too bold on the website. Applying the same fix as in gt.
![image](https://github.com/user-attachments/assets/61f530ac-5a70-4f87-849f-f330b821a0b8)

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [ ] I have listed any major changes in the [NEWS](https://github.com/rstudio/pointblank/blob/main/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/pointblank/tree/main/tests/testthat) for any new functionality.
