### PR TITLE
Bugfix `rows_complete()` dropping non-tested columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 - `info_columns()` warn more informatively when no columns are selected (#589).
 
-- Data extracts for `rows_distinct()` preserves columns other than the ones tested (#588)
+- Data extracts for `rows_distinct()`/`rows_complete()` preserves all columns, not just the ones tested (#588, #591)
 
 - The `brief` argument of validation functions now also supports `{glue}` syntax (#587)
 

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -2492,7 +2492,9 @@ interrogate_complete <- function(
 
       table_check <-
         table %>%
-        dplyr::mutate(pb_is_good_ = stats::complete.cases(dplyr::pick({{ column_names }})))
+        dplyr::mutate(
+          pb_is_good_ = stats::complete.cases(dplyr::pick({{ column_names }}))
+        )
     }
 
     table_check

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -2486,7 +2486,7 @@ interrogate_complete <- function(
 
       table_check <-
         table %>%
-        dplyr::mutate(pb_is_good_ = col_expr)
+        dplyr::mutate(pb_is_good_ = !!col_expr)
 
     } else {
 

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -2486,15 +2486,13 @@ interrogate_complete <- function(
 
       table_check <-
         table %>%
-        dplyr::select({{ column_names }}) %>%
         dplyr::mutate(pb_is_good_ = col_expr)
 
     } else {
 
       table_check <-
         table %>%
-        dplyr::select({{ column_names }}) %>%
-        dplyr::mutate(pb_is_good_ = stats::complete.cases(.))
+        dplyr::mutate(pb_is_good_ = stats::complete.cases(dplyr::pick({{ column_names }})))
     }
 
     table_check

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -2418,7 +2418,7 @@ interrogate_distinct <- function(
 
     table %>%
       dplyr::left_join(unduplicated, by = column_names) %>%
-      dplyr::mutate(`pb_is_good_` = is.na(`pb_is_good_`))
+      dplyr::mutate(`pb_is_good_` = !is.na(`pb_is_good_`))
   }
 
   # Perform the validation of the table

--- a/tests/testthat/test-get_data_extracts.R
+++ b/tests/testthat/test-get_data_extracts.R
@@ -269,14 +269,22 @@ test_that("Data extracts of different sizes are possible to create", {
   get_data_extracts(agent) %>% length() %>% expect_equal(0)
 })
 
-test_that("`rows_distinct()` extracts all columns", {
+test_that("`rows_*()` functions extract all columns", {
 
   agent <- create_agent(small_table) %>%
     rows_distinct(c(date, date_time)) %>%
+    rows_complete(c(a, b, c)) %>%
     interrogate()
 
+  # rows_distinct step
   expect_identical(
-    colnames(get_data_extracts(agent)[[1]]),
+    colnames(get_data_extracts(agent, 1)),
+    colnames(small_table)
+  )
+
+  # rows_complete step
+  expect_identical(
+    colnames(get_data_extracts(agent, 2)),
     colnames(small_table)
   )
 


### PR DESCRIPTION
# Summary

Similar to #588 - ensures that `rows_complete()` preserves all columns instead of just the ones tested.

Now:

```r
create_agent(small_table) %>% 
  rows_complete(c(a, b, c)) %>% 
  interrogate() %>% 
  get_data_extracts(1)
#> 
#> ── Interrogation Started - there is a single validation step ───────────────────────────────────────────
#> ✔ Step 1: OK.
#> 
#> ── Interrogation Completed ─────────────────────────────────────────────────────────────────────────────
#> # A tibble: 2 × 8
#>   date_time           date           a b             c     d e     f    
#>   <dttm>              <date>     <int> <chr>     <dbl> <dbl> <lgl> <chr>
#> 1 2016-01-06 17:23:00 2016-01-06     2 5-jdo-903    NA 3892. FALSE mid  
#> 2 2016-01-30 11:23:00 2016-01-30     1 3-dka-303    NA 2230. TRUE  high
```

Previously:

```r
create_agent(small_table) %>% 
  rows_complete(c(a, b, c)) %>% 
  interrogate() %>% 
  get_data_extracts(1)
#> 
#> ── Interrogation Started - there is a single validation step ───────────────────────────────────────────
#> ✔ Step 1: OK.
#> 
#> ── Interrogation Completed ─────────────────────────────────────────────────────────────────────────────
#> # A tibble: 2 × 3
#>       a b             c
#>   <int> <chr>     <dbl>
#> 1     2 5-jdo-903    NA
#> 2     1 3-dka-303    NA
```

Rider: fixes a critical typo from #588 where I got the T/F flipped in `tbl_rows_distinct_2()` (`interrogate_distinct()` method for mysql and bigquery)

# Related GitHub Issues and PRs

- Ref: #588

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/pointblank/blob/main/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/pointblank/tree/main/tests/testthat) for any new functionality.
