### PR TITLE
Add `na_pass` argument to `col_vals_expr()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # pointblank (development version)
 
-- Add `na_pass` to `col_vals_expr()` for finer control of `NA` values (#617)
+- Add `na_pass` to `col_vals_expr()` for finer control of `NA` values. Additionally, a good practice safeguard: if an expression generates `NA` values, a warning is thrown to set `na_pass` explicitly. (#617)
 
 - Bugfix agents auto-generating a table label that was too long. They now get truncated (#614)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # pointblank (development version)
 
-- Add `na_pass` to `col_vals_expr()` for finer control of `NA` values. Additionally, a good practice safeguard: if an expression generates `NA` values, a warning is thrown to set `na_pass` explicitly. (#617)
+- Add `na_pass` to `col_vals_expr()` for finer control of `NA` values. Previously, `NA`s were ignored, but now they caught as failures with the default `na_pass = FALSE`. As a safeguard, if an expression generates `NA` values while `na_pass` is unset, a warning is thrown. (#617)
 
 - Bugfix agents auto-generating a table label that was too long. They now get truncated (#614)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pointblank (development version)
 
+- Add `na_pass` to `col_vals_expr()` for finer control of `NA` values (#617)
+
 - Bugfix agents auto-generating a table label that was too long. They now get truncated (#614)
 
 - Bugfix agents not searching the formula environment when materializing `~ tbl` (#599)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # pointblank (development version)
 
-- Add `na_pass` to `col_vals_expr()` for finer control of `NA` values. Previously, `NA`s were ignored, but now they caught as failures with the default `na_pass = FALSE`. As a safeguard, if an expression generates `NA` values while `na_pass` is unset, a warning is thrown. (#617)
+- Add `na_pass` to `col_vals_expr()` for finer control of `NA` values. Previously, `NA`s were ignored, but now they are caught as failures with the default `na_pass = FALSE`. As a safeguard, if an expression generates `NA` values while `na_pass` is not explicitly supplied, a warning is thrown. (#617)
 
 - Bugfix agents auto-generating a table label that was too long. They now get truncated (#614)
 

--- a/R/col_vals_expr.R
+++ b/R/col_vals_expr.R
@@ -68,6 +68,13 @@
 #' formally tested (so be mindful of this when using unsupported backends with
 #' **pointblank**).
 #'
+#' @section Missing Values:
+#'
+#' This validation function supports special handling of `NA` values. The
+#' `na_pass` argument will determine whether an `NA` value appearing in a test
+#' unit should be counted as a *pass* or a *fail*. The default of `na_pass =
+#' FALSE` means that any `NA`s encountered will accumulate failing test units.
+#'
 #' @section Preconditions:
 #'
 #' Providing expressions as `preconditions` means **pointblank** will preprocess
