### PR TITLE
Fix for testthat 3.3.0

### DIFF
--- a/tests/testthat/test-tidyselect_integration.R
+++ b/tests/testthat/test-tidyselect_integration.R
@@ -70,10 +70,10 @@ test_that("Full range of tidyselect features available in column selection", {
 
   # Supplying a character vector variable still works, but signals deprecation:
   rlang::local_options(lifecycle_verbosity = "warning")
-  expect_success(expect_warning(
-    expect_rows_distinct(tbl, exist_col),
+  expect_warning(
+    expect_success(expect_rows_distinct(tbl, exist_col)),
     "Using an external vector in selections was deprecated in tidyselect 1.1.0."
-  ))
+  )
 
 })
 


### PR DESCRIPTION
`expect_success()` now tests for exactly one success which means we need to change the order of the expectations.
