### PR TITLE
fix: ampersand use in `specially()`

### DIFF
--- a/R/get_agent_report.R
+++ b/R/get_agent_report.R
@@ -873,7 +873,36 @@ get_agent_report <- function(
         assertion_str <- assertion_type[x]
 
         if (assertion_str == "specially") {
-          values_i <- capture_function(values_i)
+
+          text <- capture_function(values_i)
+          text <- gsub("$", "&dollar;", text, fixed = TRUE)
+
+          if (size == "small") {
+
+            return(
+              paste0(
+                "<div><p title=\"", text, "\" style=\"margin-top: 0px; ",
+                "margin-bottom: 0px; ",
+                "font-family: monospace; white-space: nowrap; ",
+                "text-overflow: ellipsis; overflow: hidden;\">",
+                text,
+                "</p></div>"
+              )
+            )
+
+          } else {
+
+            return(
+              paste0(
+                "<div><p style=\"margin-top: 0px; ",
+                "margin-bottom: 0px; ",
+                "font-size: 11px; white-space: nowrap; ",
+                "text-overflow: ellipsis; overflow: hidden;\">",
+                "<code>", text, "</code>",
+                "</p></div>"
+              )
+            )
+          }
         }
 
         # In the `serially()` step, there are two possibilities for what

--- a/tests/testthat/test-get_agent_report.R
+++ b/tests/testthat/test-get_agent_report.R
@@ -263,6 +263,31 @@ test_that("The correct title is rendered in the agent report", {
   # )
 })
 
+test_that("specially() report handles ampersands and special chars", {
+
+  agent <-
+    create_agent(tbl = small_table) %>%
+    specially(fn = function(x) x$a > 1 & x$d < 10000) %>%
+    interrogate()
+
+  # The gt report should render without KaTeX parse errors
+  expect_no_error(
+    report_html <- get_agent_report(agent) %>%
+      gt::as_raw_html(inline_css = FALSE)
+  )
+
+  # The display_table = FALSE path should also work
+  report_tbl <- get_agent_report(agent, display_table = FALSE)
+  expect_equal(nrow(report_tbl), 1)
+  expect_equal(report_tbl$type, "specially")
+
+  # The small size variant should also render without error
+  expect_no_error(
+    get_agent_report(agent, size = "small") %>%
+      gt::as_raw_html(inline_css = FALSE)
+  )
+})
+
 test_that("col_vals_expr() shows used columns", {
 
   tbl <-


### PR DESCRIPTION
This PR improves the handling and display of special characters in the output of `specially()` assertions within the agent report.

Fixes: https://github.com/rstudio/pointblank/issues/661