@@ -313,6 +320,7 @@ NULL
 col_vals_expr <- function(
     x,
     expr,
+    na_pass = FALSE,
     preconditions = NULL,
     segments = NULL,
     actions = NULL,
@@ -353,6 +361,7 @@ col_vals_expr <- function(
       create_agent(x, label = "::QUIET::") %>%
       col_vals_expr(
         expr = expr,
+        na_pass = na_pass,
         preconditions = preconditions,
         segments = segments,
         label = label,
@@ -400,6 +409,7 @@ col_vals_expr <- function(
         columns_expr = NA_character_,
         column = NA_character_,
         values = expr,
+        na_pass = na_pass,
         preconditions = preconditions,
         seg_expr = segments,
         seg_col = seg_col,
@@ -421,6 +431,7 @@ col_vals_expr <- function(
 expect_col_vals_expr <- function(
     object,
     expr,
+    na_pass = FALSE,
     preconditions = NULL,
     threshold = 1
 ) {
@@ -431,6 +442,7 @@ expect_col_vals_expr <- function(
     create_agent(tbl = object, label = "::QUIET::") %>%
     col_vals_expr(
       expr = {{ expr }},
+      na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(notify_at = threshold)
     ) %>%
@@ -476,6 +488,7 @@ expect_col_vals_expr <- function(
 test_col_vals_expr <- function(
     object,
     expr,
+    na_pass = FALSE,
     preconditions = NULL,
     threshold = 1
 ) {
@@ -484,6 +497,7 @@ test_col_vals_expr <- function(
     create_agent(tbl = object, label = "::QUIET::") %>%
     col_vals_expr(
       expr = {{ expr }},
+      na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(notify_at = threshold)
     ) %>%

--- a/R/col_vals_expr.R
+++ b/R/col_vals_expr.R
@@ -330,6 +330,11 @@ col_vals_expr <- function(
     active = TRUE
 ) {
 
+  # Mark if unspecified and resolve the default behavior at interrogate
+  if (missing(na_pass)) {
+    na_pass <- NA
+  }
+
   if (!inherits(expr, "call")) {
 
     if (rlang::is_formula(expr)) {
@@ -436,6 +441,11 @@ expect_col_vals_expr <- function(
     threshold = 1
 ) {
 
+  # Mark if unspecified and resolve the default behavior at interrogate
+  if (missing(na_pass)) {
+    na_pass <- NA
+  }
+
   fn_name <- "expect_col_vals_expr"
 
   vs <-
@@ -492,6 +502,11 @@ test_col_vals_expr <- function(
     preconditions = NULL,
     threshold = 1
 ) {
+
+  # Mark if unspecified and resolve the default behavior at interrogate
+  if (missing(na_pass)) {
+    na_pass <- NA
+  }
 
   vs <-
     create_agent(tbl = object, label = "::QUIET::") %>%

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -2119,19 +2119,23 @@ interrogate_expr <- function(
       dplyr::mutate(pb_is_good_ = !!expr)
 
     if (anyNA(tbl$pb_is_good_)) {
+
+      # Throw warning if `expr` results in `NA` values but `na_pass` was unset
       if (is.na(na_pass)) {
         warn(
           paste(
             "Expression generated `NA` value(s).",
             "Edit the `expr` or specify `na_pass` (default is `FALSE`)."
           ),
-          # "simpleWarning" lets it trickle up to test/expect functions
+          # "simpleWarning" lets it trickle up to the test/expect functions
           class = "simpleWarning"
         )
-        # Re-apply default `na_pass = FALSE`
+        # Re-apply user-facing default of `na_pass = FALSE`
         na_pass <- FALSE
       }
+
       tbl$pb_is_good_[is.na(tbl$pb_is_good_)] <- na_pass
+
     }
 
     tbl

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -2100,10 +2100,14 @@ interrogate_expr <- function(
   # Get the expression
   expr <- get_values_at_idx(agent = agent, idx = idx)
 
+  # Determine whether NAs should be allowed
+  na_pass <- get_column_na_pass_at_idx(agent = agent, idx = idx)
+
   # Create function for validating the `col_vals_expr()` step function
   tbl_val_expr <- function(
     table,
-    expr
+    expr,
+    na_pass
   ) {
 
     # Ensure that the input `table` is actually a table object
@@ -2112,12 +2116,20 @@ interrogate_expr <- function(
     expr <- expr[[1]]
 
     table %>%
-      dplyr::mutate(pb_is_good_ = !!expr) %>%
-      dplyr::filter(!is.na(pb_is_good_))
+      dplyr::mutate(
+        pb_is_good_ = !!expr,
+        pb_is_good_ = replace(pb_is_good_, is.na(pb_is_good_), !!na_pass)
+      )
   }
 
   # Perform rowwise validations for the column
-  pointblank_try_catch(tbl_val_expr(table = table, expr = expr))
+  pointblank_try_catch(
+    tbl_val_expr(
+      table = table,
+      expr = expr,
+      na_pass = na_pass
+    )
+  )
 }
 
 interrogate_specially <- function(

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -2115,11 +2115,27 @@ interrogate_expr <- function(
 
     expr <- expr[[1]]
 
-    table %>%
-      dplyr::mutate(
-        pb_is_good_ = !!expr,
-        pb_is_good_ = replace(pb_is_good_, is.na(pb_is_good_), !!na_pass)
-      )
+    tbl <- table %>%
+      dplyr::mutate(pb_is_good_ = !!expr)
+
+    if (anyNA(tbl$pb_is_good_)) {
+      if (is.na(na_pass)) {
+        warn(
+          paste(
+            "Expression generated `NA` value(s).",
+            "Edit the `expr` or specify `na_pass` (default is `FALSE`)."
+          ),
+          # "simpleWarning" lets it trickle up to test/expect functions
+          class = "simpleWarning"
+        )
+        # Re-apply default `na_pass = FALSE`
+        na_pass <- FALSE
+      }
+      tbl$pb_is_good_[is.na(tbl$pb_is_good_)] <- na_pass
+    }
+
+    tbl
+
   }
 
   # Perform rowwise validations for the column

--- a/man/col_vals_expr.Rd
+++ b/man/col_vals_expr.Rd
@@ -9,6 +9,7 @@
 col_vals_expr(
   x,
   expr,
+  na_pass = FALSE,
   preconditions = NULL,
   segments = NULL,
   actions = NULL,
@@ -18,9 +19,21 @@ col_vals_expr(
   active = TRUE
 )
 
-expect_col_vals_expr(object, expr, preconditions = NULL, threshold = 1)
+expect_col_vals_expr(
+  object,
+  expr,
+  na_pass = FALSE,
+  preconditions = NULL,
+  threshold = 1
+)
 
-test_col_vals_expr(object, expr, preconditions = NULL, threshold = 1)
+test_col_vals_expr(
+  object,
+  expr,
+  na_pass = FALSE,
+  preconditions = NULL,
+  threshold = 1
+)
 }
 \arguments{
 \item{x}{\emph{A pointblank agent or a data table}
@@ -38,6 +51,13 @@ commonly created with \code{\link[=create_agent]{create_agent()}}.}
 A predicate expression to use for this validation. This can either be in
 the form of a call made with the \code{expr()} function or as a one-sided \strong{R}
 formula (using a leading \code{~}).}
+
+\item{na_pass}{\emph{Allow missing values to pass validation}
+
+\verb{scalar<logical>} // \emph{default:} \code{FALSE}
+
+Should any encountered \code{NA} values be considered as passing test units? By
+default, this is \code{FALSE}. Set to \code{TRUE} to give \code{NA}s a pass.}
 
 \item{preconditions}{\emph{Input table modification prior to validation}
 
@@ -182,6 +202,14 @@ formally tested (so be mindful of this when using unsupported backends with
 \strong{pointblank}).
 }
 
+\section{Missing Values}{
+
+
+This validation function supports special handling of \code{NA} values. The
+\code{na_pass} argument will determine whether an \code{NA} value appearing in a test
+unit should be counted as a \emph{pass} or a \emph{fail}. The default of \code{na_pass = FALSE} means that any \code{NA}s encountered will accumulate failing test units.
+}
+
 \section{Preconditions}{
 
 
@@ -294,7 +322,7 @@ representation.
 
 R statement:
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\% 
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{agent \%>\%
   col_vals_expr(
     expr = ~ a \%\% 1 == 0,
     preconditions = ~ . \%>\% dplyr::filter(a < 10),
@@ -380,7 +408,7 @@ This way of using validation functions acts as a data filter. Data is passed
 through but should \code{stop()} if there is a single test unit failing. The
 behavior of side effects can be customized with the \code{actions} option.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\% 
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{tbl \%>\%
   col_vals_expr(expr = expr(a \%\% 1 == 0)) \%>\%
   dplyr::pull(a)
 #> [1] 1 2 1 7 8 6

--- a/tests/testthat/test-expectation_fns.R
+++ b/tests/testthat/test-expectation_fns.R
@@ -693,17 +693,17 @@ test_that("pointblank expectation function produce the correct results", {
   #
 
   expect_col_vals_expr(tbl, ~ a %% 1 == 0)
-  expect_col_vals_expr(tbl, ~ c %% 1 == 0)
+  expect_col_vals_expr(tbl, ~ c %% 1 == 0, na_pass = TRUE)
   expect_col_vals_expr(tbl, expr(a %% 1 == 0))
-  expect_col_vals_expr(tbl, expr(c %% 1 == 0))
+  expect_col_vals_expr(tbl, expr(c %% 1 == 0), na_pass = TRUE)
   expect_col_vals_expr(tbl, ~ case_when(
     b == 1 ~ a > 5 & c >= 1
-  ))
+  ), na_pass = TRUE)
   expect_col_vals_expr(tbl, expr(
     case_when(
       b == 1 ~ a > 5 & c >= 1
     )
-  ))
+  ), na_pass = TRUE)
 
   expect_success(expect_col_vals_expr(tbl, ~ a %% 1 == 0))
   expect_success(expect_col_vals_expr(tbl, ~ a %>% between(0, 10)))

--- a/tests/testthat/test-interrogate_with_agent.R
+++ b/tests/testthat/test-interrogate_with_agent.R
@@ -2016,3 +2016,29 @@ test_that("Select validation steps can be `active` or not", {
       )
   )
 })
+
+test_that("col_vals_expr(na_pass) works as expected #616", {
+
+  agent <- small_table %>%
+    create_agent() %>%
+    col_vals_equal(c, 3) %>%
+    col_vals_expr(expr(c == 3)) %>%
+    interrogate()
+
+  expect_identical(
+    agent$validation_set$tbl_checked[[1]][[1]],
+    agent$validation_set$tbl_checked[[2]][[1]]
+  )
+
+  agent <- small_table %>%
+    create_agent() %>%
+    col_vals_equal(c, 3, na_pass = TRUE) %>%
+    col_vals_expr(expr(c == 3), na_pass = TRUE) %>%
+    interrogate()
+
+  expect_identical(
+    agent$validation_set$tbl_checked[[1]][[1]],
+    agent$validation_set$tbl_checked[[2]][[1]]
+  )
+
+})

--- a/tests/testthat/test-interrogate_with_agent.R
+++ b/tests/testthat/test-interrogate_with_agent.R
@@ -2017,12 +2017,12 @@ test_that("Select validation steps can be `active` or not", {
   )
 })
 
-test_that("col_vals_expr(na_pass) works as expected #616", {
+test_that("col_vals_expr(na_pass) works as expected (#616)", {
 
   agent <- small_table %>%
     create_agent() %>%
     col_vals_equal(c, 3) %>%
-    col_vals_expr(expr(c == 3)) %>%
+    col_vals_expr(expr(c == 3), na_pass = FALSE) %>%
     interrogate()
 
   expect_identical(
@@ -2039,6 +2039,41 @@ test_that("col_vals_expr(na_pass) works as expected #616", {
   expect_identical(
     agent$validation_set$tbl_checked[[1]][[1]],
     agent$validation_set$tbl_checked[[2]][[1]]
+  )
+
+})
+
+test_that("col_vals_expr(na_pass) NA value handling (#617)", {
+
+  agent1 <- small_table %>%
+    create_agent() %>%
+    col_vals_expr(expr(c == 3)) %>%
+    interrogate()
+  expect_true(agent1$validation_set$eval_warning)
+
+  agent2 <- small_table %>%
+    create_agent() %>%
+    col_vals_expr(expr(c == 3), na_pass = FALSE) %>%
+    interrogate()
+  expect_false(agent2$validation_set$eval_warning)
+  expect_identical(
+    agent1$validation_set$tbl_checked,
+    agent2$validation_set$tbl_checked
+  )
+
+  # Warnings trickle up for test/expect functions
+  tbl <- data.frame(x = c(NA, 1))
+  expect_warning(
+    expect_false(
+      tbl %>%
+        test_col_vals_expr(expr(x == 1))
+    )
+  )
+  expect_warning(
+    expect_error(
+      tbl %>%
+        expect_col_vals_expr(expr(x == 1))
+    )
   )
 
 })

--- a/tests/testthat/test-test_fns.R
+++ b/tests/testthat/test-test_fns.R
@@ -275,21 +275,21 @@ test_that("pointblank expectation functions produce the correct results", {
   #
 
   expect_true(test_col_vals_expr(tbl, ~ a %% 1 == 0))
-  expect_true(test_col_vals_expr(tbl, ~ c %% 1 == 0))
+  expect_true(test_col_vals_expr(tbl, ~ c %% 1 == 0, na_pass = TRUE))
   expect_true(test_col_vals_expr(tbl, expr(a %% 1 == 0)))
-  expect_true(test_col_vals_expr(tbl, expr(c %% 1 == 0)))
+  expect_true(test_col_vals_expr(tbl, expr(c %% 1 == 0), na_pass = TRUE))
 
   expect_true(
     test_col_vals_expr(tbl, ~ case_when(
       b == 1 ~ a > 5 & c >= 1
-    ))
+    ), na_pass = TRUE)
   )
   expect_true(
     test_col_vals_expr(tbl, expr(
       case_when(
         b == 1 ~ a > 5 & c >= 1
       )
-    ))
+    ), na_pass = TRUE)
   )
 
   expect_true(test_col_vals_expr(tbl, ~ a < 0, threshold = 1000))


### PR DESCRIPTION
# Summary

This brings `col_vals_expr()` in like with other `col_*()` functions. Also resolves buggy interaction with `get_sundered_data()` (#616 )

```r
small_table %>% 
  create_agent() %>% 
  col_vals_expr(expr(c == 3), na_pass = FALSE) %>% # default
  interrogate() %>% 
  get_sundered_data()
#> # A tibble: 3 × 8
#>   date_time           date           a b             c     d e     f    
#>   <dttm>              <date>     <int> <chr>     <dbl> <dbl> <lgl> <chr>
#> 1 2016-01-04 11:00:00 2016-01-04     2 1-bcd-345     3 3423. TRUE  high 
#> 2 2016-01-05 13:32:00 2016-01-05     6 8-kdg-938     3 2343. TRUE  high 
#> 3 2016-01-15 18:46:00 2016-01-15     7 1-knw-093     3  843. TRUE  high

small_table %>% 
  create_agent() %>% 
  col_vals_expr(expr(c == 3), na_pass = TRUE) %>% 
  interrogate() %>% 
  get_sundered_data()
#> # A tibble: 5 × 8
#>   date_time           date           a b             c     d e     f    
#>   <dttm>              <date>     <int> <chr>     <dbl> <dbl> <lgl> <chr>
#> 1 2016-01-04 11:00:00 2016-01-04     2 1-bcd-345     3 3423. TRUE  high 
#> 2 2016-01-05 13:32:00 2016-01-05     6 8-kdg-938     3 2343. TRUE  high 
#> 3 2016-01-06 17:23:00 2016-01-06     2 5-jdo-903    NA 3892. FALSE mid  
#> 4 2016-01-15 18:46:00 2016-01-15     7 1-knw-093     3  843. TRUE  high 
#> 5 2016-01-30 11:23:00 2016-01-30     1 3-dka-303    NA 2230. TRUE  high
```

# Related GitHub Issues and PRs

- Ref: #616

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [x] I have listed any major changes in the [NEWS](https://github.com/rstudio/pointblank/blob/main/NEWS.md).
- [x] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/pointblank/tree/main/tests/testthat) for any new functionality.
