### PR TITLE
Bugfix `rows_distinct()` dropping non-tested columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pointblank (development version)
 
+- Data extracts for `rows_distinct()` preserves columns other than the ones tested (#588)
+
 # pointblank 0.12.2
 
 This release provides a few minor improvements along with many bug fixes.

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -2392,9 +2392,8 @@ interrogate_distinct <- function(
     column_validity_has_columns(columns = column_names)
 
     table %>%
-      dplyr::select({{ column_names }}) %>%
       dplyr::group_by(!!!col_syms) %>%
-      dplyr::mutate(`pb_is_good_` = ifelse(dplyr::n() == 1, TRUE, FALSE)) %>%
+      dplyr::mutate(`pb_is_good_` = dplyr::n() == 1L) %>%
       dplyr::ungroup()
   }
 
@@ -2413,15 +2412,13 @@ interrogate_distinct <- function(
 
     unduplicated <-
       table %>%
-      dplyr::select({{ column_names }}) %>%
       dplyr::count(!!!col_syms, name = "pb_is_good_") %>%
-      dplyr::mutate(`pb_is_good_` = ifelse(`pb_is_good_` == 1, TRUE, FALSE)) %>%
-      dplyr::filter(`pb_is_good_` == TRUE)
+      dplyr::mutate(`pb_is_good_` = `pb_is_good_` == 1L) %>%
+      dplyr::filter(`pb_is_good_`)
 
     table %>%
-      dplyr::select({{ column_names }}) %>%
       dplyr::left_join(unduplicated, by = column_names) %>%
-      dplyr::mutate(`pb_is_good_` = ifelse(is.na(`pb_is_good_`), FALSE, TRUE))
+      dplyr::mutate(`pb_is_good_` = is.na(`pb_is_good_`))
   }
 
   # Perform the validation of the table

--- a/tests/testthat/test-get_data_extracts.R
+++ b/tests/testthat/test-get_data_extracts.R
@@ -268,3 +268,16 @@ test_that("Data extracts of different sizes are possible to create", {
   get_data_extracts(agent) %>% names() %>% expect_null()
   get_data_extracts(agent) %>% length() %>% expect_equal(0)
 })
+
+test_that("`rows_distinct()` extracts all columns", {
+
+  agent <- create_agent(small_table) %>%
+    rows_distinct(c(date, date_time)) %>%
+    interrogate()
+
+  expect_identical(
+    colnames(get_data_extracts(agent)[[1]]),
+    colnames(small_table)
+  )
+
+})


### PR DESCRIPTION
# Summary

This PR ensures that the data extracts for `rows_distinct()`/`interrogate_distinct()` preserves all columns instead of subsetting just the set of columns tested.

Now:

```r
create_agent(small_table) %>% 
  rows_distinct(c(date, date_time)) %>% 
  interrogate() %>% 
  get_data_extracts()
#> 
#> ── Interrogation Started - there is a single validation step ───────────────
#> ✔ Step 1: OK.
#> 
#> ── Interrogation Completed ─────────────────────────────────────────────────
#> $`1`
#> # A tibble: 2 × 8
#>   date_time           date           a b             c     d e     f    
#>   <dttm>              <date>     <int> <chr>     <dbl> <dbl> <lgl> <chr>
#> 1 2016-01-20 04:30:00 2016-01-20     3 5-bce-642     9  838. FALSE high 
#> 2 2016-01-20 04:30:00 2016-01-20     3 5-bce-642     9  838. FALSE high
```

Previously:

```r
create_agent(small_table) %>% 
  rows_distinct(c(date, date_time)) %>% 
  interrogate() %>% 
  get_data_extracts()
#> 
#> ── Interrogation Started - there is a single validation step ───────────────
#> ✔ Step 1: OK.
#> 
#> ── Interrogation Completed ─────────────────────────────────────────────────
#> $`1`
#> # A tibble: 2 × 2
#>   date       date_time          
#>   <date>     <dttm>             
#> 1 2016-01-20 2016-01-20 04:30:00
#> 2 2016-01-20 2016-01-20 04:30:00
```


# Related GitHub Issues and PRs

- Ref: closes #475

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/pointblank/blob/main/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/pointblank/tree/main/tests/testthat) for any new functionality.
