### PR TITLE
docs: remove log4r references

### DIFF
--- a/inst/translations/ES/vignettes/VALID-I.Rmd
+++ b/inst/translations/ES/vignettes/VALID-I.Rmd
@@ -170,16 +170,16 @@ agent
 
 <img src="images/agent_report_2.png" width=100%>
 
-It's possible to invoke a function when a particular failure condition is met and this can be set in the `action_levels()` function and made part of the `action_levels` object. One example of a function that can be used is the included `log4r_step()` function for logging failure conditions across validation steps. Let's make a new `action_levels` object and include the logging function in the `WARN` and `STOP` failure conditions. Note that the function calls must be written as one-sided **R** formulas.
+It's possible to invoke a custom function when a particular failure condition is met and this can be set in the `action_levels()` function and made part of the `action_levels` object. Let's make a new `action_levels` object and include a custom logging function in the `WARN` and `STOP` failure conditions. Note that the function calls must be written as one-sided **R** formulas, and the `x` variable provides access to the x-list for each validation step.
 
 ```{r action_levels_set_2, eval=FALSE}
-al <- 
+al <-
   action_levels(
     warn_at = 0.1,
     stop_at = 0.2,
     fns = list(
-      warn = ~ log4r_step(x),
-      stop = ~ log4r_step(x)
+      warn = ~ message("Step ", x$i, " exceeded the WARN threshold."),
+      stop = ~ message("Step ", x$i, " exceeded the STOP threshold.")
     )
   )
 ```
@@ -190,19 +190,10 @@ Printing this new `al` object will show us the failure threshold settings and th
 al
 ```
 
-```
-── The `action_levels` settings ────────────────────────────────────────────
-WARN failure threshold of 0.1 of all test units.
-\fns\ ~ log4r_step(x)
-STOP failure threshold of 0.2 of all test units.
-\fns\ ~ log4r_step(x)
-──────────────────────────────────────────────────────────────────────────
-```
-
-Using this new `al` object with our validation workflow will result in failures at certain validation steps to be logged. By default, this is to a file named `"pb_log_file"` in the working directory but the `log4r_step()` function is flexible for allowing any **log4r** appender to be used. Running the following data validation code
+Using this new `al` object with our validation workflow will result in our custom functions being called at certain validation steps. Running the following data validation code
 
 ```{r agent_small_table_3, eval=FALSE}
