### PR TITLE
Look inside the formula environment first when materializing `~ tbl`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pointblank (development version)
 
+- Bugfix agents not searching the formula environment when materializing `~ tbl` (#599)
+
 - `info_columns()` warn more informatively when no columns are selected (#589).
 
 - `write_yaml()` errors more informatively when `tbl` value is incompatible for yaml-writing (#597)

--- a/R/incorporate.R
+++ b/R/incorporate.R
@@ -190,32 +190,17 @@ incorporate <- function(informant) {
 
     } else if (rlang::is_formula(read_fn)) {
 
-      tbl <-
-        read_fn %>%
-        rlang::f_rhs() %>%
-        rlang::eval_tidy(env = caller_env(n = 1))
+      tbl <- eval_f_rhs(read_fn)
 
       if (inherits(tbl, "read_fn")) {
-
         if (inherits(tbl, "with_tbl_name") && is.na(tbl_name)) {
           tbl_name <- tbl %>% rlang::f_lhs() %>% as.character()
         }
-
-        tbl <-
-          tbl %>%
-          rlang::f_rhs() %>%
-          rlang::eval_tidy(env = caller_env(n = 1))
+        tbl <- eval_f_rhs(tbl)
       }
 
     } else {
-
-      # TODO: Improve the `stop()` message here
-      stop(
-        "The `read_fn` object must be a function or an R formula.\n",
-        "* A function can be made with `function()` {<tbl reading code>}.\n",
-        "* An R formula can also be used, with the expression on the RHS.",
-        call. = FALSE
-      )
+      err_not_table_object()
     }
   }
 

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -196,14 +196,7 @@ interrogate <- function(
       }
 
     } else {
-
-      # TODO: create a better `stop()` message
-      stop(
-        "The `read_fn` object must be a function or an R formula.\n",
-        "* A function can be made with `function()` {<tbl reading code>}.\n",
-        "* An R formula can also be used, with the expression on the RHS.",
-        call. = FALSE
-      )
+      err_not_table_object()
     }
 
     # Obtain basic information on the table and

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -186,15 +186,13 @@ interrogate <- function(
     if (inherits(agent$read_fn, "function")) {
       agent$tbl <- rlang::exec(agent$read_fn)
     } else if (rlang::is_formula(agent$read_fn)) {
-      agent$tbl <- agent$read_fn %>% rlang::f_rhs() %>% rlang::eval_tidy()
+      agent$tbl <- eval_f_rhs(agent$read_fn)
 
       if (inherits(agent$tbl, "read_fn")) {
-
         if (inherits(agent$tbl, "with_tbl_name")) {
           agent$tbl_name <- agent$tbl %>% rlang::f_lhs() %>% as.character()
         }
-
-        agent$tbl <- materialize_table(agent$tbl)
+        agent$tbl <- eval_f_rhs(agent$tbl)
       }
 
     } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -206,20 +206,22 @@ materialize_table <- function(tbl, check = TRUE) {
       tbl <- eval_f_rhs(tbl)
     }
   } else {
-
-    stop(
-      "The `tbl` object must either be a table, a function, or a formula.\n",
-      "* A table-prep formula can be used (with the expression on the RHS).\n",
-      "* A function can be made with `function()` {<tbl reading code>}.",
-      call. = FALSE
-    )
+    err_not_table_object()
   }
 
-  if (check) {
-    is_a_table_object(tbl)
+  if (check && !is_a_table_object(tbl)) {
+    err_not_table_object()
   }
 
   tbl
+}
+
+err_not_table_object <- function() {
+  cli::cli_abort(c(
+    "x" = "The agent `tbl` must either be a table, a function, or a formula",
+    "i" = "A table-prep formula can be made with expression on the RHS",
+    "i" = "A function can be made with `function() {{<tbl reading code>}}`"
+  ), call = NULL)
 }
 
 eval_f_rhs <- function(f) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -201,13 +201,10 @@ materialize_table <- function(tbl, check = TRUE) {
   } else if (inherits(tbl, "function")) {
     tbl <- rlang::exec(tbl)
   } else if (rlang::is_formula(tbl)) {
-
-    tbl <- tbl %>% rlang::f_rhs() %>% rlang::eval_tidy()
-
+    tbl <- eval_f_rhs(tbl)
     if (inherits(tbl, "read_fn")) {
-      tbl <- tbl %>% rlang::f_rhs() %>% rlang::eval_tidy()
+      tbl <- eval_f_rhs(tbl)
     }
-
   } else {
 
     stop(
@@ -223,6 +220,10 @@ materialize_table <- function(tbl, check = TRUE) {
   }
 
   tbl
+}
+
+eval_f_rhs <- function(f) {
+  eval(rlang::f_rhs(f), rlang::f_env(f))
 }
 
 as_columns_expr <- function(columns) {

--- a/tests/testthat/test-create_agent.R
+++ b/tests/testthat/test-create_agent.R
@@ -149,3 +149,23 @@ test_that("Creating a valid `agent` object is possible", {
 
   expect_true(agent_4$embed_report)
 })
+
+test_that("`agent` can materialize table from formula environment", {
+
+  agent <- local({
+    df <- data.frame(x = 1)
+    create_agent(tbl = ~ df)
+  })
+
+  expect_null(agent$tbl)
+
+  expect_no_error({
+    agent <- agent %>%
+      rows_distinct(x) %>%
+      interrogate()
+
+  })
+
+  expect_identical(agent$tbl, data.frame(x = 1))
+
+})

--- a/tests/testthat/test-incorporate_with_informant.R
+++ b/tests/testthat/test-incorporate_with_informant.R
@@ -217,3 +217,19 @@ test_that("Incorporating an informant from YAML yields the correct results", {
 })
 
 fs::file_delete(path = "informant-test_table.yml")
+
+test_that("`informant` can materialize table from formula environment (#602)", {
+
+  informant <- local({
+    df <- data.frame(x = 1)
+    create_informant(tbl = ~ df)
+  })
+
+  expect_null(informant$tbl)
+
+  expect_no_error({
+    informant <- informant %>%
+      incorporate()
+  })
+
+})


### PR DESCRIPTION
# Summary

Fixes an edge case where `tbl` is passed as formula and the variable is defined in an environment not available at `interrogate()`. The following reprex from https://github.com/rstudio/pointblank/issues/598#issuecomment-2661202541 now works as intended:

```r
agent <- local({
  df <- data.frame(x = 1)
  create_agent(tbl = ~ df)
})
agent %>% 
  rows_distinct(x) %>% 
  interrogate()
```

Previously, cases like this would error from not searching for `df` in the formula environment (in this case, it would scope the `stats::df()` function instead).

# Related GitHub Issues and PRs

- Ref: #598

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/pointblank/blob/main/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/pointblank/tree/main/tests/testthat) for any new functionality.
