### PR TITLE
Used columns in `col_vals_expr()` are extracted lazily

### DIFF
--- a/R/col_vals_expr.R
+++ b/R/col_vals_expr.R
@@ -339,10 +339,6 @@ col_vals_expr <- function(
     }
   }
   
-  # Extract columns from expr
-  data_cols <- colnames(apply_preconditions_for_cols(x, preconditions))
-  columns <- all_data_vars(expr, data_cols)
-  
   # Resolve segments into list
   segments_list <- 
     resolve_segments(
@@ -404,7 +400,7 @@ col_vals_expr <- function(
         assertion_type = "col_vals_expr",
         i_o = i_o,
         columns_expr = NA_character_,
-        column = columns,
+        column = NA_character_,
         values = expr,
         preconditions = preconditions,
         seg_expr = segments,

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -311,6 +311,13 @@ interrogate <- function(
           assertion_type = assertion_type
         )
       
+      if (assertion_type == "col_vals_expr") {
+        # Extract columns from expr and update validation set with used columns
+        expr <- get_values_at_idx(agent = agent, idx = i)[[1]]
+        columns <- all_data_vars(expr, data_cols = colnames(table))
+        agent$validation_set[[i, "column"]] <- list(columns)
+      }
+      
     } else if (assertion_type == "conjointly") {
       
       validation_formulas <- get_values_at_idx(agent = agent, idx = i)

--- a/tests/testthat/test-interrogate_simple.R
+++ b/tests/testthat/test-interrogate_simple.R
@@ -2155,3 +2155,28 @@ test_that("class preserved in `value`", {
   expect_true(agent$validation_set$eval_error)
   
 })
+
+test_that("col_vals_expr extracts used columns lazily", {
+  
+  agent_uninterrogated <- create_agent(tbl = iris) |> 
+    col_vals_expr(~ Petal.Length > Petal.Width)
+  expect_equal(
+    agent_uninterrogated$validation_set$column[[1]],
+    NA_character_
+  )
+  
+  agent_interrogated <- agent_uninterrogated %>% 
+    interrogate()
+  expect_equal(
+    agent_interrogated$validation_set$column[[1]],
+    c("Petal.Length", "Petal.Width")
+  )
+  
+  agent_inactive <- create_agent(tbl = iris) |> 
+    col_vals_expr(~ Petal.Length > Petal.Width, active = FALSE)
+  expect_equal(
+    agent_inactive$validation_set$column[[1]],
+    NA_character_
+  )
+  
+})


### PR DESCRIPTION
In https://github.com/rstudio/pointblank/pull/505, the extraction of used columns was eager, at the validation step's creation. This forced evaluation of `preconditions` even when `active` was set to FALSE. To respect `active` and prevent materializing the table until if/when necessary, this PR simply moves the "extract used columns" behavior into `interrogate()`.

Consequently, **inactive steps** revert to the old `col_vals_expr()` behavior of not showing used columns (as what columns are available in the table is is unknown until precondition is triggered)

(modified) reprex from #569

```r
agent <- create_agent(tbl = iris) |> 
  col_vals_expr(~ Petal.Volume > Petal.Width,
                preconditions = \(x) x[x$Petal.Volume > -1, ],
                active = has_columns(iris, Petal.Volume)
  ) |>
  interrogate()

str(
  agent$validation_set[, c("eval_active", "column")]
)
#> tibble [1 × 2] (S3: tbl_df/tbl/data.frame)
#>  $ eval_active: logi FALSE
#>  $ column     :List of 1
#>   ..$ : chr NA
```

For the same reason, **uninterrogated agents** will not show used columns for `col_vals_expr()`. But **interrogated agents** will.

```r
agent_uninterrogated <- create_agent(tbl = iris) |> 
  col_vals_expr(~ Petal.Length > Petal.Width)
str(
  agent_uninterrogated$validation_set[, c("eval_active", "column")]
)
#> tibble [1 × 2] (S3: tbl_df/tbl/data.frame)
#>  $ eval_active: logi NA
#>  $ column     :List of 1
#>   ..$ : chr NA

agent_interrogated <- agent_uninterrogated %>% 
  interrogate()
str(
  agent_interrogated$validation_set[, c("eval_active", "column")]
)
#> tibble [1 × 2] (S3: tbl_df/tbl/data.frame)
#>  $ eval_active: logi TRUE
#>  $ column     :List of 1
#>   ..$ : chr [1:2] "Petal.Length" "Petal.Width"
```

Active and interrogated `col_vals_expr()` steps will continue to show used columns in the report:

```r
get_agent_report(agent_interrogated)
```

![image](https://github.com/user-attachments/assets/0a3beedb-3c60-43e8-afc9-d20f6f1a8891)