-agent <- 
+agent <-
   create_agent(
     tbl = small_table,
     tbl_name = "small_table",
@@ -230,22 +221,7 @@ x Step 4: STOP condition met.
 ── Interrogation Completed ─────────────────────────────────────────────────
 ```
 
-and the file `"pb_log_file"` can be looked at with `readLines()`, showing us four entries (one for each validation step with at least a `WARN` condition).
-
-```{r read_log_file, eval=FALSE}
-readLines("pb_log_file")
-```
-
-```
-[1] "ERROR [2020-11-06 01:26:07] Step 2 exceeded the STOP failure threshold (f_failed = 0.46154) ['col_vals_in_set']" 
-[2] "WARN  [2020-11-06 01:26:07] Step 3 exceeded the WARN failure threshold (f_failed = 0.15385) ['col_vals_lt']"     
-[3] "ERROR [2020-11-06 01:26:07] Step 4 exceeded the STOP failure threshold (f_failed = 0.53846) ['col_vals_regex']"  
-[4] "WARN  [2020-11-06 01:26:07] Step 5 exceeded the WARN failure threshold (f_failed = 0.07692) ['col_vals_between']"
-```
-
-The `log4r_step()` function is a bit special in that it only provides the most severe condition in a given validation step, so long as the function call is present in multiple conditions of the `list()` given to `action_levels()`'s `fns` argument.
-
-It's possible to provide any custom-made function that generates some side effect in the same way as `log4r_step()` is used. Just like `log4r_step()`, the custom function can take advantage of the `x` variable, which is the x-list for the validation step. Let's take a look at what that is for step 2 (the `col_vals_in_set` validation step) by using the `get_agent_x_list()` function:
+Any custom function can take advantage of the `x` variable, which is the x-list for the validation step. Let's take a look at what that is for step 2 (the `col_vals_in_set` validation step) by using the `get_agent_x_list()` function:
 
 ```{r get_agent_x_list, eval=FALSE}
 x <- get_agent_x_list(agent, i = 2)

--- a/inst/translations/ES/vignettes/VALID-II.Rmd
+++ b/inst/translations/ES/vignettes/VALID-II.Rmd
@@ -96,10 +96,10 @@ The `action_levels()` function can be as useful here as it is for the [**VALID-I
 
 Compared to the [**VALID-I**](../articles/VALID-I.html) workflow, which deals more with reporting, having actions triggered by failures in the **VALID-II** workflow is probably more useful and important. We can imagine a situation where an **R** script is deployed with data validation interspersed throughout. Depending on the deployment, we may desire a hard stop (affecting the downstream components), or, we may want a softer approach with warning and logging.
 
-Let's try a hybrid approach where each of three available conditions have failure threshold levels set and an associated function to invoke. The functions to invoke at each condition can be whatever makes sense for the workflow (i.e., we don't have to issue warnings in the `WARN` condition if we want something else). Here, we will use a `warning()` for `WARN`, a `stop()` for `STOP`, and a logging function (`log4r_step()`) for `NOTIFY`. Here's how we might create such an `action_levels` object with `action_levels()`:
+Let's try a hybrid approach where each of three available conditions have failure threshold levels set and an associated function to invoke. The functions to invoke at each condition can be whatever makes sense for the workflow (i.e., we don't have to issue warnings in the `WARN` condition if we want something else). Here, we will use a `warning()` for `WARN`, a `stop()` for `STOP`, and a `message()` for `NOTIFY`. Here's how we might create such an `action_levels` object with `action_levels()`:
 
 ```{r action_levels_set_1}
-al <- 
+al <-
   action_levels(
     warn_at = 0.1,
     stop_at = 0.2,
@@ -107,7 +107,7 @@ al <-
     fns = list(
       warn = ~ warning("WARN threshold exceeded."),
       stop = ~ stop("STOP threshold exceeded."),
-      notify = ~ log4r_step(x)
+      notify = ~ message("Step ", x$i, " exceeded the NOTIFY threshold.")
     )
   )
 ```
@@ -116,17 +116,6 @@ Once we assigned the `action_levels` to an object (in this case, as `al`) we can
 
 ```{r eval=FALSE}
 al
-```
-
-```
-── The `action_levels` settings ────────────────────────────────────────────
-WARN failure threshold of 0.1 of all test units.
-\fns\ ~ warning("WARN threshold exceeded.")
-STOP failure threshold of 0.2 of all test units.
-\fns\ ~ stop("STOP threshold exceeded.")
-NOTIFY failure threshold of 0.3 of all test units.
-\fns\ ~ log4r_step(x)
-──────────────────────────────────────────────────────────────────────────
 ```
 
 Finally, we will apply this object to every validation function call in the expression (changed slightly to result in more test units failing).
