### PR TITLE
Fallback on failed glue in `label` and `brief`

### DIFF
--- a/R/steps_and_briefs.R
+++ b/R/steps_and_briefs.R
@@ -116,8 +116,16 @@ create_validation_step <- function(
 }
 
 glue_chr <- function(x, glue_mask) {
-  if (is.na(x)) return(x)
-  as.character(glue::glue_data(glue_mask, x, .envir = NULL))
+  # TODO: also skip autobriefs (#273)
+  if (is.na(x) || !grepl("{", x, fixed = TRUE)) {
+    return(x)
+  }
+  # Try glue and fallback to original string if failed
+  out <- tryCatch(
+    expr = as.character(glue::glue_data(glue_mask, x, .envir = NULL)),
+    error = function(e) x
+  )
+  out
 }
 
 get_hash_version <- function() {

--- a/tests/testthat/test-glue_label_brief.R
+++ b/tests/testthat/test-glue_label_brief.R
@@ -67,9 +67,19 @@ test_that("label supports glue syntax for {.seg_val} {.seg_col} {.step} {.col}",
 test_that("glue scope doesn't expose internal variables", {
 
   # Ex: should not be able to access `columns` local variable in `col_vals_lt()`
-  expect_error(create_agent(small_table) %>% col_vals_lt(c, 8, label = "{columns}"))
+  expect_identical(
+    create_agent(small_table) %>%
+      col_vals_lt(c, 8, label = "{columns}") %>%
+      {.$validation_set$label},
+    "{columns}"
+  )
   # Ex: should not be able to access `i` local variable in `create_validation_step()`
-  expect_error(create_agent(small_table) %>% col_vals_lt(c, 8, label = "{i}"))
+  expect_identical(
+    create_agent(small_table) %>%
+      col_vals_lt(c, 8, label = "{i}") %>%
+      {.$validation_set$label},
+    "{i}"
+  )
 
   # Should be able to access global vars/fns
   expect_equal(
@@ -83,23 +93,23 @@ test_that("glue scope doesn't expose internal variables", {
 
 test_that("glue env searches from the caller env of the validation function", {
 
-  to_upper <- function(x) stop("Oh no!")
+  to_upper <- function(x) "global"
 
-  expect_error(
+  expect_identical(
     create_agent(small_table) %>%
       col_vals_lt(c, 8, label = "{to_upper(.col)}") %>%
       {.$validation_set$label},
-    "Oh no!"
+    "global"
   )
 
-  expect_equal(
+  expect_identical(
     local({
-      to_upper <- function(x) toupper(x)
+      to_upper <- function(x) "local"
       create_agent(small_table) %>%
         col_vals_lt(c, 8, label = "{to_upper(.col)}") %>%
         {.$validation_set$label}
     }),
-    "C"
+    "local"
   )
 
 })

--- a/tests/testthat/test-glue_label_brief.R
+++ b/tests/testthat/test-glue_label_brief.R
@@ -281,3 +281,18 @@ test_that("glue works for brief too", {
   )
 
 })
+
+test_that("safe fallback when glue fails (#598)", {
+
+  expect_no_error({
+    agent <- create_agent(small_table) %>%
+      col_vals_regex(b, "^\\d{1,2}") %>%
+      interrogate()
+  })
+
+  expect_identical(
+    agent$validation_set$brief,
+    generate_autobriefs(agent, "b", NULL, "^\\d{1,2}", "col_vals_regex"),
+  )
+
+})


### PR DESCRIPTION
# Summary

Implements a safeguard to fall back to the original string as-is if glue interpolation fails. This is a broad-stroke solution to cases such as when a user regex like `{1,2}` is preserved in autobrief and triggers an error at glue. The fallback is probably nice to have anyways though, since agents tend to be conservative about throwing errors outright.

Now (attempts glue and falls back to autobrief string as-is):

```r
create_agent(small_table) %>% 
  col_vals_regex(b, "^\\d{1,2}") %>% 
  interrogate() %>% 
  {.$validation_set$brief}
#> 
#> ── Interrogation Started - there is a single validation step ─────────────────────
#> ✔ Step 1: OK.
#> 
#> ── Interrogation Completed ───────────────────────────────────────────────────────
#> [1] "Expect that values in `b` should match the regular expression: `^\\d{1,2}`. "
```

Previously (attempts glue and errors):

```r
create_agent(small_table) %>% 
  col_vals_regex(b, "^\\d{1,2}") %>% 
  interrogate()
#> Error:
#> ! Failed to parse glue component
#> Caused by error in `parse()`:
#> ! <text>:1:2: unexpected ','
#> 1: 1,
#>      ^
```

# Related GitHub Issues and PRs

- Ref: #600

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [ ] I have listed any major changes in the [NEWS](https://github.com/rstudio/pointblank/blob/main/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/pointblank/tree/main/tests/testthat) for any new functionality.
