### PR TITLE
`yaml_agent_string()` returns the yaml string

### DIFF
--- a/R/yaml_write.R
+++ b/R/yaml_write.R
@@ -640,6 +640,8 @@ yaml_write <- function(
 #' @section Function ID:
 #' 11-5
 #'
+#' @return The yaml string, invisibly
+#'
 #' @export
 yaml_agent_string <- function(
     agent = NULL,
@@ -648,27 +650,25 @@ yaml_agent_string <- function(
     expanded = FALSE
 ) {
 
-  switch(
+  yaml_string <- switch(
     rlang::check_exclusive(agent, filename),
     agent = {
       # Display the agent's YAML as a nicely formatted string by
       # generating the YAML (`as_agent_yaml_list() %>% as.yaml()`) and
       # then emitting it to the console via `message()`
-      message(
-        as_agent_yaml_list(
-          agent = agent,
-          expanded = expanded
-        ) %>%
-          yaml::as.yaml(
-            handlers = list(
-              logical = function(x) {
-                result <- ifelse(x, "true", "false")
-                class(result) <- "verbatim"
-                result
-              }
-            )
+      as_agent_yaml_list(
+        agent = agent,
+        expanded = expanded
+      ) %>%
+        yaml::as.yaml(
+          handlers = list(
+            logical = function(x) {
+              result <- ifelse(x, "true", "false")
+              class(result) <- "verbatim"
+              result
+            }
           )
-      )
+        )
     },
     filename = {
       # Display the agent's YAML as a nicely formatted string by
@@ -677,12 +677,13 @@ yaml_agent_string <- function(
       if (!is.null(path)) {
         filename <- file.path(path, filename)
       }
-      message(
-        readLines(filename) %>%
-          paste(collapse = "\n")
-      )
+      readLines(filename) %>%
+        paste(collapse = "\n")
     }
   )
+
+  message(yaml_string)
+  invisible(yaml_string)
 
 }
 

--- a/R/yaml_write.R
+++ b/R/yaml_write.R
@@ -580,7 +580,7 @@ yaml_write <- function(
 #'   yielding a validation function per column? By default, this is `FALSE`
 #'   so expressions as written will be retained in the YAML representation.
 #'
-#' @return Nothing is returned. Instead, text is printed to the console.
+#' @return The yaml string is printed to the console and returned invisibly.
 #'
 #' @section Examples:
 #'
@@ -639,8 +639,6 @@ yaml_write <- function(
 #' @family pointblank YAML
 #' @section Function ID:
 #' 11-5
-#'
-#' @return The yaml string, invisibly
 #'
 #' @export
 yaml_agent_string <- function(

--- a/man/yaml_agent_string.Rd
+++ b/man/yaml_agent_string.Rd
@@ -22,7 +22,7 @@ yielding a validation function per column? By default, this is \code{FALSE}
 so expressions as written will be retained in the YAML representation.}
 }
 \value{
-Nothing is returned. Instead, text is printed to the console.
+The yaml string is printed to the console and returned invisibly.
 }
 \description{
 With \strong{pointblank} YAML, we can serialize an agent's validation plan (with
@@ -42,7 +42,7 @@ There's a YAML file available in the \strong{pointblank} package that's called
 \code{"agent-small_table.yml"}. The path for it can be accessed through
 \code{system.file()}:
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{yml_file_path <- 
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{yml_file_path <-
   system.file(
     "yaml", "agent-small_table.yml",
     package = "pointblank"

--- a/tests/testthat/test-yaml.R
+++ b/tests/testthat/test-yaml.R
@@ -59,8 +59,11 @@ test_that("YAML writing and reading works as expected", {
   expect_false(inherits(agent, "has_intel"))
 
   # Expect that `yaml_agent_string` shows a YAML string in the
-  # console and returns nothing (when reading from an agent)
-  expect_null(suppressMessages(yaml_agent_string(agent = agent)))
+  # console and returns the string itself
+  expect_type(
+    suppressMessages(yaml_agent_string(agent = agent)),
+    "character"
+  )
   expect_match(
     as.character(testthat::capture_messages(yaml_agent_string(agent = agent))),
     "tbl: ~small_table.*?tbl_name: .*?label: .*?actions:.*?warn_fraction: 0.1.*?stop_fraction: 0.2.*?steps:.*"
@@ -74,7 +77,10 @@ test_that("YAML writing and reading works as expected", {
 
   # Expect that `yaml_agent_string()` shows a YAML string in the
   # console and returns nothing (when reading from a YAML file)
-  expect_null(suppressMessages(yaml_agent_string(filename = file.path(work_path, "test.yaml"))))
+  expect_type(
+    suppressMessages(yaml_agent_string(filename = file.path(work_path, "test.yaml"))),
+    "character"
+  )
   expect_match(
     as.character(testthat::capture_messages(yaml_agent_string(filename = file.path(work_path, "test.yaml")))),
     "tbl: ~small_table.*?tbl_name: .*?label: .*?actions:.*?warn_fraction: 0.1.*?stop_fraction: 0.2.*?steps:.*"

--- a/tests/testthat/test-yaml.R
+++ b/tests/testthat/test-yaml.R
@@ -75,8 +75,8 @@ test_that("YAML writing and reading works as expected", {
   # Expect that the file was written to the temp directory
   expect_true("test.yaml" %in% list.files(path = work_path))
 
-  # Expect that `yaml_agent_string()` shows a YAML string in the
-  # console and returns nothing (when reading from a YAML file)
+  # Expect that `yaml_agent_string` shows a YAML string in the
+  # console and returns the string itself
   expect_type(
     suppressMessages(yaml_agent_string(filename = file.path(work_path, "test.yaml"))),
     "character"


### PR DESCRIPTION
# Summary

Resolves #609 

Now:

```r
yaml <- create_agent(~ small_table) %>% 
  yaml_agent_string()
#> type: agent
#> tbl: ~small_table
#> tbl_name: ~small_table
#> label: '[2025-03-24|14:54:42]'
#> lang: en
#> locale: en
#> steps: []

yaml
#> [1] "type: agent\ntbl: ~small_table\ntbl_name: ~small_table\nlabel: '[2025-03-24|14:54:42]'\nlang: en\nlocale: en\nsteps: []\n"

cat(yaml)
#> type: agent
#> tbl: ~small_table
#> tbl_name: ~small_table
#> label: '[2025-03-24|14:54:42]'
#> lang: en
#> locale: en
#> steps: []
```

Previously:

```r
yaml <- create_agent(~ small_table) %>% 
  yaml_agent_string()
#> type: agent
#> tbl: ~small_table
#> tbl_name: ~small_table
#> label: '[2025-03-19|12:30:03]'
#> lang: en
#> locale: en
#> steps: []

yaml
#> NULL
```

# Related GitHub Issues and PRs

- Ref: #609 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/pointblank/blob/main/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/pointblank/tree/main/tests/testthat) for any new functionality.