@@ -140,14 +129,4 @@ small_table %>%
   col_vals_between(vars(d), left = 0, right = 4000, actions = al)
 ```
 
-In addition to an error and a warning, the `log4r_step()` function used for the `NOTIFY` condition generates, in this case, a new `"pb_log_file"` text file for logs. We can examine it with `readLines()`; it has a single entry that relates to `Step 1` (the `col_vals_in_set()` step):
-
-```{r read_log_file, eval=FALSE}
-readLines("pb_log_file")
-```
-
-```
-FATAL [2020-11-09 00:23:48] Step 1 exceeded the NOTIFY failure threshold (f_failed = 0.46154) ['col_vals_in_set']
-```
-
-The `log4r_step()` function offered by **pointblank** is shown in examples and explained in more detail in the [*VALID-I: Data Quality Reporting Workflow*](../articles/VALID-I.html) article.
+In addition to an error and a warning, the custom function used for the `NOTIFY` condition will emit a message for any validation step that exceeds the `NOTIFY` threshold. Custom action functions have access to the x-list for each validation step through the `x` variable (as described in the [*VALID-I: Data Quality Reporting Workflow*](../articles/VALID-I.html) article).

--- a/inst/translations/man-ES.R
+++ b/inst/translations/man-ES.R
@@ -270,10 +270,8 @@
 #' personalizable.
 #' 
 #' Las funciones [x_write_disk()], [yaml_write()] permiten la escritura de
-#' objetos **pointblank** al disco. Además, la función [log4r_step()] tiene
-#' el argumento `append_to` que acepta nombres de archivo, y es razonable que un
-#' La serie de archivos de registro se puede diferenciar por un componente de
-#' fecha en el nombre esquema. La modificación de la cadena del nombre del
+#' objetos **pointblank** al disco. La serie de archivos de registro se puede
+#' diferenciar por un componente de fecha en el nombre esquema. La modificación de la cadena del nombre del
 #' archivo tiene efecto inmediatamente, pero no en el momento de escribir un
 #' archivo en el disco. En la mayoría de los casos, especialmente cuando usando
 #' `affix_date()` con las funciones de escritura de archivos antes mencionadas,

--- a/vignettes/VALID-I.Rmd
+++ b/vignettes/VALID-I.Rmd
@@ -174,16 +174,16 @@ agent
 
 <img src="images/agent_report_2.png" width=100%>
 
-It's possible to invoke a function when a particular failure condition is met and this can be set in the `action_levels()` function and made part of the `action_levels` object. One example of a function that can be used is the included `log4r_step()` function for logging failure conditions across validation steps. Let's make a new `action_levels` object and include the logging function in the `WARN` and `STOP` failure conditions. Note that the function calls must be written as one-sided **R** formulas.
+It's possible to invoke a custom function when a particular failure condition is met and this can be set in the `action_levels()` function and made part of the `action_levels` object. Let's make a new `action_levels` object and include a custom logging function in the `WARN` and `STOP` failure conditions. Note that the function calls must be written as one-sided **R** formulas, and the `x` variable provides access to the x-list for each validation step.
 
 ```{r action_levels_set_2}
-al <- 
+al <-
   action_levels(
     warn_at = 0.1,
     stop_at = 0.2,
     fns = list(
-      warn = ~ log4r_step(x),
-      stop = ~ log4r_step(x)
+      warn = ~ message("Step ", x$i, " exceeded the WARN threshold."),
+      stop = ~ message("Step ", x$i, " exceeded the STOP threshold.")
     )
   )
 ```
@@ -194,10 +194,10 @@ Printing this new `al` object will show us the failure threshold settings and th
 al
 ```
 
-Using this new `al` object with our validation workflow will result in failures at certain validation steps to be logged. By default, this is to a file named `"pb_log_file"` in the working directory but the `log4r_step()` function is flexible for allowing any **log4r** *appender* to be used. Running the following data validation code
+Using this new `al` object with our validation workflow will result in our custom functions being called at certain validation steps. Running the following data validation code
 
 ```{r agent_small_table_3, eval=FALSE}
-agent <- 
+agent <-
   create_agent(
     tbl = small_table,
     tbl_name = "small_table",
@@ -225,22 +225,7 @@ x Step 4: STOP condition met.
 ── Interrogation Completed ─────────────────────────────────────────────────
 ```
 
