### PR TITLE
Info columns warning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pointblank (development version)
 
+- `info_columns()` warn more informatively when no columns are selected.
+
 # pointblank 0.12.2
 
 This release provides a few minor improvements along with many bug fixes.

--- a/R/info_add.R
+++ b/R/info_add.R
@@ -440,7 +440,7 @@ info_columns <- function(
 ) {
 
   # Capture the `columns` expression
-  columns <- rlang::enquo(columns)
+  columns_expr <- rlang::enquo(columns)
 
   metadata_items <- rlang::list2(...)
 
@@ -456,15 +456,15 @@ info_columns <- function(
   }
 
   # Resolve the columns based on the expression
-  columns <- resolve_columns(x = tbl, var_expr = columns)
+  columns <- resolve_columns(x = tbl, var_expr = columns_expr)
 
   if (length(columns) == 1 && is.na(columns)) {
 
-    warning(
-      "No columns were matched with the expression used, so, no ",
-      "info was added.",
-      call. = FALSE
-    )
+    columns_expr <- rlang::expr_deparse(rlang::quo_get_expr(columns_expr))
+    cli::cli_warn(c(
+      "No columns were matched, so no info was added.",
+      i = "Problem in: {.code {columns_expr}}"
+    ))
 
     return(metadata)
   }

--- a/tests/testthat/test-tidyselect_integration.R
+++ b/tests/testthat/test-tidyselect_integration.R
@@ -253,4 +253,19 @@ test_that("tidyselect integration in `info_columns`", {
     "nomatch"
   )
 
+  # `where()` works (#503)
+  informant <- create_informant(small_table) %>%
+    info_columns(
+      columns = where(lubridate::is.timepoint),
+      info = "Data about a time point"
+    )
+  cols_info <- sapply(informant$metadata$columns, `[[`, "info")
+  expect_identical(
+    Filter(Negate(is.null), cols_info),
+    list(
+      date_time = "Data about a time point",
+      date = "Data about a time point"
+    )
+  )
+
 })

--- a/tests/testthat/test-tidyselect_integration.R
+++ b/tests/testthat/test-tidyselect_integration.R
@@ -242,3 +242,15 @@ test_that("c()-expr works for serially", {
   )
 
 })
+
+test_that("tidyselect integration in `info_columns`", {
+
+  # Informative warnings on no-match (#344)
+  expect_warning(
+    mtcars %>%
+      create_informant() %>%
+      info_columns(matches("nomatch"), info = "hi"),
+    "nomatch"
+  )
+
+})


### PR DESCRIPTION
# Summary

This PR makes `info_columns()` emit a more informative warning message that isolates the problematic column-selecting expression.

Now:

```r
mtcars %>% 
  create_informant() %>% 
  info_columns(matches("x"), info = "hi") %>% 
  info_columns(starts_with("y"), info = "hi") %>% 
  info_columns(matches("mpg"), info = "there")
#> Warning: No columns were matched, so no info was added.
#> ℹ Problem in: `matches("x")`
#> Warning: No columns were matched, so no info was added.
#> ℹ Problem in: `starts_with("y")`
```

Previously:

```r
mtcars %>% 
  create_informant() %>% 
  info_columns(matches("x"), info = "hi") %>% 
  info_columns(starts_with("y"), info = "hi") %>% 
  info_columns(matches("mpg"), info = "there")
#> Warning: No columns were matched with the expression used, so, no info was
#> added.
#> Warning: No columns were matched with the expression used, so, no info was
#> added.
```

# Related GitHub Issues and PRs

- Ref: closes #344

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/pointblank/blob/main/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/pointblank/tree/main/tests/testthat) for any new functionality.
