### PR TITLE
More helpful error messages when YAML-writing agents/informants with a non-lazy tbl

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - `info_columns()` warn more informatively when no columns are selected (#589).
 
+- `write_yaml()` errors more informatively when `tbl` value is incompatible for yaml-writing (#597)
+
 - Data extracts for `rows_distinct()`/`rows_complete()` preserves all columns, not just the ones tested (#588, #591)
 
 - The `brief` argument of validation functions now also supports `{glue}` syntax (#587)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1732,3 +1732,8 @@ deparse_expr <- function(expr, collapse = " ", ...) {
     paste("<expr>", deparsed)
   }
 }
+
+string_is_valid_symbol <- function(x) {
+  rlang::is_scalar_character(x) &&
+    identical(make.names(x), x)
+}

--- a/R/yaml_write.R
+++ b/R/yaml_write.R
@@ -1664,7 +1664,7 @@ check_lazy_tbl <- function(x, type = c("agent", "informant")) {
       "i" = if (string_is_valid_symbol(tbl_name)) {
         paste(
           "Did you mean to pass the table lazily?",
-          "{.code create_{type}(tbl = ~ {tbl_name})}"
+          "Ex: {.code create_{type}(tbl = ~ {tbl_name})}"
         )
       } else {
         "See {.code ?yaml_write} for details."

--- a/R/yaml_write.R
+++ b/R/yaml_write.R
@@ -966,12 +966,7 @@ prune_lst_step <- function(lst_step) {
 
 as_agent_yaml_list <- function(agent, expanded) {
 
-  if (is.null(agent$read_fn)) {
-    stop(
-      "The agent must have a `tbl` value that can be put into YAML.",
-       call. = FALSE
-    )
-  }
+  check_lazy_tbl(agent, "agent")
 
   action_levels_default <- as_action_levels(agent$actions)
   end_fns <- agent$end_fns %>% unlist()
@@ -1574,12 +1569,7 @@ get_column_text <- function(step_list, expanded) {
 
 as_informant_yaml_list <- function(informant) {
 
-  if (is.null(informant$read_fn)) {
-    stop(
-      "The informant must have a `tbl` value that can be put into YAML.",
-      call. = FALSE
-    )
-  }
+  check_lazy_tbl(informant, "informant")
 
   lst_tbl_name <- to_list_tbl_name(informant$tbl_name)
   lst_read_fn <- to_list_read_fn(informant$read_fn)
@@ -1664,3 +1654,22 @@ as_tbl_store_yaml_list <- function(tbl_store) {
     lst_init                      # initialization statement
   )
 }
+
+check_lazy_tbl <- function(x, type = c("agent", "informant")) {
+  type <- match.arg(type)
+  tbl_name <- x$tbl_name
+  if (is.null(x$read_fn)) {
+    cli::cli_abort(c(
+      "x" = "The {type} must have a `tbl` value that can be put into YAML.",
+      "i" = if (string_is_valid_symbol(tbl_name)) {
+        paste(
+          "Did you mean to pass the table lazily?",
+          "{.code create_{type}(tbl = ~ {tbl_name})}"
+        )
+      } else {
+        "See {.code ?yaml_write} for details."
+      }
+    ), call = NULL)
+  }
+}
+

--- a/R/yaml_write.R
+++ b/R/yaml_write.R
@@ -1672,4 +1672,3 @@ check_lazy_tbl <- function(x, type = c("agent", "informant")) {
     ), call = NULL)
   }
 }
-


### PR DESCRIPTION
# Summary

`write_yaml()` now uses information in `$tbl_name` to construct more informative error messages when the `tbl` is not supplied lazily upon agent/informant's creation (requirement for yaml-writing).

Special error msg if `tbl` was supplied as a **variable** (hint to use `~`):

```r
create_agent(small_table) %>% 
  yaml_write()
#> Error:
#> ✖ The agent must have a `tbl` value that can be put into YAML.
#> ℹ Did you mean to pass the table lazily? Ex: `create_agent(tbl = ~ small_table)`
```

Generic error msg if `tbl` was supplied as a complex **expression** (points to `yaml_write()`):

```r
create_agent(small_table %>% head(1)) %>% 
  yaml_write()
#> Error:
#> ✖ The agent must have a `tbl` value that can be put into YAML.
#> ℹ See `?yaml_write` for details.
```

This behavior has been united across agents and informants via a helper function `check_lazy_tbl()`

# Related GitHub Issues and PRs

- Ref: #596 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/pointblank/blob/main/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/pointblank/tree/main/tests/testthat) for any new functionality.
