### PR TITLE
Replace '$' char w/ HTML entity

### DIFF
--- a/R/get_agent_report.R
+++ b/R/get_agent_report.R
@@ -1187,15 +1187,18 @@ get_agent_report <- function(
           NA_character_
           
         } else {
-          
+
           text <-
-            values_i %>%
-            tidy_gsub(
-              "~",
-              "<span style=\"color: purple;\">&marker;</span>"
-            ) %>%
-            unname()
-          
+            unname(
+              tidy_gsub(
+                values_i,
+                "~",
+                "<span style=\"color: purple;\">&marker;</span>"
+              )
+            )
+            
+          text <- gsub("$", "&dollar;", values_i, fixed = TRUE)
+
           text <- paste(text, collapse = ", ")
           
           if (size == "small") {


### PR DESCRIPTION
With a recent update in gt, using `fmt_markdown()` with text between `$` characters elicits a transformation of contained characters to formatted equation text in HTML. As noted in https://github.com/rstudio/pointblank/issues/561, even a single `$` character will evoke the unwanted transformation since the text in doubled in the HTML string.

The short-term solution here is to replace any `$` characters with their HTML entity `%dollar;`.

This problem will need more investigation since there are other places in the codebase where `fmt_markdown()` is used (likely with arbitrary text).

Fixes: https://github.com/rstudio/pointblank/issues/561