### PR TITLE
Added an infix resolution for log4r_step's message argument

### DIFF
--- a/R/logging.R
+++ b/R/logging.R
@@ -18,7 +18,6 @@
 #
 #------------------------------------------------------------------------------#
 
-
 # nocov start
 
 #' Enable logging of failure conditions at the validation step level
@@ -179,11 +178,10 @@
 #'
 #' @export
 log4r_step <- function(
-    x,
-    message = NULL,
-    append_to = "pb_log_file"
+  x,
+  message = NULL,
+  append_to = "pb_log_file"
 ) {
-
   rlang::check_installed("log4r", "to use the `log4r_step()` function.")
 
   type <- x$this_type
@@ -222,9 +220,15 @@ log4r_step <- function(
   # condition is present for this validation step *and*
   # there is a `log4r_step()` function ready for
   # evaluation at those higher severities
-  if (warn_val   && log4r_fn_present[1]) highest_level <- 3
-  if (stop_val   && log4r_fn_present[2]) highest_level <- 4
-  if (notify_val && log4r_fn_present[3]) highest_level <- 5
+  if (warn_val && log4r_fn_present[1]) {
+    highest_level <- 3
+  }
+  if (stop_val && log4r_fn_present[2]) {
+    highest_level <- 4
+  }
+  if (notify_val && log4r_fn_present[3]) {
+    highest_level <- 5
+  }
 
   if (highest_level > level_val) {
     return(invisible(NULL))
@@ -236,12 +240,15 @@ log4r_step <- function(
 
   logger <- log4r::logger(appenders = appenders)
 
+  message <- message %||%
+    "Step {x$i} exceeded the {level} failure threshold \\
+      (f_failed = {x$f_failed}) ['{x$type}']"
+
   log4r::levellog(
     logger = logger,
     level = level_val,
     message = glue::glue(
-      "Step {x$i} exceeded the {level} failure threshold \\
-      (f_failed = {x$f_failed}) ['{x$type}']"
+      message
     )
   )
 }

--- a/tests/testthat/test-log4r_step.R
+++ b/tests/testthat/test-log4r_step.R
@@ -1,0 +1,174 @@
+test_that("log4r_step() uses custom message argument correctly", {
+  
+  skip_if_not_installed("log4r")
+  
+  # Use a fixed filename in tempdir
+  temp_log_file <- file.path(tempdir(), "test_log4r_custom.log")
+  if (file.exists(temp_log_file)) unlink(temp_log_file)
+  on.exit(unlink(temp_log_file), add = TRUE)
+  
+  # Test with custom message
+  al_custom <-
+    action_levels(
+      warn_at = 0.1,
+      fns = list(
+        warn = ~ log4r_step(
+          x,
+          message = "Custom: Step {x$i} had {x$n_failed} failing units.",
+          append_to = file.path(tempdir(), "test_log4r_custom.log")
+        )
+      )
+    )
+  
+  agent_custom <-
+    create_agent(
+      tbl = small_table,
+      tbl_name = "small_table",
+      label = "Custom message test",
+      actions = al_custom
+    ) %>%
+    col_vals_lt(a, value = 7) %>%
+    interrogate()
+  
+  # Read the log file
+  log_contents <- readLines(temp_log_file)
+  
+  # Check that the custom message appears in the log
+  expect_true(any(grepl("Custom: Step 1 had 2 failing units", log_contents)))
+  expect_false(any(grepl("exceeded the WARN failure threshold", log_contents)))
+  
+  # Clean up for next test
+  unlink(temp_log_file)
+  
+  # Test with default message (NULL)
+  temp_log_file2 <- file.path(tempdir(), "test_log4r_default.log")
+  if (file.exists(temp_log_file2)) unlink(temp_log_file2)
+  on.exit(unlink(temp_log_file2), add = TRUE)
+  
+  al_default <-
+    action_levels(
+      warn_at = 0.1,
+      fns = list(
+        warn = ~ log4r_step(
+          x,
+          append_to = file.path(tempdir(), "test_log4r_default.log")
+        )
+      )
+    )
+  
+  agent_default <-
+    create_agent(
+      tbl = small_table,
+      tbl_name = "small_table",
+      label = "Default message test",
+      actions = al_default
+    ) %>%
+    col_vals_lt(a, value = 7) %>%
+    interrogate()
+  
+  # Read the log file
+  log_contents_default <- readLines(temp_log_file2)
+  
+  # Check that the default message appears in the log
+  expect_true(any(grepl("exceeded the WARN failure threshold", log_contents_default)))
+  expect_true(any(grepl("f_failed = 0.15385", log_contents_default)))
+  expect_true(any(grepl("col_vals_lt", log_contents_default)))
+})
+
+test_that("log4r_step() message argument supports glue syntax", {
+  
+  skip_if_not_installed("log4r")
+  
+  # Use a fixed filename in tempdir
+  temp_log_file <- file.path(tempdir(), "test_log4r_glue.log")
+  if (file.exists(temp_log_file)) unlink(temp_log_file)
+  on.exit(unlink(temp_log_file), add = TRUE)
+  
+  # Test with glue-style message using various x-list components
+  al_glue <-
+    action_levels(
+      warn_at = 0.1,
+      fns = list(
+        warn = ~ log4r_step(
+          x,
+          message = "Step {x$i}: {x$type} validation. Passed: {x$n_passed}, Failed: {x$n_failed}",
+          append_to = file.path(tempdir(), "test_log4r_glue.log")
+        )
+      )
+    )
+  
+  agent_glue <-
+    create_agent(
+      tbl = small_table,
+      tbl_name = "small_table",
+      actions = al_glue
+    ) %>%
+    col_vals_gt(d, value = 10000) %>%
+    interrogate()
+  
+  # Read the log file
+  log_contents <- readLines(temp_log_file)
+  
+  # Check that the glue interpolation worked
+  expect_true(any(grepl("Step 1: col_vals_gt validation", log_contents)))
+  expect_true(any(grepl("Passed: .*, Failed: .*", log_contents)))
+})
+
+test_that("log4r_step() respects severity hierarchy with custom messages", {
+  
+  skip_if_not_installed("log4r")
+  
+  # Use fixed filenames in tempdir
+  temp_log_warn <- file.path(tempdir(), "test_log4r_warn.log")
+  temp_log_stop <- file.path(tempdir(), "test_log4r_stop.log")
+  if (file.exists(temp_log_warn)) unlink(temp_log_warn)
+  if (file.exists(temp_log_stop)) unlink(temp_log_stop)
+  on.exit({
+    unlink(temp_log_warn)
+    unlink(temp_log_stop)
+  }, add = TRUE)
+  
+  # Create action levels with both warn and stop
+  al_multi <-
+    action_levels(
+      warn_at = 0.1,
+      stop_at = 0.2,
+      fns = list(
+        warn = ~ log4r_step(
+          x,
+          message = "WARN: Step {x$i}",
+          append_to = file.path(tempdir(), "test_log4r_warn.log")
+        ),
+        stop = ~ log4r_step(
+          x,
+          message = "STOP: Step {x$i}",
+          append_to = file.path(tempdir(), "test_log4r_stop.log")
+        )
+      )
+    )
+  
+  agent_multi <-
+    create_agent(
+      tbl = small_table,
+      tbl_name = "small_table",
+      actions = al_multi
+    ) %>%
+    col_vals_gt(d, value = 5000) %>%  # This will fail enough to trigger stop
+    interrogate()
+  
+  # The stop condition should be logged, not the warn
+  # (because stop is higher severity and both thresholds are exceeded)
+  if (file.exists(temp_log_stop) && file.size(temp_log_stop) > 0) {
+    log_contents_stop <- readLines(temp_log_stop)
+    expect_true(any(grepl("STOP: Step 1", log_contents_stop)))
+  }
+  
+  # Warn should not be logged when stop threshold is also exceeded
+  if (file.exists(temp_log_warn)) {
+    # File might exist but should be empty or not contain the message
+    if (file.size(temp_log_warn) > 0) {
+      log_contents_warn <- readLines(temp_log_warn)
+      expect_false(any(grepl("WARN: Step 1", log_contents_warn)))
+    }
+  }
+})


### PR DESCRIPTION
Added a line to allow for non-default message arugments in `log4r_step()` - assuming this is actually a bug.

Fixes: #654

# Checklist

- [X] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
- [X] I have listed any major changes in the [NEWS](https://github.com/rstudio/pointblank/blob/main/NEWS.md).
- [ ] I have added [`testthat`](https://github.com/r-lib/testthat) unit tests to [`tests/testthat`](https://github.com/rstudio/pointblank/tree/main/tests/testthat) for any new functionality.
