### PR TITLE
Use `check_installed()` + drop crayon from Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,8 +51,6 @@ Imports:
 Suggests:
     arrow,
     bigrquery,
-    covr,
-    crayon,
     data.table,
     duckdb,
     ggforce,

--- a/R/datasets.R
+++ b/R/datasets.R
@@ -73,18 +73,10 @@
 small_table_sqlite <- function() {
 
   # nocov start
-  
-  if (!requireNamespace("DBI", quietly = TRUE) &&
-      !requireNamespace("RSQLite", quietly = TRUE)) {
-    
-    stop(
-      "Creating the SQLite table object requires both the DBI and RSQLite ",
-      "packages:\n",
-      "* Install them with `install.packages(\"DBI\")` and ",
-      "`install.packages(\"RSQLite\")`.",
-      call. = FALSE
-    )
-  }
+  rlang::check_installed(
+    c("DBI", "RSQLite"),
+    "to create an SQLite table object."
+  )
   
   con <- 
     DBI::dbConnect(

--- a/R/logging.R
+++ b/R/logging.R
@@ -184,14 +184,7 @@ log4r_step <- function(
     append_to = "pb_log_file"
 ) {
   
-  if (!requireNamespace("log4r", quietly = TRUE)) {
-    
-    stop(
-      "Using the `log4r_step()` function requires the log4r package:\n",
-      "* It can be installed with `install.packages(\"log4r\")`.",
-      call. = FALSE
-    )
-  }
+  rlang::check_installed("log4r", "to use the `log4r_step()` function.")
   
   type <- x$this_type
   warn_val <- x$warn

--- a/R/scan_data.R
+++ b/R/scan_data.R
@@ -221,26 +221,10 @@ scan_data <- function(
   }
   
   if (any(c("interactions", "correlations") %in% sections)) {
-    
-    if (!requireNamespace("ggplot2", quietly = TRUE)) {
-      
-      stop(
-        "The `interactions` and `correlations` sections require ", 
-        "the ggplot2 package:\n",
-        "* It can be installed with `install.packages(\"ggplot2\")`.",
-        call. = FALSE
-      )
-    }
-    
-    if (!requireNamespace("ggforce", quietly = TRUE)) {
-      
-      stop(
-        "The `interactions` and `correlations` sections require ", 
-        "the ggforce package:\n",
-        "* It can be installed with `install.packages(\"ggforce\")`.",
-        call. = FALSE
-      )
-    }
+    rlang::check_installed(
+      c("ggforce", "ggplot2"),
+      "to use the `interactions` and `correlations` sections."
+    )
   }
   
   # Normalize the reporting language identifier and stop if necessary

--- a/R/table_transformers.R
+++ b/R/table_transformers.R
@@ -546,18 +546,7 @@ tt_time_shift <- function(
     time_shift = "0y 0m 0d 0H 0M 0S"
 ) {
   
-  # nocov start
-  
-  if (!requireNamespace("lubridate", quietly = TRUE)) {
-    
-    stop(
-      "The `tt_time_shift()` function requires the lubridate package:\n",
-      "* It can be installed with `install.packages(\"lubridate\")`.",
-      call. = FALSE
-    )
-  }
-  
-  # nocov end
+  rlang::check_installed("lubridate", "to use the `tt_time_shift()` function.")
   
   # Determine whether the `tbl` object is acceptable here
   check_is_a_table_object(tbl = tbl)
@@ -760,18 +749,7 @@ tt_time_slice <- function(
     arrange = FALSE
 ) {
   
-  # nocov start
-  
-  if (!requireNamespace("lubridate", quietly = TRUE)) {
-    
-    stop(
-      "The `tt_time_shift()` function requires the lubridate package:\n",
-      "* It can be installed with `install.packages(\"lubridate\")`.",
-      call. = FALSE
-    )
-  }
-  
-  # nocov end
+  rlang::check_installed("lubridate", "to use the `tt_time_slice()` function.")
   
   keep <- match.arg(keep)
   

--- a/R/tbl_from_db.R
+++ b/R/tbl_from_db.R
@@ -368,14 +368,7 @@ db_tbl <- function(
     dbname <- bq_project
   }
   
-  if (!requireNamespace("DBI", quietly = TRUE)) {
-    
-    stop(
-      "Accessing a database table requires the DBI package:\n",
-      "* It can be installed with `install.packages(\"DBI\")`.",
-      call. = FALSE
-    )
-  }
+  rlang::check_installed("DBI", "to access a database table.")
   
   if (is.character(dbtype)) {
     
@@ -523,72 +516,27 @@ db_tbl <- function(
 # nolint start
 
 RPostgres_driver <- function() {
-  
-  if (!requireNamespace("RPostgres", quietly = TRUE)) {
-    
-    stop(
-      "Accessing a PostgreSQL table requires the RPostgres package:\n",
-      "* It can be installed with `install.packages(\"RPostgres\")`.",
-      call. = FALSE
-    )
-  }
-  
+  rlang::check_installed("RPostgres", "to access a PostgreSQL table.")
   RPostgres::Postgres()
 }
 
 RMySQL_driver <- function() {
-  
-  if (!requireNamespace("RMySQL", quietly = TRUE)) {
-    
-    stop(
-      "Accessing a MariaDB or MySQL table requires the RMySQL package:\n",
-      "* It can be installed with `install.packages(\"RMySQL\")`.",
-      call. = FALSE
-    )
-  }
-  
+  rlang::check_installed("RMySQL", "to access a MariaDB or MySQL table.")
   RMySQL::MySQL()
 }
 
 bigrquery_driver <- function() {
-  
-  if (!requireNamespace("bigrquery", quietly = TRUE)) {
-    
-    stop(
-      "Accessing a BigQuery table requires the bigrquery package:\n",
-      "* It can be installed with `install.packages(\"bigrquery\")`.",
-      call. = FALSE
-    )
-  }
-  
+  rlang::check_installed("bigquery", "to access a BigQuery table.")
   bigrquery::bigquery()
 }
 
 DuckDB_driver <- function() {
-  
-  if (!requireNamespace("duckdb", quietly = TRUE)) {
-    
-    stop(
-      "Accessing a DuckDB table requires the duckdb package:\n",
-      "* It can be installed with `install.packages(\"duckdb\")`.",
-      call. = FALSE
-    )
-  }
-  
+  rlang::check_installed("duckdb", "to access a DuckDB table.")
   duckdb::duckdb()
 }
 
 RSQLite_driver <- function() {
-  
-  if (!requireNamespace("RSQLite", quietly = TRUE)) {
-    
-    stop(
-      "Accessing a SQLite table requires the RSQLite package:\n",
-      "* It can be installed with `install.packages(\"RSQLite\")`.",
-      call. = FALSE
-    )
-  }
-  
+  rlang::check_installed("RSQLite", "to access a SQLite table.")
   RSQLite::SQLite()
 }
 

--- a/R/tbl_from_file.R
+++ b/R/tbl_from_file.R
@@ -285,13 +285,7 @@ file_tbl <- function(
     verify = TRUE
 ) {
   
-  if (!requireNamespace("readr", quietly = TRUE)) {
-    stop(
-      "Reading a table from a file requires the readr package:\n",
-      " * It can be installed with `install.packages(\"readr\")`.",
-      call. = FALSE
-    )
-  }
+  rlang::check_installed("readr", "to read a table from a file.")
   
   file_extension <- tolower(tools::file_ext(file))
   file_name <- basename(file)
@@ -529,13 +523,7 @@ from_github <- function(
     
   } else if (grepl("#", repo, fixed = TRUE)) {
     
-    if (!requireNamespace("jsonlite", quietly = TRUE)) {
-      stop(
-        "Getting a table from a file in a PR requires the jsonlite package:\n",
-        " * It can be installed with `install.packages(\"jsonlite\")`.",
-        call. = FALSE
-      )
-    }
+    rlang::check_installed("jsonlite", "to get a table from a file in a PR.")
 
     pr_number <- unlist(strsplit(repo, "#"))[2]
     pulls_doc_tempfile <- tempfile(pattern = "pulls", fileext = ".json")

--- a/R/utils.R
+++ b/R/utils.R
@@ -1606,8 +1606,8 @@ cli_bullet_msg <- function(
   msg <- glue::glue_collapse(msg, "\n")
   msg <- glue::glue(msg, .envir = .envir)
   
-  if (!is.null(color) && requireNamespace("crayon", quietly = TRUE)) {
-    color_style <- crayon::make_style(color)
+  if (!is.null(color)) {
+    color_style <- cli::make_ansi_style(color)
     bullet <- color_style(bullet)
   }
 

--- a/R/validate_rmd.R
+++ b/R/validate_rmd.R
@@ -116,14 +116,7 @@ validate_rmd <- function(
   
   if (test_options$perform_logging) {
     
-    if (!requireNamespace("log4r", quietly = TRUE)) {
-      
-      stop(
-        "Using the `log4r_step()` function requires the log4r package:\n",
-        "* It can be installed with `install.packages(\"log4r\")`.",
-        call. = FALSE
-      )
-    }
+    rlang::check_installed("log4r", "to use the `log4r_step()` function.")
     
     # Create a log4r `logger` object and store it in `test_options`
     test_options$logger <- 


### PR DESCRIPTION
# Summary

`cli::make_ansi_style()` seems to be a drop-in replacement for `crayon::make_style()` ?

Also use `rlang::check_installed()` for handling missing packages.

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/pointblank/blob/main/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/pointblank/tree/main/tests/testthat) for any new functionality.
