### PR TITLE
Use lower-case version of source details

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -895,7 +895,7 @@ get_tbl_information_dbi <- function(tbl) {
     # nocov end
 
   } else {
-    tbl_src <- gsub("^([a-z]*).*", "\\1", get_tbl_dbi_src_details(tbl))
+    tbl_src <- gsub("^([a-z]*).*", "\\1", tbl_src_details)
   }
 
   db_tbl_name <- as.character(dbplyr::remote_name(tbl))


### PR DESCRIPTION
# Summary

I came across this when I was trying to use a Redshift table. I ended up with a bank string `""` for `tbl_src` because the regular expression is looking for lower-case letters. The other code paths for specific types of databases use `tbl_src_details`, which is just the lower-case version of `get_tbl_dbi_src_details(tbl)`.

Would you like me to add anything to this PR?

# Related GitHub Issues and PRs

- Ref: # 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [ ] I have listed any major changes in the [NEWS](https://github.com/rstudio/pointblank/blob/main/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/pointblank/tree/main/tests/testthat) for any new functionality.
