### PR TITLE
Support Perl regex

### DIFF
--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -1849,7 +1849,7 @@ interrogate_regex <- function(
       tbl <-
         table %>%
         dplyr::mutate(pb_is_good_ = ifelse(
-          !is.na({{ column }}), grepl(regex, {{ column }}), NA)
+          !is.na({{ column }}), grepl(regex, {{ column }}, perl = TRUE), NA)
         ) %>%
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           is.na(pb_is_good_) ~ na_pass,

--- a/tests/testthat/test-interrogate_simple.R
+++ b/tests/testthat/test-interrogate_simple.R
@@ -929,6 +929,15 @@ test_that("Interrogating simply returns the expected results", {
   # Expect that `tbl_result` is never created
   expect_false(exists("tbl_result"))
 
+  # `perl=TRUE` for R dataframes (#606)
+  expect_no_error(
+    data.frame(x = c("ab", "ac")) %>%
+      col_vals_regex(
+        columns = "x",
+        regex = "a(?!d)"
+      )
+  )
+
   #
   # col_vals_within_spec()
   #


### PR DESCRIPTION
# Summary

Sets `perl = TRUE` in internal interrogation function for `col_vals_regex()`

```r
data.frame(x = c("aa", "ab", "ac")) %>%
  create_agent() %>% 
  col_vals_regex(
    columns = "x",
    regex = "a(?!b)"
  ) %>% 
  interrogate() %>% 
  get_data_extracts()
#> $`1`
#> # A tibble: 1 × 1
#>   x    
#>   <chr>
#> 1 ab
```

# Related GitHub Issues and PRs

- Ref: #606 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [ ] I have listed any major changes in the [NEWS](https://github.com/rstudio/pointblank/blob/main/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/pointblank/tree/main/tests/testthat) for any new functionality.
