### PR TITLE
Add tests for is_exact=FALSE with logical cols

### DIFF
--- a/tests/testthat/test-col_schema.R
+++ b/tests/testthat/test-col_schema.R
@@ -256,3 +256,25 @@ test_that("col_schema() with positional table arg works in pipeline (#657)", {
     tbl
   )
 })
+
+test_that("is_exact = FALSE catches wrong types on logical columns in pipeline (#670)", {
+
+  # Wrong type for logical column should error in pipeline
+  expect_error(
+    data.frame(a = 1:2, b = rep(TRUE, 2)) %>%
+      col_schema_match(
+        col_schema(a = "integer", b = "anything"),
+        is_exact = FALSE
+      )
+  )
+
+  # Correct type for logical column should pass
+  expect_identical(
+    data.frame(a = 1:2, b = rep(TRUE, 2)) %>%
+      col_schema_match(
+        col_schema(a = "integer", b = "logical"),
+        is_exact = FALSE
+      ),
+    data.frame(a = 1:2, b = rep(TRUE, 2))
+  )
+})

--- a/tests/testthat/test-schema.R
+++ b/tests/testthat/test-schema.R
@@ -799,3 +799,45 @@ test_that("is_exact = FALSE validates all columns, not just the first (#657)", {
       )
   )
 })
+
+test_that("is_exact = FALSE catches wrong types on logical columns (#670)", {
+
+  tbl_with_logical <- data.frame(a = 1:2, b = rep(TRUE, 2))
+  tbl_with_na <- data.frame(a = 1:2, b = rep(NA, 2))
+
+  # Correct types should pass
+  expect_true(
+    tbl_with_logical %>%
+      test_col_schema_match(
+        schema = col_schema(a = "integer", b = "logical"),
+        is_exact = FALSE
+      )
+  )
+
+  # Wrong type for a logical column should fail
+  expect_false(
+    tbl_with_logical %>%
+      test_col_schema_match(
+        schema = col_schema(a = "integer", b = "anything"),
+        is_exact = FALSE
+      )
+  )
+
+  # Also fails for NA-only logical columns
+  expect_false(
+    tbl_with_na %>%
+      test_col_schema_match(
+        schema = col_schema(a = "integer", b = "anything"),
+        is_exact = FALSE
+      )
+  )
+
+  # Wrong type on a non-logical column should still fail
+  expect_false(
+    tbl_with_na %>%
+      test_col_schema_match(
+        schema = col_schema(a = "anything", b = "logical"),
+        is_exact = FALSE
+      )
+  )
+})


### PR DESCRIPTION
This PR adds new tests to improve validation of logical column types when using the `is_exact = FALSE` option in schema matching functions. These tests ensure that logical columns are correctly validated in both pipelines and direct function calls, catching cases where the column type does not match the expected schema.

Fixes: https://github.com/rstudio/pointblank/issues/670