### PR TITLE
Truncate long auto-generated `tbl_name`s

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pointblank (development version)
 
+- Bugfix agents auto-generating a table label that was too long. They now get truncated (#614)
+
 - Bugfix agents not searching the formula environment when materializing `~ tbl` (#599)
 
 - `info_columns()` warn more informatively when no columns are selected (#589).

--- a/R/create_agent.R
+++ b/R/create_agent.R
@@ -512,8 +512,7 @@ create_agent <- function(
     tbl_name <- rlang::expr_deparse(tbl_expr)
     # truncate tbl expr that exceeds `deparse()` width (#613)
     if (nchar(tbl_name) > 60) {
-      tbl_expr_truncated <- rlang::call2(tbl_expr[[1]], quote(...))
-      tbl_name <- rlang::expr_deparse(tbl_expr_truncated)
+      tbl_name <- truncate_expr(tbl_expr)
     }
   }
   # ignore empty or magrittr pipe

--- a/R/create_agent.R
+++ b/R/create_agent.R
@@ -513,7 +513,7 @@ create_agent <- function(
     # truncate tbl expr that exceeds `deparse()` width (#613)
     if (nchar(tbl_name) > 60) {
       tbl_expr_truncated <- rlang::call2(tbl_expr[[1]], quote(...))
-      tb_name <- rlang::expr_deparse(tbl_expr_truncated)
+      tbl_name <- rlang::expr_deparse(tbl_expr_truncated)
     }
   }
   # ignore empty or magrittr pipe

--- a/R/create_agent.R
+++ b/R/create_agent.R
@@ -507,13 +507,12 @@ create_agent <- function(
 
   # Try to infer the table name if one isn't
   # explicitly given in `tbl_name`
-  if (!is.null(tbl) && is.null(tbl_name)) {
-    tbl_name <- deparse(match.call()$tbl)
-    if (tbl_name[1] == ".") {
-      tbl_name <- NA_character_
-    }
+  if (is.null(tbl_name) && !missing(tbl)) {
+    tbl_expr <- rlang::enexpr(tbl)
+    tbl_name <- rlang::expr_deparse(tbl_expr)
   }
-  if (is.null(tbl_name)) {
+  # ignore empty or magrittr pipe
+  if (is.null(tbl) || tbl_name == ".") {
     tbl_name <- NA_character_
   }
 

--- a/R/create_agent.R
+++ b/R/create_agent.R
@@ -513,7 +513,7 @@ create_agent <- function(
     # truncate tbl expr that exceeds `deparse()` width (#613)
     if (nchar(tbl_name) > 60) {
       tbl_expr_truncated <- rlang::call2(tbl_expr[[1]], quote(...))
-      tb_name <- rlang::expr_depr(tbl_expr_truncated)
+      tb_name <- rlang::expr_deparse(tbl_expr_truncated)
     }
   }
   # ignore empty or magrittr pipe

--- a/R/create_agent.R
+++ b/R/create_agent.R
@@ -509,7 +509,7 @@ create_agent <- function(
   # explicitly given in `tbl_name`
   if (is.null(tbl_name) && !missing(tbl)) {
     tbl_expr <- rlang::enexpr(tbl)
-    tbl_name <- rlang::expr_deparse(tbl_expr)
+    tbl_name <- paste0(deparse(tbl_expr), collapse = " ")
     # truncate tbl expr that exceeds `deparse()` width (#613)
     if (nchar(tbl_name) > 60) {
       tbl_name <- truncate_expr(tbl_expr)

--- a/R/create_agent.R
+++ b/R/create_agent.R
@@ -510,6 +510,11 @@ create_agent <- function(
   if (is.null(tbl_name) && !missing(tbl)) {
     tbl_expr <- rlang::enexpr(tbl)
     tbl_name <- rlang::expr_deparse(tbl_expr)
+    # truncate tbl expr that exceeds `deparse()` width (#613)
+    if (nchar(tbl_name) > 60) {
+      tbl_expr_truncated <- rlang::call2(tbl_expr[[1]], quote(...))
+      tb_name <- rlang::expr_depr(tbl_expr_truncated)
+    }
   }
   # ignore empty or magrittr pipe
   if (is.null(tbl) || tbl_name == ".") {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1740,3 +1740,12 @@ string_is_valid_symbol <- function(x) {
   rlang::is_scalar_character(x) &&
     identical(make.names(x), x)
 }
+
+truncate_expr <- function(x) {
+  if (rlang::is_symbol(x)) {
+    rlang::expr_deparse(x)
+  } else {
+    truncated <- rlang::call2(x[[1]], quote(...))
+    rlang::expr_deparse(truncated)
+  }
+}

--- a/tests/testthat/test-create_agent.R
+++ b/tests/testthat/test-create_agent.R
@@ -186,4 +186,12 @@ test_that("auto generation of `tbl_name` edgecases", {
     "data.frame(a = c(1, 2, 3), b = 4:6)"
   )
 
+  expect_equal(
+    create_agent(~ data.frame(
+      a = c(1, 2, 3), b = c(1, 2, 3), c = c(1, 2, 3), d = c(1, 2, 3)
+    )) %>%
+      el("tbl_name"),
+    "~..."
+  )
+
 })

--- a/tests/testthat/test-create_agent.R
+++ b/tests/testthat/test-create_agent.R
@@ -170,7 +170,7 @@ test_that("`agent` can materialize table from formula environment", {
 
 })
 
-test_that("auto generation of `tbl_name` edgecases", {
+test_that("truncate long auto-generated `tbl_name`s", {
 
   # Isue #613 (can't use base pipe in test but this is equivalent)
   expect_identical(
@@ -186,12 +186,18 @@ test_that("auto generation of `tbl_name` edgecases", {
     "data.frame(a = c(1, 2, 3), b = 4:6)"
   )
 
+  # Same treatment for formulas
   expect_identical(
     create_agent(~ data.frame(
       a = c(1, 2, 3), b = c(1, 2, 3), c = c(1, 2, 3), d = c(1, 2, 3)
     )) %>%
       el("tbl_name"),
     "~..."
+  )
+  expect_identical(
+    create_agent(~ data.frame(a = c(1, 2, 3), b = 4:6)) %>%
+      el("tbl_name"),
+    "~ data.frame(a = c(1, 2, 3), b = 4:6)"
   )
 
 })

--- a/tests/testthat/test-create_agent.R
+++ b/tests/testthat/test-create_agent.R
@@ -101,7 +101,7 @@ test_that("Creating a valid `agent` object is possible", {
   # RHS for `tbl_name`
   expect_equal(
     create_agent(tbl = ~ pointblank::small_table) %>% .$tbl_name,
-    "~ pointblank::small_table"
+    "~pointblank::small_table"
   )
 
   # Expect that using a `read_fn` to read in a table but
@@ -197,7 +197,7 @@ test_that("truncate long auto-generated `tbl_name`s", {
   expect_identical(
     create_agent(~ data.frame(a = c(1, 2, 3), b = 4:6)) %>%
       el("tbl_name"),
-    "~ data.frame(a = c(1, 2, 3), b = 4:6)"
+    "~data.frame(a = c(1, 2, 3), b = 4:6)"
   )
 
 })

--- a/tests/testthat/test-create_agent.R
+++ b/tests/testthat/test-create_agent.R
@@ -173,20 +173,20 @@ test_that("`agent` can materialize table from formula environment", {
 test_that("auto generation of `tbl_name` edgecases", {
 
   # Isue #613 (can't use base pipe in test but this is equivalent)
-  expect_equal(
+  expect_identical(
     create_agent(data.frame(
       a = c(1, 2, 3), b = c(1, 2, 3), c = c(1, 2, 3), d = c(1, 2, 3)
     )) %>%
       el("tbl_name"),
     "data.frame(...)"
   )
-  expect_equal(
+  expect_identical(
     create_agent(data.frame(a = c(1, 2, 3), b = 4:6)) %>%
       el("tbl_name"),
     "data.frame(a = c(1, 2, 3), b = 4:6)"
   )
 
-  expect_equal(
+  expect_identical(
     create_agent(~ data.frame(
       a = c(1, 2, 3), b = c(1, 2, 3), c = c(1, 2, 3), d = c(1, 2, 3)
     )) %>%

--- a/tests/testthat/test-create_agent.R
+++ b/tests/testthat/test-create_agent.R
@@ -101,7 +101,7 @@ test_that("Creating a valid `agent` object is possible", {
   # RHS for `tbl_name`
   expect_equal(
     create_agent(tbl = ~ pointblank::small_table) %>% .$tbl_name,
-    "~pointblank::small_table"
+    "~ pointblank::small_table"
   )
 
   # Expect that using a `read_fn` to read in a table but

--- a/tests/testthat/test-create_agent.R
+++ b/tests/testthat/test-create_agent.R
@@ -169,3 +169,21 @@ test_that("`agent` can materialize table from formula environment", {
   expect_identical(agent$tbl, data.frame(x = 1))
 
 })
+
+test_that("auto generation of `tbl_name` edgecases", {
+
+  # Isue #613 (can't use base pipe in test but this is equivalent)
+  expect_equal(
+    create_agent(data.frame(
+      a = c(1, 2, 3), b = c(1, 2, 3), c = c(1, 2, 3), d = c(1, 2, 3)
+    )) %>%
+      el("tbl_name"),
+    "data.frame(...)"
+  )
+  expect_equal(
+    create_agent(data.frame(a = c(1, 2, 3), b = 4:6)) %>%
+      el("tbl_name"),
+    "data.frame(a = c(1, 2, 3), b = 4:6)"
+  )
+
+})


### PR DESCRIPTION
# Summary

This PR touches the `tbl_name` metadata in agents, which is used for display in `get_agent_report()`

Previously, `tbl_name` defaulted to a `deparse()` of the user-supplied `tbl` expression. This led to a problem because `deparse()` has a cut off width of 60:

```r
deparse(quote(
  data.frame(a = c(1, 2, 3), b = c(1, 2, 3))
))
#> [1] "data.frame(a = c(1, 2, 3), b = c(1, 2, 3))"

deparse(quote(
  data.frame(a = c(1, 2, 3), b = c(1, 2, 3), c = c(1, 2, 3), d = c(1, 2, 3))
))
#> [1] "data.frame(a = c(1, 2, 3), b = c(1, 2, 3), c = c(1, 2, 3), d = c(1, "
#> [2] "    2, 3))"
```

This PR takes those long expressions and truncates them into something more readable that _also fits in the agent report_:

```r
data.frame(a = c(1, 2, 3), b = c(1, 2, 3), c = c(1, 2, 3), d = c(1, 2, 3)) |>
  create_agent() |>
  el("tbl_name")
#> [1] "data.frame(...)"
```

Previously (#613):

```r
data.frame(a = c(1, 2, 3), b = c(1, 2, 3), c = c(1, 2, 3), d = c(1, 2, 3)) |>
    create_agent() |>
    el("tbl_name")
#> [1] "data.frame(a = c(1, 2, 3), b = c(1, 2, 3), c = c(1, 2, 3), d = c(1, "
#> [2] "    2, 3))"
```


# Related GitHub Issues and PRs

- Ref: #613

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/pointblank/blob/main/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/pointblank/tree/main/tests/testthat) for any new functionality.
