### PR TITLE
fix: schema check fails supplied a data frame

### DIFF
--- a/R/col_schema_match.R
+++ b/R/col_schema_match.R
@@ -615,6 +615,17 @@ col_schema <- function(
 
   x <- rlang::list2(...)
 
+  # If a single unnamed table object was passed via `...`, treat it as `.tbl`
+  if (
+    is.null(.tbl) &&
+    length(x) == 1L &&
+    (is.null(names(x)) || !nzchar(names(x))) &&
+    inherits(x[[1]], "data.frame")
+  ) {
+    .tbl <- x[[1]]
+    x <- list()
+  }
+
   # Transform SQL column types to lowercase to allow
   # both uppercase and lowercase conventions while
   # standardizing the input

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -2644,7 +2644,7 @@ interrogate_col_schema_match <- function(
 
       unit_results <- c()
 
-      for (i in seq_along(length(table_schema_y))) {
+      for (i in seq_along(table_schema_y)) {
 
         unit_results <-
           c(

--- a/tests/testthat/test-col_schema.R
+++ b/tests/testthat/test-col_schema.R
@@ -241,3 +241,18 @@ test_that("`col_schema_match()` works properly", {
   expect_error(tbl %>% col_schema_match(schema_obj_cnc_2, complete = FALSE, in_order = FALSE))
   expect_error(tbl %>% col_schema_match(schema_obj_cnc_3, complete = FALSE, in_order = FALSE))
 })
+
+test_that("col_schema() with positional table arg works in pipeline (#657)", {
+
+  schema_from_tbl <- col_schema(tbl)
+
+  # Should pass when validating the same table
+
+  expect_identical(tbl %>% col_schema_match(schema_from_tbl), tbl)
+
+  # Should also work with is_exact = FALSE
+  expect_identical(
+    tbl %>% col_schema_match(schema_from_tbl, is_exact = FALSE),
+    tbl
+  )
+})

--- a/tests/testthat/test-schema.R
+++ b/tests/testthat/test-schema.R
@@ -716,3 +716,86 @@ test_that("The `test_cols_schema_match()` function works", {
       )
   )
 })
+
+test_that("col_schema() accepts a table as a positional argument (#657)", {
+
+  # A schema generated from a table via positional arg should
+  # be identical to one created with .tbl
+  schema_positional <- col_schema(small_table)
+  schema_tbl_arg <- col_schema(.tbl = small_table)
+
+  expect_identical(schema_positional, schema_tbl_arg)
+  expect_s3_class(schema_positional, "col_schema")
+  expect_s3_class(schema_positional, "r_type")
+  expect_equal(names(schema_positional), colnames(small_table))
+
+  # Validating a table against a schema from itself should pass
+  # (agent workflow)
+  agent <-
+    create_agent(
+      tbl = small_table,
+      actions = action_levels(stop_at = 1)
+    ) %>%
+    col_schema_match(schema = col_schema(small_table)) %>%
+    interrogate()
+
+  expect_true(all_passed(agent))
+
+  # (test workflow)
+  expect_true(
+    small_table %>%
+      test_col_schema_match(schema = col_schema(small_table))
+  )
+
+  # (expect workflow)
+  expect_success(
+    small_table %>%
+      expect_col_schema_match(schema = col_schema(small_table))
+  )
+
+  # Named args should still work as before
+  schema_named <- col_schema(a = "integer", b = "character")
+  expect_equal(names(schema_named), c("a", "b"))
+  expect_equal(schema_named[["a"]], "integer")
+})
+
+test_that("is_exact = FALSE validates all columns, not just the first (#657)", {
+
+  tbl <- dplyr::tibble(a = 1L, b = "x", c = 3.0)
+
+  # Wrong type on second column should fail
+  expect_false(
+    tbl %>%
+      test_col_schema_match(
+        schema = col_schema(a = "integer", b = "integer", c = "numeric"),
+        is_exact = FALSE
+      )
+  )
+
+  # Wrong type on third column should fail
+  expect_false(
+    tbl %>%
+      test_col_schema_match(
+        schema = col_schema(a = "integer", b = "character", c = "logical"),
+        is_exact = FALSE
+      )
+  )
+
+  # Correct types should pass
+  expect_true(
+    tbl %>%
+      test_col_schema_match(
+        schema = col_schema(a = "integer", b = "character", c = "numeric"),
+        is_exact = FALSE
+      )
+  )
+
+  # Wrong column name on second column should fail
+  expect_false(
+    tbl %>%
+      test_col_schema_match(
+        schema = col_schema(a = "integer", z = "character", c = "numeric"),
+        is_exact = FALSE
+      )
+  )
+})


### PR DESCRIPTION
This PR fixes `col_schema()` and related schema-matching functions in two main ways: it allows a table to be passed as a positional argument to `col_schema()`, making the API more flexible, and it fixes a bug in the schema validation loop to ensure all columns are checked when `is_exact = FALSE`.

Fixes: https://github.com/rstudio/pointblank/issues/657