-and the file `"pb_log_file"` can be looked at with `readLines()`, showing us four entries (one for each validation step with at least a `WARN` condition).
-
-```{r read_log_file, eval=FALSE}
-readLines("pb_log_file")
-```
-
-```
-[1] "ERROR [2020-11-06 01:26:07] Step 2 exceeded the STOP failure threshold (f_failed = 0.46154) ['col_vals_in_set']" 
-[2] "WARN  [2020-11-06 01:26:07] Step 3 exceeded the WARN failure threshold (f_failed = 0.15385) ['col_vals_lt']"     
-[3] "ERROR [2020-11-06 01:26:07] Step 4 exceeded the STOP failure threshold (f_failed = 0.53846) ['col_vals_regex']"  
-[4] "WARN  [2020-11-06 01:26:07] Step 5 exceeded the WARN failure threshold (f_failed = 0.07692) ['col_vals_between']"
-```
-
-The `log4r_step()` function is a bit special in that it only provides the most severe condition in a given validation step, so long as the function call is present in multiple conditions of the `list()` given to `action_levels()`'s `fns` argument.
-
-It's possible to provide any custom-made function that generates some side effect in the same way as `log4r_step()` is used. Just like `log4r_step()`, the custom function can take advantage of the `x` variable, which is the x-list for the validation step. Let's take a look at what that is for step 2 (the `col_vals_in_set` validation step) by using the `get_agent_x_list()` function:
+Any custom function can take advantage of the `x` variable, which is the x-list for the validation step. Let's take a look at what that is for step 2 (the `col_vals_in_set` validation step) by using the `get_agent_x_list()` function:
 
 ```{r get_agent_x_list, eval=FALSE}
 x <- get_agent_x_list(agent, i = 2)

--- a/vignettes/VALID-II.Rmd
+++ b/vignettes/VALID-II.Rmd
@@ -96,10 +96,10 @@ The `action_levels()` function can be as useful here as it is for the [**VALID-I
 
 Compared to the [**VALID-I**](../articles/VALID-I.html) workflow, which deals more with reporting, having actions triggered by failures in the **VALID-II** workflow is probably more useful and important. We can imagine a situation where an **R** script is deployed with data validation interspersed throughout. Depending on the deployment, we may desire a hard stop (affecting the downstream components), or, we may want a softer approach with warning and logging.
 
-Let's try a hybrid approach where each of three available conditions have failure threshold levels set and an associated function to invoke. The functions to invoke at each condition can be whatever makes sense for the workflow (i.e., we don't have to issue warnings in the `WARN` condition if we want something else). Here, we will use a `warning()` for `WARN`, a `stop()` for `STOP`, and a logging function (`log4r_step()`) for `NOTIFY`. Here's how we might create such an `action_levels` object with `action_levels()`:
+Let's try a hybrid approach where each of three available conditions have failure threshold levels set and an associated function to invoke. The functions to invoke at each condition can be whatever makes sense for the workflow (i.e., we don't have to issue warnings in the `WARN` condition if we want something else). Here, we will use a `warning()` for `WARN`, a `stop()` for `STOP`, and a `message()` for `NOTIFY`. Here's how we might create such an `action_levels` object with `action_levels()`:
 
 ```{r action_levels_set_1}
-al <- 
+al <-
   action_levels(
     warn_at = 0.1,
     stop_at = 0.2,
@@ -107,7 +107,7 @@ al <-
     fns = list(
       warn = ~ warning("WARN threshold exceeded."),
       stop = ~ stop("STOP threshold exceeded."),
-      notify = ~ log4r_step(x)
+      notify = ~ message("Step ", x$i, " exceeded the NOTIFY threshold.")
     )
   )
 ```
@@ -129,14 +129,4 @@ small_table %>%
   col_vals_between(d, left = 0, right = 4000, actions = al)
 ```
 
-In addition to an error and a warning, the `log4r_step()` function used for the `NOTIFY` condition generates, in this case, a new `"pb_log_file"` text file for logs. We can examine it with `readLines()`; it has a single entry that relates to `Step 1` (the `col_vals_in_set()` step):
-
-```{r read_log_file, eval=FALSE}
-readLines("pb_log_file")
-```
-
-```
-FATAL [2020-11-09 00:23:48] Step 1 exceeded the NOTIFY failure threshold (f_failed = 0.46154) ['col_vals_in_set']
-```
-
-The `log4r_step()` function offered by **pointblank** is shown in examples and explained in more detail in the [*VALID-I: Data Quality Reporting Workflow*](../articles/VALID-I.html) article.
+In addition to an error and a warning, the custom function used for the `NOTIFY` condition will emit a message for any validation step that exceeds the `NOTIFY` threshold. Custom action functions have access to the x-list for each validation step through the `x` variable (as described in the [*VALID-I: Data Quality Reporting Workflow*](../articles/VALID-I.html) article).


### PR DESCRIPTION
This PR updates the documentation and examples to remove the use of the `log4r_step()` logging function (which has been removed from the package).

Fixes: https://github.com/rstudio/pointblank/issues/676