### PR TITLE
Better alignment of `agent$validation_step` to rows of `get_agent_report(agent)`

### DIFF
--- a/R/get_agent_report.R
+++ b/R/get_agent_report.R
@@ -448,7 +448,8 @@ get_agent_report <- function(
   
   # nocov start
   
-  validation_set <- validation_set[report_tbl$i, ]
+  validation_set <- validation_set %>% 
+    dplyr::filter(.data$i == report_tbl$i)
   eval <- eval[report_tbl$i]
   extracts <- 
     agent$extracts[

--- a/R/get_agent_report.R
+++ b/R/get_agent_report.R
@@ -449,7 +449,7 @@ get_agent_report <- function(
   # nocov start
   
   validation_set <- validation_set %>% 
-    dplyr::filter(.data$i == report_tbl$i)
+    dplyr::filter(.data$i %in% report_tbl$i)
   eval <- eval[report_tbl$i]
   extracts <- 
     agent$extracts[


### PR DESCRIPTION
This is a small surgery on a single line of `get_agent_report()`:

https://github.com/rstudio/pointblank/blob/5a00f4b296aec1e1683fff62a4ee58e74edb61a2/R/get_agent_report.R#L451

The PR just makes the logic of matching rows between `validation_set` and `report_tbl` more explicit, via `filter()` on the matching `i` columns (where agents always have the invariant of `all(diff(agent$validation_set$i) == 1)`).

This resolves a cryptic error you get when you remove rows from the `agent$validation_set` for the purposes of `get_agent_report()` (ref: #563). Now, we get a better alignment of "rows in `$validation_set`" and "rows that appear in the `{gt}` agent report". I'm taking caution to not advertise this as public API (IMO getting the "hide rows" features in `{gt}` will serve as a better interface to this, when that's implemented). For the time being, the PR simply addresses some confusion about why removing rows in `$validation_set` does not produce the same effect for `get_agent_report()` (with an added benefit of making the intent behind the code for this line more explicit).

Using reprex from #563 (hide inactive columns), this now works:

```r
devtools::load_all()

x <- iris |> 
  create_agent() |> 
  col_exists("Petal.Length",
             active = has_columns(iris, Petal.Length)) |> 
  col_exists("Spec",
             active = has_columns(iris, Spec)) |> 
  col_exists("Sepal.Length",
             active = has_columns(iris, Sepal.Length)) |> 
  interrogate()

get_agent_report(x)
```

![image](https://github.com/user-attachments/assets/b97c4f4c-ddde-4e06-86e9-20516910ce72)

```r
x$validation_set <- x$validation_set[x$validation_set$eval_active, ]
get_agent_report(x)
```

![image](https://github.com/user-attachments/assets/ae75b370-c0d9-490d-9456-b0ca50e14eb0)
