### PR TITLE
fix: pipe replacements

### DIFF
--- a/R/action_levels.R
+++ b/R/action_levels.R
@@ -497,8 +497,8 @@ stock_stoppage <- function(x) {
   operator <- prep_operator_text(fn_name = x$type)
 
   if (grepl("between", fn_name)) {
-    value_1 <- prep_values_text(x$values) %>% tidy_gsub(",.*", "")
-    value_2 <- prep_values_text(x$values) %>% tidy_gsub(".*, ", "")
+    value_1 <- tidy_gsub(prep_values_text(x$values), ",.*", "")
+    value_2 <- tidy_gsub(prep_values_text(x$values), ".*, ", "")
   }
 
   if (grepl("col_is", fn_name)) {
@@ -529,8 +529,8 @@ stock_warning <- function(x) {
   operator <- prep_operator_text(fn_name = x$type)
 
   if (grepl("between", fn_name)) {
-    value_1 <- prep_values_text(x$values) %>% tidy_gsub(",.*", "")
-    value_2 <- prep_values_text(x$values) %>% tidy_gsub(".*, ", "")
+    value_1 <- tidy_gsub(prep_values_text(x$values), ",.*", "")
+    value_2 <- tidy_gsub(prep_values_text(x$values), ".*, ", "")
   }
 
   if (grepl("col_is", fn_name)) {

--- a/R/col_count_match.R
+++ b/R/col_count_match.R
@@ -284,7 +284,7 @@ col_count_match <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_count_match(
         count = count,
         preconditions = preconditions,
@@ -292,7 +292,7 @@ col_count_match <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -349,16 +349,16 @@ expect_col_count_match <- function(
   fn_name <- "expect_col_count_match"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_count_match(
       count = {{ count }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
-  x <- vs$notify %>% all()
+  x <- vs$notify |> all()
 
   threshold_type <- get_threshold_type(threshold = threshold)
 
@@ -402,14 +402,14 @@ test_col_count_match <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_count_match(
       count = {{ count }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_exists.R
+++ b/R/col_exists.R
@@ -263,14 +263,14 @@ col_exists <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_exists(
         columns = tidyselect::all_of(columns),
         actions = prime_actions(actions),
         label = label,
         brief = brief,
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -331,13 +331,13 @@ expect_col_exists <- function(
   fn_name <- "expect_col_exists"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_exists(
       columns = {{ columns }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -401,13 +401,13 @@ test_col_exists <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_exists(
       columns = {{ columns }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_is_character.R
+++ b/R/col_is_character.R
@@ -254,14 +254,14 @@ col_is_character <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_is_character(
         columns = tidyselect::all_of(columns),
         label = label,
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -322,13 +322,13 @@ expect_col_is_character <- function(
   fn_name <- "expect_col_is_character"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_is_character(
       columns = {{ columns }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -393,13 +393,13 @@ test_col_is_character <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_is_character(
       columns = {{ columns }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_is_date.R
+++ b/R/col_is_date.R
@@ -246,14 +246,14 @@ col_is_date <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_is_date(
         columns = tidyselect::all_of(columns),
         label = label,
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -314,13 +314,13 @@ expect_col_is_date <- function(
   fn_name <- "expect_col_is_date"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_is_date(
       columns = {{ columns }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -387,13 +387,13 @@ test_col_is_date <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_is_date(
       columns = {{ columns }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_is_factor.R
+++ b/R/col_is_factor.R
@@ -252,14 +252,14 @@ col_is_factor <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_is_factor(
         columns = tidyselect::all_of(columns),
         label = label,
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -320,13 +320,13 @@ expect_col_is_factor <- function(
   fn_name <- "expect_col_is_factor"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_is_factor(
       columns = {{ columns }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -393,13 +393,13 @@ test_col_is_factor <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_is_factor(
       columns = {{ columns }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_is_integer.R
+++ b/R/col_is_integer.R
@@ -250,14 +250,14 @@ col_is_integer <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_is_integer(
         columns = tidyselect::all_of(columns),
         label = label,
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -318,13 +318,13 @@ expect_col_is_integer <- function(
   fn_name <- "expect_col_is_integer"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_is_integer(
       columns = {{ columns }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -391,13 +391,13 @@ test_col_is_integer <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_is_integer(
       columns = {{ columns }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_is_logical.R
+++ b/R/col_is_logical.R
@@ -247,14 +247,14 @@ col_is_logical <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_is_logical(
         columns = tidyselect::all_of(columns),
         label = label,
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -315,13 +315,13 @@ expect_col_is_logical <- function(
   fn_name <- "expect_col_is_logical"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_is_logical(
       columns = {{ columns }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -388,13 +388,13 @@ test_col_is_logical <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_is_logical(
       columns = {{ columns }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_is_numeric.R
+++ b/R/col_is_numeric.R
@@ -247,14 +247,14 @@ col_is_numeric <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_is_numeric(
         columns = tidyselect::all_of(columns),
         label = label,
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -315,13 +315,13 @@ expect_col_is_numeric <- function(
   fn_name <- "expect_col_is_numeric"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_is_numeric(
       columns = {{ columns }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -388,13 +388,13 @@ test_col_is_numeric <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_is_numeric(
       columns = {{ columns }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_is_posix.R
+++ b/R/col_is_posix.R
@@ -247,14 +247,14 @@ col_is_posix <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_is_posix(
         columns = tidyselect::all_of(columns),
         label = label,
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -315,13 +315,13 @@ expect_col_is_posix <- function(
   fn_name <- "expect_col_is_posix"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_is_posix(
       columns = {{ columns }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -388,13 +388,13 @@ test_col_is_posix <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_is_posix(
       columns = {{ columns }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_schema_match.R
+++ b/R/col_schema_match.R
@@ -338,7 +338,7 @@ col_schema_match <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_schema_match(
         schema = schema,
         complete = complete,
@@ -348,7 +348,7 @@ col_schema_match <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -404,18 +404,18 @@ expect_col_schema_match <- function(
   fn_name <- "expect_col_schema_match"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_schema_match(
       schema = {{ schema }},
       complete = complete,
       in_order = in_order,
       is_exact = is_exact,
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
-  x <- vs$notify %>% all()
+  x <- all(vs$notify)
 
   threshold_type <- get_threshold_type(threshold = threshold)
 
@@ -461,16 +461,16 @@ test_col_schema_match <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_schema_match(
       schema = {{ schema }},
       complete = complete,
       in_order = in_order,
       is_exact = is_exact,
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))
@@ -688,8 +688,8 @@ create_col_schema_from_df <- function(tbl) {
   if (is_a_table_object(tbl) && !is_tbl_df(tbl)) {
 
     tbl <-
-      tbl %>%
-      utils::head(1) %>%
+      tbl |>
+      utils::head(1) |>
       dplyr::collect()
   }
 

--- a/R/col_vals_between.R
+++ b/R/col_vals_between.R
@@ -405,7 +405,7 @@ col_vals_between <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_vals_between(
         columns = tidyselect::all_of(columns),
         left = left,
@@ -418,7 +418,7 @@ col_vals_between <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -499,7 +499,7 @@ expect_col_vals_between <- function(
   fn_name <- "expect_col_vals_between"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_between(
       columns = {{ columns }},
       left = {{ left }},
@@ -508,9 +508,9 @@ expect_col_vals_between <- function(
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -589,7 +589,7 @@ test_col_vals_between <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_between(
       columns = {{ columns }},
       left = {{ left }},
@@ -598,9 +598,9 @@ test_col_vals_between <- function(
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_vals_decreasing.R
+++ b/R/col_vals_decreasing.R
@@ -391,7 +391,7 @@ col_vals_decreasing <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_vals_decreasing(
         columns = tidyselect::all_of(columns),
         allow_stationary = allow_stationary,
@@ -403,7 +403,7 @@ col_vals_decreasing <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -478,7 +478,7 @@ expect_col_vals_decreasing <- function(
   fn_name <- "expect_col_vals_decreasing"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_decreasing(
       columns = {{ columns }},
       allow_stationary = allow_stationary,
@@ -486,9 +486,9 @@ expect_col_vals_decreasing <- function(
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -558,7 +558,7 @@ test_col_vals_decreasing <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_decreasing(
       columns = {{ columns }},
       allow_stationary = allow_stationary,
@@ -566,9 +566,9 @@ test_col_vals_decreasing <- function(
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_vals_equal.R
+++ b/R/col_vals_equal.R
@@ -344,7 +344,7 @@ col_vals_equal <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_vals_equal(
         columns = tidyselect::all_of(columns),
         value = value,
@@ -355,7 +355,7 @@ col_vals_equal <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -429,16 +429,16 @@ expect_col_vals_equal <- function(
   fn_name <- "expect_col_vals_equal"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_equal(
       columns = {{ columns }},
       value = {{ value }},
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -510,16 +510,16 @@ test_col_vals_equal <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_equal(
       columns = {{ columns }},
       value = {{ value }},
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_vals_expr.R
+++ b/R/col_vals_expr.R
@@ -337,7 +337,7 @@ col_vals_expr <- function(
 
     if (rlang::is_formula(expr)) {
 
-      expr <- expr %>% rlang::f_rhs()
+      expr <- expr |> rlang::f_rhs()
 
     } else {
 
@@ -361,7 +361,7 @@ col_vals_expr <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_vals_expr(
         expr = expr,
         na_pass = na_pass,
@@ -371,7 +371,7 @@ col_vals_expr <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -447,17 +447,17 @@ expect_col_vals_expr <- function(
   fn_name <- "expect_col_vals_expr"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_expr(
       expr = {{ expr }},
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
-  x <- vs$notify %>% all()
+  x <- vs$notify |> all()
 
   threshold_type <- get_threshold_type(threshold = threshold)
 
@@ -507,15 +507,15 @@ test_col_vals_expr <- function(
   }
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_expr(
       expr = {{ expr }},
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_vals_gt.R
+++ b/R/col_vals_gt.R
@@ -466,7 +466,7 @@ col_vals_gt <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_vals_gt(
         columns = tidyselect::all_of(columns),
         value = value,
@@ -477,7 +477,7 @@ col_vals_gt <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -551,16 +551,16 @@ expect_col_vals_gt <- function(
   fn_name <- "expect_col_vals_gt"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_gt(
       columns = {{ columns }},
       value = {{ value }},
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -632,16 +632,16 @@ test_col_vals_gt <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_gt(
       columns = {{ columns }},
       value = {{ value }},
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_vals_gte.R
+++ b/R/col_vals_gte.R
@@ -343,7 +343,7 @@ col_vals_gte <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_vals_gte(
         columns = tidyselect::all_of(columns),
         value = value,
@@ -354,7 +354,7 @@ col_vals_gte <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -428,16 +428,16 @@ expect_col_vals_gte <- function(
   fn_name <- "expect_col_vals_gte"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_gte(
       columns = {{ columns }},
       value = {{ value }},
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -509,16 +509,16 @@ test_col_vals_gte <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_gte(
       columns = {{ columns }},
       value = {{ value }},
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_vals_in_set.R
+++ b/R/col_vals_in_set.R
@@ -337,7 +337,7 @@ col_vals_in_set <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_vals_in_set(
         columns = tidyselect::all_of(columns),
         set = set,
@@ -347,7 +347,7 @@ col_vals_in_set <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -420,15 +420,15 @@ expect_col_vals_in_set <- function(
   fn_name <- "expect_col_vals_in_set"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_in_set(
       columns = {{ columns }},
       set = {{ set }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -498,15 +498,15 @@ test_col_vals_in_set <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_in_set(
       columns = {{ columns }},
       set = {{ set }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_vals_increasing.R
+++ b/R/col_vals_increasing.R
@@ -379,7 +379,7 @@ col_vals_increasing <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_vals_increasing(
         columns = tidyselect::all_of(columns),
         allow_stationary = allow_stationary,
@@ -391,7 +391,7 @@ col_vals_increasing <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -466,7 +466,7 @@ expect_col_vals_increasing <- function(
   fn_name <- "expect_col_vals_increasing"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_increasing(
       columns = {{ columns }},
       allow_stationary = allow_stationary,
@@ -474,9 +474,9 @@ expect_col_vals_increasing <- function(
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -552,7 +552,7 @@ test_col_vals_increasing <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_increasing(
       columns = {{ columns }},
       allow_stationary = allow_stationary,
@@ -560,9 +560,9 @@ test_col_vals_increasing <- function(
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_vals_lt.R
+++ b/R/col_vals_lt.R
@@ -345,7 +345,7 @@ col_vals_lt <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_vals_lt(
         columns = tidyselect::all_of(columns),
         value = value,
@@ -356,7 +356,7 @@ col_vals_lt <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -430,16 +430,16 @@ expect_col_vals_lt <- function(
   fn_name <- "expect_col_vals_lt"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_lt(
       columns = {{ columns }},
       value = {{ value }},
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -511,16 +511,16 @@ test_col_vals_lt <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_lt(
       columns = {{ columns }},
       value = {{ value }},
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_vals_lte.R
+++ b/R/col_vals_lte.R
@@ -346,7 +346,7 @@ col_vals_lte <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_vals_lte(
         columns = tidyselect::all_of(columns),
         value = value,
@@ -357,7 +357,7 @@ col_vals_lte <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -431,16 +431,16 @@ expect_col_vals_lte <- function(
   fn_name <- "expect_col_vals_lte"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_lte(
       columns = {{ columns }},
       value = {{ value }},
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -512,16 +512,16 @@ test_col_vals_lte <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_lte(
       columns = {{ columns }},
       value = {{ value }},
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_vals_make_set.R
+++ b/R/col_vals_make_set.R
@@ -339,7 +339,7 @@ col_vals_make_set <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_vals_make_set(
         columns = tidyselect::all_of(columns),
         set = set,
@@ -349,7 +349,7 @@ col_vals_make_set <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -422,15 +422,15 @@ expect_col_vals_make_set <- function(
   fn_name <- "expect_col_vals_make_set"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_make_set(
       columns = {{ columns }},
       set = {{ set }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -500,15 +500,15 @@ test_col_vals_make_set <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_make_set(
       columns = {{ columns }},
       set = {{ set }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_vals_make_subset.R
+++ b/R/col_vals_make_subset.R
@@ -336,7 +336,7 @@ col_vals_make_subset <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_vals_make_subset(
         columns = tidyselect::all_of(columns),
         set = set,
@@ -346,7 +346,7 @@ col_vals_make_subset <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -418,15 +418,15 @@ expect_col_vals_make_subset <- function(
   fn_name <- "expect_col_vals_make_subset"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_make_subset(
       columns = {{ columns }},
       set = {{ set }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -496,15 +496,15 @@ test_col_vals_make_subset <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_make_subset(
       columns = {{ columns }},
       set = {{ set }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_vals_not_between.R
+++ b/R/col_vals_not_between.R
@@ -408,7 +408,7 @@ col_vals_not_between <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_vals_not_between(
         columns = tidyselect::all_of(columns),
         left = left,
@@ -421,7 +421,7 @@ col_vals_not_between <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -502,7 +502,7 @@ expect_col_vals_not_between <- function(
   fn_name <- "expect_col_vals_not_between"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_not_between(
       columns = {{ columns }},
       left = {{ left }},
@@ -511,9 +511,9 @@ expect_col_vals_not_between <- function(
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -592,7 +592,7 @@ test_col_vals_not_between <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_not_between(
       columns = {{ columns }},
       left = {{ left }},
@@ -601,9 +601,9 @@ test_col_vals_not_between <- function(
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_vals_not_equal.R
+++ b/R/col_vals_not_equal.R
@@ -343,7 +343,7 @@ col_vals_not_equal <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_vals_not_equal(
         columns = tidyselect::all_of(columns),
         value = value,
@@ -354,7 +354,7 @@ col_vals_not_equal <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -428,16 +428,16 @@ expect_col_vals_not_equal <- function(
   fn_name <- "expect_col_vals_not_equal"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_not_equal(
       columns = {{ columns }},
       value = {{ value }},
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -509,16 +509,16 @@ test_col_vals_not_equal <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_not_equal(
       columns = {{ columns }},
       value = {{ value }},
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_vals_not_in_set.R
+++ b/R/col_vals_not_in_set.R
@@ -333,7 +333,7 @@ col_vals_not_in_set <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_vals_not_in_set(
         columns = tidyselect::all_of(columns),
         set = set,
@@ -343,7 +343,7 @@ col_vals_not_in_set <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -415,15 +415,15 @@ expect_col_vals_not_in_set <- function(
   fn_name <- "expect_col_vals_not_in_set"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_not_in_set(
       columns = {{ columns }},
       set = {{ set }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -493,15 +493,15 @@ test_col_vals_not_in_set <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_not_in_set(
       columns = {{ columns }},
       set = {{ set }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_vals_not_null.R
+++ b/R/col_vals_not_null.R
@@ -324,7 +324,7 @@ col_vals_not_null <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_vals_not_null(
         columns = tidyselect::all_of(columns),
         preconditions = preconditions,
@@ -333,7 +333,7 @@ col_vals_not_null <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -403,14 +403,14 @@ expect_col_vals_not_null <- function(
   fn_name <- "expect_col_vals_not_null"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_not_null(
       columns = {{ columns }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -477,14 +477,14 @@ test_col_vals_not_null <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_not_null(
       columns = {{ columns }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_vals_null.R
+++ b/R/col_vals_null.R
@@ -323,7 +323,7 @@ col_vals_null <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_vals_null(
         columns = tidyselect::all_of(columns),
         preconditions = preconditions,
@@ -332,7 +332,7 @@ col_vals_null <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -402,14 +402,14 @@ expect_col_vals_null <- function(
   fn_name <- "expect_col_vals_null"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_null(
       columns = {{ columns }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -476,14 +476,14 @@ test_col_vals_null <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_null(
       columns = {{ columns }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_vals_regex.R
+++ b/R/col_vals_regex.R
@@ -337,7 +337,7 @@ col_vals_regex <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_vals_regex(
         columns = tidyselect::all_of(columns),
         regex = regex,
@@ -348,7 +348,7 @@ col_vals_regex <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -422,16 +422,16 @@ expect_col_vals_regex <- function(
   fn_name <- "expect_col_vals_regex"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_regex(
       columns = {{ columns }},
       regex = {{ regex }},
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -502,16 +502,16 @@ test_col_vals_regex <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_regex(
       columns = {{ columns }},
       regex = {{ regex }},
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_vals_str_len.R
+++ b/R/col_vals_str_len.R
@@ -134,7 +134,7 @@ col_vals_str_len <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_vals_str_len(
         columns = tidyselect::all_of(columns),
         min = min,
@@ -146,7 +146,7 @@ col_vals_str_len <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -217,7 +217,7 @@ expect_col_vals_str_len <- function(
   fn_name <- "expect_col_vals_str_len"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_str_len(
       columns = {{ columns }},
       min = min,
@@ -225,9 +225,9 @@ expect_col_vals_str_len <- function(
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(notify_at = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -296,7 +296,7 @@ test_col_vals_str_len <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_str_len(
       columns = {{ columns }},
       min = min,
@@ -304,9 +304,9 @@ test_col_vals_str_len <- function(
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(notify_at = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/col_vals_within_spec.R
+++ b/R/col_vals_within_spec.R
@@ -402,7 +402,7 @@ col_vals_within_spec <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       col_vals_within_spec(
         columns = tidyselect::all_of(columns),
         spec = spec,
@@ -413,7 +413,7 @@ col_vals_within_spec <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -487,16 +487,16 @@ expect_col_vals_within_spec <- function(
   fn_name <- "expect_col_vals_within_spec"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_within_spec(
       columns = {{ columns }},
       spec = {{ spec }},
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   x <- vs$notify
 
@@ -567,16 +567,16 @@ test_col_vals_within_spec <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     col_vals_within_spec(
       columns = {{ columns }},
       spec = {{ spec }},
       na_pass = na_pass,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))
@@ -591,7 +591,7 @@ test_col_vals_within_spec <- function(
 country_has_postal_code_fmt <- function(country) {
 
   code_tbl <-
-    dplyr::select(countries, alpha_2, alpha_3, postal_code_format) %>%
+    dplyr::select(countries, alpha_2, alpha_3, postal_code_format) |>
     dplyr::filter(!is.na(postal_code_format))
 
   country_codes <-

--- a/R/column_roles.R
+++ b/R/column_roles.R
@@ -33,7 +33,7 @@ get_column_roles <- function(data) {
 
     col_type_i <- col_types$r_col_type[i]
     col_name_i <- col_types$name[i]
-    data_column <- data %>% dplyr::select({{ col_name_i }})
+    data_column <- data |> dplyr::select({{ col_name_i }})
 
     col_role_i <-
       switch(
@@ -80,8 +80,8 @@ get_non_null_col_sample <- function(
 
   # Filter out all NA/NULL values from the `data_column`
   data_column <-
-    data_column %>%
-    dplyr::rename(a__ = 1) %>%
+    data_column |>
+    dplyr::rename(a__ = 1) |>
     dplyr::filter(!is.na(a__))
 
   # Obtain a subsample of non-NULL values in the column
@@ -114,22 +114,22 @@ get_column_cardinality <- function(
 ) {
 
   data_column_groups <-
-    data_column %>%
-    dplyr::rename(a__ = 1) %>%
+    data_column |>
+    dplyr::rename(a__ = 1) |>
     dplyr::distinct()
 
   data_column_has_any_na <-
-    data_column_groups %>%
-    dplyr::filter(is.na(a__)) %>%
-    dplyr::distinct() %>%
-    dplyr::collect() %>%
-    nrow() %>%
+    data_column_groups |>
+    dplyr::filter(is.na(a__)) |>
+    dplyr::distinct() |>
+    dplyr::collect() |>
+    nrow() |>
     as.logical()
 
   data_column_groups_n <-
-    data_column_groups %>%
-    dplyr::count() %>%
-    dplyr::pull(n) %>%
+    data_column_groups |>
+    dplyr::count() |>
+    dplyr::pull(n) |>
     as.integer()
 
   if (data_column_has_any_na && !include_na) {
@@ -143,10 +143,10 @@ get_column_cardinality <- function(
 is_column_integerlike <- function(data_column) {
 
   data_vals <-
-    data_column %>%
-    dplyr::rename(a__ = 1) %>%
-    dplyr::distinct() %>%
-    dplyr::collect() %>%
+    data_column |>
+    dplyr::rename(a__ = 1) |>
+    dplyr::distinct() |>
+    dplyr::collect() |>
     dplyr::pull(a__)
 
   rlang::is_integerish(data_vals)
@@ -168,16 +168,16 @@ get_column_types <- function(data_column) {
 
 get_string_length_stats <- function(data_column) {
 
-  data_column %>%
-    dplyr::rename(a__ = 1) %>%
-    dplyr::mutate(str_length__ = nchar(a__)) %>%
-    dplyr::group_by() %>%
+  data_column |>
+    dplyr::rename(a__ = 1) |>
+    dplyr::mutate(str_length__ = nchar(a__)) |>
+    dplyr::group_by() |>
     dplyr::summarize(
       min = min(str_length__, na.rm = TRUE),
       mean = mean(str_length__, na.rm = TRUE),
       max = max(str_length__, na.rm = TRUE)
-    ) %>%
-    dplyr::ungroup() %>%
+    ) |>
+    dplyr::ungroup() |>
     as.list()
 }
 
@@ -512,8 +512,8 @@ get_column_role_character <- function(data_column) {
 
   # Get the distinct non-null items from the column sample
   column_items <-
-    column_samp %>%
-    dplyr::distinct() %>%
+    column_samp |>
+    dplyr::distinct() |>
     dplyr::pull()
 
   if (col_name_possibly__country(column_name)) {
@@ -563,9 +563,9 @@ get_column_role_character <- function(data_column) {
     # Extract all fully-alphabetical subdivision names to
     # serve as a large set
     subd_names <-
-      subdivisions %>%
-      dplyr::select(subd_name) %>%
-      dplyr::filter(grepl("[A-Z][A-Z]", subd_name)) %>%
+      subdivisions |>
+      dplyr::select(subd_name) |>
+      dplyr::filter(grepl("[A-Z][A-Z]", subd_name)) |>
       dplyr::pull()
 
     # If any of the column items matches any one of the
@@ -610,8 +610,8 @@ get_column_role_character <- function(data_column) {
 
     # Extract all subdivision short names to serve as a large set
     subd_names <-
-      subdivisions %>%
-      dplyr::filter(country_alpha_3 %in% names(subd_list_main)) %>%
+      subdivisions |>
+      dplyr::filter(country_alpha_3 %in% names(subd_list_main)) |>
       dplyr::pull(name_en)
 
     # If any of the column items matches any one of the
@@ -625,8 +625,8 @@ get_column_role_character <- function(data_column) {
       for (co in names(subd_list_main)) {
 
         subd_list_co <-
-          subdivisions %>%
-          dplyr::filter(country_alpha_3 == {{ co }}) %>%
+          subdivisions |>
+          dplyr::filter(country_alpha_3 == {{ co }}) |>
           dplyr::pull(name_en)
 
         # obtain fractional amounts of subdivision names in each main country
@@ -824,8 +824,8 @@ get_column_role_numeric <- function(data_column) {
 
   # Get the distinct non-null items from the column sample
   column_items <-
-    column_samp %>%
-    dplyr::distinct() %>%
+    column_samp |>
+    dplyr::distinct() |>
     dplyr::pull()
 
   if (col_name_possibly__latitude(column_name)) {

--- a/R/conjointly.R
+++ b/R/conjointly.R
@@ -382,7 +382,7 @@ conjointly <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       conjointly(
         .list = .list,
         preconditions = preconditions,
@@ -391,7 +391,7 @@ conjointly <- function(
         label = label,
         brief = brief,
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -462,16 +462,16 @@ expect_conjointly <- function(
   fn_name <- "expect_conjointly"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     conjointly(
       .list = .list,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
-  x <- vs$notify %>% all()
+  x <- vs$notify |> all()
 
   threshold_type <- get_threshold_type(threshold = threshold)
 
@@ -513,14 +513,14 @@ test_conjointly <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     conjointly(
       .list = .list,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/draft_validation.R
+++ b/R/draft_validation.R
@@ -518,8 +518,8 @@ draft_validation <- function(
         agent_lines,
         "%>%\n  interrogate()\n\nagent",
         collapse = ""
-      ) %>%
-      gsub("  %>%", " %>%", .)
+      )
+    file_content <- gsub("  %>%", " %>%", file_content)
 
   } else {
 
@@ -546,8 +546,8 @@ draft_validation <- function(
         "agent\n",
         "```\n",
         collapse = ""
-      ) %>%
-      gsub("  %>%", " %>%", .)
+      )
+    file_content <- gsub("  %>%", " %>%", file_content)
   }
 
   # Write the file to the resulting `path`
@@ -775,11 +775,9 @@ resolve_file_filename <- function(agent,
       name <- gsub("::", "__", name, fixed = TRUE)
     }
 
-    file_name <-
-      name[1] %>%
-      fs::path_sanitize() %>%
-      gsub("(\\.| |'|\\:)", "_", .) %>%
-      paste0(., ".", output_type)
+    file_name <- fs::path_sanitize(name[1])
+    file_name <- gsub("(\\.| |'|\\:)", "_", file_name)
+    file_name <- paste0(file_name, ".", output_type)
   }
 
   file_name

--- a/R/emailing.R
+++ b/R/emailing.R
@@ -210,7 +210,7 @@ email_blast <- function(
   # nocov start
 
   # Evaluate condition for sending email
-  condition_result <- rlang::f_rhs(send_condition) %>% rlang::eval_tidy()
+  condition_result <- rlang::f_rhs(send_condition) |> rlang::eval_tidy()
 
   if (!is.logical(condition_result)) {
     warning("The `send_condition` expression must resolve to a logical value",
@@ -225,9 +225,9 @@ email_blast <- function(
     # Preparation of the message
     blastula_message <-
       blastula::compose_email(
-        header = glue::glue(msg_header) %>% blastula::md(),
-        body = glue::glue(msg_body) %>% blastula::md(),
-        footer = glue::glue(msg_footer) %>% blastula::md(),
+        header = glue::glue(msg_header) |> blastula::md(),
+        body = glue::glue(msg_body) |> blastula::md(),
+        footer = glue::glue(msg_footer) |> blastula::md(),
       )
 
     # Sending of the message
@@ -390,7 +390,7 @@ stock_msg_body <- function() {
       ),
       htmltools::HTML("&#9678;")
     )
-  ) %>%
+  ) |>
     as.character()
 }
 
@@ -432,7 +432,7 @@ stock_msg_footer <- function() {
         htmltools::HTML("{get_lsv('email/footer_2')[[x$lang]]}")
       )
     )
-  ) %>%
+  ) |>
     as.character()
 }
 

--- a/R/get_agent_report.R
+++ b/R/get_agent_report.R
@@ -317,18 +317,18 @@ get_agent_report <- function(
   validation_set <- agent$validation_set
 
   eval <-
-    validation_set %>%
-    dplyr::select(eval_error, eval_warning) %>%
+    validation_set |>
+    dplyr::select(eval_error, eval_warning) |>
     dplyr::mutate(condition = dplyr::case_when(
       !eval_error & !eval_warning ~ "OK",
       eval_error & eval_warning ~ "W + E",
       eval_error ~ "ERROR",
       eval_warning ~ "WARNING"
-    )) %>%
+    )) |>
     dplyr::pull(condition)
 
   columns <-
-    validation_set$column %>%
+    validation_set$column |>
     vapply(
       FUN.VALUE = character(1),
       USE.NAMES = FALSE,
@@ -342,7 +342,7 @@ get_agent_report <- function(
     )
 
   values <-
-    validation_set$values %>%
+    validation_set$values |>
     vapply(
       FUN.VALUE = character(1),
       USE.NAMES = FALSE,
@@ -361,7 +361,7 @@ get_agent_report <- function(
     )
 
   precon_count <-
-    validation_set$preconditions %>%
+    validation_set$preconditions |>
     vapply(
       FUN.VALUE = character(1),
       USE.NAMES = FALSE,
@@ -415,7 +415,7 @@ get_agent_report <- function(
     )
 
   report_tbl <-
-    report_tbl %>%
+    report_tbl |>
     dplyr::mutate(
       eval_pts = ifelse(eval != "OK", 10, 0),
       C_pts = ifelse(!is.na(C) & C, 3, 0),
@@ -426,16 +426,16 @@ get_agent_report <- function(
 
   if (arrange_by == "severity") {
     report_tbl <-
-      report_tbl %>%
+      report_tbl |>
       dplyr::arrange(dplyr::desc(total_pts))
   }
 
   if (keep == "fail_states") {
-    report_tbl <- report_tbl %>% dplyr::filter(total_pts > 0)
+    report_tbl <- dplyr::filter(report_tbl, total_pts > 0)
   }
 
   report_tbl <-
-    report_tbl %>%
+    report_tbl |>
     dplyr::select(-dplyr::ends_with("pts"))
 
   if (!display_table) {
@@ -450,7 +450,7 @@ get_agent_report <- function(
 
   # resolve `arrange_by` + post-`interrogate()` filtering of `$validation_set`
   rows_keep <- match(report_tbl$i, validation_set$i)
-  validation_set <- validation_set %>%
+  validation_set <- validation_set |>
     dplyr::slice(.env$rows_keep)
   eval <- eval[report_tbl$i]
   extracts <-
@@ -795,9 +795,9 @@ get_agent_report <- function(
         } else {
 
           text <-
-            column_i %>%
-            unlist() %>%
-            strsplit(", ") %>%
+            column_i |>
+            unlist() |>
+            strsplit(", ") |>
             unlist()
 
           title <- text
@@ -1237,7 +1237,7 @@ get_agent_report <- function(
 
             paste0(
               "<div><p title=\"",
-              values_i %>% tidy_gsub("~", "") %>% paste(., collapse = ", "),
+              paste(tidy_gsub(values_i, "~", ""), collapse = ", "),
               "\" style=\"margin-top: 0px; margin-bottom: 0px; ",
               "font-size: 11px; white-space: nowrap; ",
               "text-overflow: ellipsis; overflow: hidden;\">",
@@ -1249,7 +1249,7 @@ get_agent_report <- function(
 
             paste0(
               "<div aria-label=\"",
-              values_i %>% tidy_gsub("~", "") %>% paste(., collapse = ", "),
+              paste(tidy_gsub(values_i, "~", ""), collapse = ", "),
               "\" data-balloon-pos=\"left\"><p style=\"margin-top: 0px; ",
               "margin-bottom: 0px; ",
               "font-size: 11px; white-space: nowrap; ",
@@ -1264,7 +1264,7 @@ get_agent_report <- function(
 
   # Reformat `precon`
   precon_upd <-
-    validation_set$preconditions %>%
+    validation_set$preconditions |>
     vapply(
       FUN.VALUE = character(1),
       USE.NAMES = FALSE,
@@ -1290,7 +1290,7 @@ get_agent_report <- function(
         } else if (rlang::is_formula(x) || rlang::is_function(x)) {
 
           if (rlang::is_formula(x)) {
-            text <- rlang::as_label(x) %>% tidy_gsub("^~", "")
+            text <- tidy_gsub(rlang::as_label(x), "^~", "")
           } else {
             text <- rlang::as_label(body(x))
           }
@@ -1324,7 +1324,7 @@ get_agent_report <- function(
   if (!is.null(seg_col) || !is.null(seg_val)) {
 
     precon_upd <-
-      seq_along(seg_col) %>%
+      seq_along(seg_col) |>
       vapply(
         FUN.VALUE = character(1),
         USE.NAMES = FALSE,
@@ -1359,7 +1359,7 @@ get_agent_report <- function(
 
   # Reformat `eval`
   eval_upd <-
-    seq_along(eval) %>%
+    seq_along(eval) |>
     vapply(
       FUN.VALUE = character(1),
       USE.NAMES = FALSE,
@@ -1397,7 +1397,7 @@ get_agent_report <- function(
 
           text <-
             htmltools::htmlEscape(
-              msg_error %>%
+              msg_error |>
                 tidy_gsub("\"", "'")
             )
 
@@ -1423,7 +1423,7 @@ get_agent_report <- function(
 
           text <-
             htmltools::htmlEscape(
-              msg_warning %>%
+              msg_warning |>
                 tidy_gsub("\"", "'")
             )
 
@@ -1449,7 +1449,7 @@ get_agent_report <- function(
 
           text <-
             htmltools::htmlEscape(
-              msg_error %>%
+              msg_error |>
                 tidy_gsub("\"", "'")
             )
 
@@ -1477,7 +1477,7 @@ get_agent_report <- function(
 
   # Reformat `extract`
   extract_upd <-
-    validation_set$i %>%
+    validation_set$i |>
     vapply(
       FUN.VALUE = character(1),
       USE.NAMES = FALSE,
@@ -1488,7 +1488,7 @@ get_agent_report <- function(
         } else {
 
           df <-
-            extracts[as.character(x)][[1]] %>%
+            extracts[as.character(x)][[1]] |>
             as.data.frame(stringsAsFactors = FALSE)
 
           fail_rows_extract <-
@@ -1551,7 +1551,7 @@ get_agent_report <- function(
   #
 
   w_upd <-
-    validation_set$warn %>%
+    validation_set$warn |>
     vapply(
       FUN.VALUE = character(1),
       USE.NAMES = FALSE,
@@ -1568,7 +1568,7 @@ get_agent_report <- function(
     )
 
   e_upd <-
-    validation_set$stop %>%
+    validation_set$stop |>
     vapply(
       FUN.VALUE = character(1),
       USE.NAMES = FALSE,
@@ -1585,7 +1585,7 @@ get_agent_report <- function(
     )
 
   c_upd <-
-    validation_set$notify %>%
+    validation_set$notify |>
     vapply(
       FUN.VALUE = character(1),
       USE.NAMES = FALSE,
@@ -1615,7 +1615,7 @@ get_agent_report <- function(
 
   # Generate a gt table
   agent_report <-
-    report_tbl %>%
+    report_tbl |>
     dplyr::mutate(
       status_color = NA_character_,
       type = type_upd,
@@ -1635,36 +1635,38 @@ get_agent_report <- function(
       E = e_upd,
       C = c_upd,
       extract = extract_upd
-    ) %>%
+    ) |>
     dplyr::select(
       status_color, i, type, columns, values, precon, eval_sym, units,
       n_pass, f_pass, n_fail, f_fail, W, E, C, extract,
       W_val, E_val, C_val, eval, active
-    ) %>%
-    gt::gt(id = "pb_agent", locale = locale) %>%
+    ) |>
+    gt::gt(id = "pb_agent", locale = locale) |>
     gt::tab_header(
       title = title_text,
       subtitle = gt::md(combined_subtitle)
-    ) %>%
+    ) |>
     gt::cols_merge(
       columns = c("n_pass", "f_pass"),
       hide_columns = "f_pass"
-    ) %>%
+    ) |>
     gt::cols_merge(
       columns = c("n_fail", "f_fail"),
       hide_columns = "f_fail"
-    ) %>%
+    ) |>
     gt::text_transform(
       locations = gt::cells_body(columns = c("n_pass", "n_fail")),
       fn = function(x) {
         dplyr::case_when(
           x == "NA NA"  ~ "&mdash;",
-          TRUE ~ x %>%
-            tidy_gsub(" ", "</code><br><code>") %>%
-            paste0("<code>", ., "</code>")
+          TRUE ~ paste0(
+            "<code>",
+            tidy_gsub(x, " ", "</code><br><code>"),
+            "</code>"
+          )
         )
       }
-    ) %>%
+    ) |>
     gt::cols_label(
       status_color = "",
       i = "",
@@ -1677,41 +1679,41 @@ get_agent_report <- function(
       n_pass = "PASS",
       n_fail = "FAIL",
       extract = "EXT"
-    ) %>%
-    gt::tab_source_note(source_note = gt::md(table_time)) %>%
+    ) |>
+    gt::tab_source_note(source_note = gt::md(table_time)) |>
     gt::tab_options(
       table.font.size = gt::pct(90),
       row.striping.include_table_body = FALSE
-    ) %>%
+    ) |>
     gt::cols_align(
       align = "center",
       columns = c("precon", "eval_sym", "W", "E", "C", "extract")
-    ) %>%
+    ) |>
     gt::cols_align(
       align = "center",
       columns = c("f_pass", "f_fail")
-    ) %>%
+    ) |>
     gt::cols_align(
       align = "right",
       columns = "i"
-    ) %>%
+    ) |>
     gt::fmt_integer(
       columns = c("units", "n_pass", "n_fail", "f_pass", "f_fail"),
       suffixing = TRUE
-    ) %>%
+    ) |>
     gt::fmt_number(
       columns = c("f_pass", "f_fail"),
       decimals = 2
-    ) %>%
+    ) |>
     gt::fmt_markdown(
       columns = c(
         "type", "columns", "values", "precon",
         "eval_sym", "W", "E", "C", "extract"
       )
-    ) %>%
-    gt::sub_missing(columns = c("columns", "values", "units", "extract")) %>%
-    gt::sub_missing(columns = "status_color", missing_text = "") %>%
-    gt::cols_hide(columns = c("W_val", "E_val", "C_val", "active", "eval")) %>%
+    ) |>
+    gt::sub_missing(columns = c("columns", "values", "units", "extract")) |>
+    gt::sub_missing(columns = "status_color", missing_text = "") |>
+    gt::cols_hide(columns = c("W_val", "E_val", "C_val", "active", "eval")) |>
     gt::text_transform(
       locations = gt::cells_body(columns = "units"),
       fn = function(x) {
@@ -1720,7 +1722,7 @@ get_agent_report <- function(
           TRUE ~ paste0("<code>", x, "</code>")
         )
       }
-    ) %>%
+    ) |>
     gt::tab_style(
       style = gt::cell_text(
         size = gt::px(28),
@@ -1729,14 +1731,14 @@ get_agent_report <- function(
         color = "#444444"
       ),
       locations = gt::cells_title("title")
-    ) %>%
+    ) |>
     gt::tab_style(
       style = gt::cell_text(
         size = gt::px(12),
         align = "left"
       ),
       locations = gt::cells_title("subtitle")
-    ) %>%
+    ) |>
     gt::tab_style(
       style = gt::cell_text(
         weight = "bold",
@@ -1744,42 +1746,42 @@ get_agent_report <- function(
         size = ifelse(size == "small", gt::px(10), gt::px(13))
       ),
       locations = gt::cells_body(columns = "i")
-    ) %>%
+    ) |>
     gt::tab_style(
       style = gt::cell_fill(color = "#4CA64C"),
       locations = gt::cells_body(
         columns = "status_color",
         rows = units == n_pass
       )
-    ) %>%
+    ) |>
     gt::tab_style(
       style = gt::cell_fill(color = "#4CA64C66", alpha = 0.5),
       locations = gt::cells_body(
         columns = "status_color",
         rows = units != n_pass
       )
-    ) %>%
+    ) |>
     gt::tab_style(
       style = gt::cell_fill(color = "#FFBF00"),
       locations = gt::cells_body(
         columns = "status_color",
         rows = W_val
       )
-    ) %>%
+    ) |>
     gt::tab_style(
       style = gt::cell_fill(color = "#CF142B"),
       locations = gt::cells_body(
         columns = "status_color",
         rows = E_val
       )
-    ) %>%
+    ) |>
     gt::tab_style(
       style = list(
         gt::cell_borders(sides = "left", color = "#D3D3D3"),
         gt::cell_fill(color = "#FCFCFC")
       ),
       locations = gt::cells_body(columns = c("precon", "W"))
-    ) %>%
+    ) |>
     gt::tab_style(
       style = gt::cell_borders(
         sides = "left",
@@ -1787,18 +1789,18 @@ get_agent_report <- function(
         style = "dashed"
       ),
       locations = gt::cells_body(columns = c("n_pass", "n_fail"))
-    ) %>%
+    ) |>
     gt::tab_style(
       style = list(
         gt::cell_borders(sides = "right", color = "#D3D3D3"),
         gt::cell_fill(color = "#FCFCFC")
       ),
       locations = gt::cells_body(columns = c("eval_sym", "C"))
-    ) %>%
+    ) |>
     gt::tab_style(
       style = gt::cell_fill(color = "#FCFCFC"),
       locations = gt::cells_body(columns = "E")
-    ) %>%
+    ) |>
     gt::tab_style(
       style = gt::cell_borders(
         sides = "left",
@@ -1808,7 +1810,7 @@ get_agent_report <- function(
       locations = list(
         gt::cells_body(columns = c("columns", "values"))
       )
-    ) %>%
+    ) |>
     gt::tab_style(
       style = list(
         gt::cell_fill(color = "#F2F2F2", alpha = 0.75),
@@ -1818,14 +1820,14 @@ get_agent_report <- function(
         columns = gt::everything(),
         rows = active == FALSE
       )
-    ) %>%
+    ) |>
     gt::tab_style(
       style = gt::cell_fill(color = "#FFC1C1", alpha = 0.35),
       locations = gt::cells_body(
         columns = gt::everything(),
         rows = eval == "ERROR"
       )
-    ) %>%
+    ) |>
     gt::tab_style(
       style = gt::cell_text(size = gt::px(11)),
       locations = gt::cells_body(
@@ -1836,7 +1838,7 @@ get_agent_report <- function(
   if (!has_agent_intel(agent)) {
 
     agent_report <-
-      agent_report %>%
+      agent_report |>
       gt::text_transform(
         locations = gt::cells_body(
           columns = c(
@@ -1847,7 +1849,7 @@ get_agent_report <- function(
         fn = function(x) {
           ""
         }
-      ) %>%
+      ) |>
       gt::tab_style(
         style = list(
           gt::cell_fill(color = "#F2F2F2"),
@@ -1863,7 +1865,7 @@ get_agent_report <- function(
             "n_pass", "n_fail", "W", "E", "C", "extract"
           )
         )
-      ) %>%
+      ) |>
       gt::tab_header(
         title = gt::md(
           paste0(
@@ -1891,8 +1893,8 @@ get_agent_report <- function(
   if (size == "small") {
 
     agent_report <-
-      agent_report %>%
-      gt::cols_hide(c("columns", "values", "eval_sym", "precon", "extract")) %>%
+      agent_report |>
+      gt::cols_hide(c("columns", "values", "eval_sym", "precon", "extract")) |>
       gt::cols_width(
         "status_color" ~ gt::px(4),
         "i" ~ gt::px(25),
@@ -1905,7 +1907,7 @@ get_agent_report <- function(
         "E" ~ gt::px(30),
         "C" ~ gt::px(30),
         gt::everything() ~ gt::px(20)
-      ) %>%
+      ) |>
       gt::tab_style(
         locations = gt::cells_body(columns = gt::everything()),
         style = "height: 35px"
@@ -1914,7 +1916,7 @@ get_agent_report <- function(
     if (!has_agent_intel(agent)) {
 
       agent_report <-
-        agent_report %>%
+        agent_report |>
         gt::tab_header(
           title = gt::md(
             paste0(
@@ -1938,7 +1940,7 @@ get_agent_report <- function(
     } else {
 
       agent_report <-
-        agent_report %>%
+        agent_report |>
         gt::tab_header(
           title = title_text,
           subtitle = gt::md(
@@ -1950,7 +1952,7 @@ get_agent_report <- function(
   } else {
 
     agent_report <-
-      agent_report %>%
+      agent_report |>
       gt::cols_width(
         "status_color" ~ gt::px(6),
         "i" ~ gt::px(35),
@@ -1964,22 +1966,22 @@ get_agent_report <- function(
         "C" ~ gt::px(30),
         "extract" ~ gt::px(65),
         gt::everything() ~ gt::px(50)
-      ) %>%
+      ) |>
       gt::tab_style(
         style = gt::cell_text(weight = "bold", color = "#666666"),
         locations = gt::cells_column_labels(columns = gt::everything())
-      ) %>%
+      ) |>
       gt::tab_style(
         locations = gt::cells_body(columns = gt::everything()),
         style = "height: 40px"
-      ) %>%
-      gt::opt_table_font(font = gt::google_font("IBM Plex Sans")) %>%
+      ) |>
+      gt::opt_table_font(font = gt::google_font("IBM Plex Sans")) |>
       gt::opt_css(
         paste0(
           "@import url(\"https://unpkg.com/",
           "balloon-css/balloon.min.css\");"
         )
-      ) %>%
+      ) |>
       gt::opt_css(
         css = "
           #pb_agent {
@@ -2434,14 +2436,14 @@ make_boxed_text_html <- function(
 
   if (size == "standard") {
     text_html <-
-      text_html %>%
+      text_html |>
       htmltools::tagAppendAttributes(
         `aria-label` = tt_text,
         `data-balloon-pos` = tt_position,
         `data-balloon-length` = if (!is.null(tt_text_size)) tt_text_size
       )
   } else {
-    text_html <- text_html %>% htmltools::tagAppendAttributes(`title` = tt_text)
+    text_html <- htmltools::tagAppendAttributes(text_html, `title` = tt_text)
   }
 
   as.character(text_html)

--- a/R/get_agent_x_list.R
+++ b/R/get_agent_x_list.R
@@ -191,8 +191,8 @@ get_agent_x_list <- function(
 
     .i <- i
     .type <- agent$validation_set[[i, "assertion_type"]]
-    .columns <- agent$validation_set[[i, "column"]] %>% unlist()
-    .values <- agent$validation_set[[i, "values"]] %>% unlist()
+    .columns <- unlist(agent$validation_set[[i, "column"]])
+    .values <- unlist(agent$validation_set[[i, "values"]])
     .label <- agent$validation_set[[i, "label"]]
     .briefs <- agent$validation_set[[i, "brief"]]
 
@@ -276,8 +276,8 @@ get_agent_x_list <- function(
 
     .validation_set <- agent$validation_set
 
-    .report_object <- agent %>% get_agent_report()
-    .report_object_small <- agent %>% get_agent_report(size = "small")
+    .report_object <- get_agent_report(agent)
+    .report_object_small <- get_agent_report(agent, size = "small")
 
     if (!is.null(.report_object)) {
       .report_html <- gt::as_raw_html(.report_object, inline_css = FALSE)
@@ -309,8 +309,8 @@ get_agent_x_list <- function(
       .email_object <-
         blastula::compose_email(
           header = NULL,
-          body = glue::glue(stock_msg_body()) %>% gt::html(),
-          footer = glue::glue(stock_msg_footer()) %>% gt::html(),
+          body = gt::html(glue::glue(stock_msg_body())),
+          footer = gt::html(glue::glue(stock_msg_footer())),
         )
 
     } else {

--- a/R/get_informant_report.R
+++ b/R/get_informant_report.R
@@ -314,7 +314,7 @@ get_informant_report <- function(
                       `font-size` = "large"
                     ),
                     htmltools::HTML("&rarr;")
-                  ) %>%
+                  ) |>
                     as.character(),
                   col_type
                 )
@@ -355,8 +355,7 @@ get_informant_report <- function(
             )
 
           column_escaped <-
-            column %>%
-            gsub("(\\(|\\)|\\[|\\]|\\||\\.|\\^|\\?|\\+|\\$|\\*)", "\\\\\\1", .)
+            gsub("(\\(|\\)|\\[|\\]|\\||\\.|\\^|\\?|\\+|\\$|\\*)", "\\\\\\1", column)
 
           row_idx <-
             grep(paste0("^<code.*?>", column_escaped, "<.*?"), tbl$item)
@@ -379,7 +378,7 @@ get_informant_report <- function(
 
   # Modify `tbl` so that `group` values correspond to the set `lang`
   tbl <-
-    tbl %>%
+    tbl |>
     dplyr::mutate(group = dplyr::case_when(
       group == "Table" ~ get_lsv(text = c(
         "informant_report", "pointblank_table_text"
@@ -482,7 +481,7 @@ get_informant_report <- function(
         ),
         htmltools::HTML(paste0(table_type_html, table_dims))
       )
-    ) %>% as.character()
+    ) |> as.character()
 
   time_end <- Sys.time()
 
@@ -513,16 +512,16 @@ get_informant_report <- function(
       tbl,
       groupname_col = "group",
       id = "pb_information"
-    ) %>%
+    ) |>
     gt::tab_header(
       title = title_text,
       subtitle = gt::md(combined_subtitle)
-    ) %>%
-    gt::tab_source_note(source_note = gt::md(table_time)) %>%
-    gt::fmt_markdown(columns = "item") %>%
+    ) |>
+    gt::tab_source_note(source_note = gt::md(table_time)) |>
+    gt::fmt_markdown(columns = "item") |>
     gt::tab_options(
       column_labels.hidden = TRUE
-    ) %>%
+    ) |>
     gt::tab_style(
       style = gt::cell_text(
         size = gt::px(28),
@@ -531,14 +530,14 @@ get_informant_report <- function(
         color = "#444444"
       ),
       locations = gt::cells_title("title")
-    ) %>%
+    ) |>
     gt::tab_style(
       style = gt::cell_text(
         size = gt::px(12),
         align = "left"
       ),
       locations = gt::cells_title("subtitle")
-    ) %>%
+    ) |>
     gt::tab_style(
       style = list(
         gt::cell_text(
@@ -554,7 +553,7 @@ get_informant_report <- function(
         )
       ),
       locations = gt::cells_row_groups(groups = TRUE)
-    ) %>%
+    ) |>
     gt::tab_style(
       style = list(
         gt::cell_text(
@@ -574,7 +573,7 @@ get_informant_report <- function(
   if (size == "small") {
 
     gt_informant_report <-
-      gt_informant_report %>%
+      gt_informant_report |>
       gt::cols_width(gt::everything() ~ gt::px(575))
   }
 
@@ -587,12 +586,12 @@ get_informant_report <- function(
     }
 
     gt_informant_report <-
-      gt_informant_report %>%
+      gt_informant_report |>
       gt::tab_options(
         table.width = width_px,
         table.font.size = gt::pct(130)
-      ) %>%
-      gt::opt_table_font(font = gt::google_font("IBM Plex Sans")) %>%
+      ) |>
+      gt::opt_table_font(font = gt::google_font("IBM Plex Sans")) |>
       gt::opt_css(
         css = "
           #pb_information {
@@ -751,14 +750,16 @@ title_text_md <- function(
     if (grepl("\\[\\[.*?\\]\\](\\n?)<<.*?>>", item[i])) {
 
       # Strip any `\n` characters
-      item[i] <- item[i] %>% gsub("\\n", "", .)
+      item[i] <- gsub("\\n", "", item[i])
 
       for (j in 1:10) {
 
-        text_content <-
-          item[i] %>%
-          gsub("(.*)(\\[\\[.*?\\]\\]<<.*?>>)(.*)", "\\2", .) %>%
-          gsub("\\[\\[(.*?)\\]\\]<<(.*?)>>", "\\1", .)
+        text_content <- gsub(
+          "(.*)(\\[\\[.*?\\]\\]<<.*?>>)(.*)", "\\2", item[i]
+        )
+        text_content <- gsub(
+          "\\[\\[(.*?)\\]\\]<<(.*?)>>", "\\1", text_content
+        )
 
         replace_within_anchor_chars <- function(x, left, right, what, repl) {
 
@@ -772,15 +773,18 @@ title_text_md <- function(
           gsub(re, repl, x, perl = TRUE)
         }
 
-        tag_content <-
-          item[i] %>%
-          gsub("(.*)(\\[\\[.*?\\]\\]<<.*?>>)(.*)", "\\2", .) %>%
-          gsub("\\[\\[(.*?)\\]\\]<<(.*?)>>", "\\2", .) %>%
-          gsub(":\\s+?", ":", .) %>%
-          gsub(";\\s+?", ";", .) %>%
-          replace_within_anchor_chars(
-            left = ":", right = ";", what = "\\s+", repl = "&nbsp;") %>%
-          strsplit(" ")
+        tag_content <- gsub(
+          "(.*)(\\[\\[.*?\\]\\]<<.*?>>)(.*)", "\\2", item[i]
+        )
+        tag_content <- gsub(
+          "\\[\\[(.*?)\\]\\]<<(.*?)>>", "\\2", tag_content
+        )
+        tag_content <- gsub(":\\s+?", ":", tag_content)
+        tag_content <- gsub(";\\s+?", ";", tag_content)
+        tag_content <- replace_within_anchor_chars(
+          tag_content, left = ":", right = ";", what = "\\s+", repl = "&nbsp;"
+        )
+        tag_content <- strsplit(tag_content, " ")
 
         id_values <-
           vapply(
@@ -933,7 +937,7 @@ make_info_label_html <- function(info_label) {
       `margin-right` = "5px",
       `padding-right` = "2px"
     )
-  ) %>% as.character()
+  ) |> as.character()
 }
 
 make_table_dims_html <- function(

--- a/R/get_informant_report.R
+++ b/R/get_informant_report.R
@@ -355,7 +355,10 @@ get_informant_report <- function(
             )
 
           column_escaped <-
-            gsub("(\\(|\\)|\\[|\\]|\\||\\.|\\^|\\?|\\+|\\$|\\*)", "\\\\\\1", column)
+            gsub(
+              "(\\(|\\)|\\[|\\]|\\||\\.|\\^|\\?|\\+|\\$|\\*)",
+              "\\\\\\1", column
+            )
 
           row_idx <-
             grep(paste0("^<code.*?>", column_escaped, "<.*?"), tbl$item)

--- a/R/get_multiagent_report.R
+++ b/R/get_multiagent_report.R
@@ -281,19 +281,19 @@ get_multiagent_report <- function(
     i_name <- rlang::quo_name(i_name)
 
     val_set_packed <-
-      multiagent[["agents"]][[i]][["validation_set"]] %>%
+      multiagent[["agents"]][[i]][["validation_set"]] |>
       dplyr::select(
         sha1, i, step_id, assertion_type, column, values,
         na_pass, preconditions, actions, label, brief,
         eval_active, eval_error, eval_warning, all_passed,
         n, f_passed, f_failed, warn, notify, stop
-      ) %>%
+      ) |>
       tidyr::pack(validation = c(
         i, step_id, assertion_type, column, values,
         na_pass, preconditions, actions, label, brief,
         eval_active, eval_error, eval_warning, all_passed,
         n, f_passed, f_failed, warn, notify, stop
-      )) %>%
+      )) |>
       dplyr::rename(!!i_name := "validation")
 
     if (i == 1) {
@@ -302,12 +302,12 @@ get_multiagent_report <- function(
     }
 
     report_tbl <-
-      report_tbl %>%
+      report_tbl |>
       dplyr::full_join(val_set_packed, by = "sha1")
   }
 
   report_tbl <-
-    report_tbl %>%
+    report_tbl |>
     dplyr::select(-sha1)
 
   if (!display_table) {
@@ -345,7 +345,7 @@ get_multiagent_report <- function(
         )
 
       long_report_i <-
-        long_report_i %>%
+        long_report_i |>
         gt::tab_options(
           table.border.top.width = "0",
           table.border.bottom.style = "double",
@@ -384,7 +384,7 @@ get_multiagent_report <- function(
         ),
         htmltools::HTML(table_type)
       )
-    ) %>% as.character()
+    ) |> as.character()
 
 
   create_report_time_html <- function(time) {
@@ -429,7 +429,7 @@ get_multiagent_report <- function(
     date_time <- c(date_time, date_time_el)
 
     val_set <-
-      multiagent[["agents"]][[i]][["validation_set"]] %>%
+      multiagent[["agents"]][[i]][["validation_set"]] |>
       dplyr::select(
         sha1, i, eval_active, eval_error, eval_warning, all_passed,
         n, f_passed, f_failed, warn, notify, stop
@@ -440,9 +440,7 @@ get_multiagent_report <- function(
     for (j in seq_len(nrow(val_set))) {
 
       vals_step_j <-
-        val_set %>%
-        dplyr::select(-sha1) %>%
-        .[j, ] %>%
+        dplyr::select(val_set, -sha1)[j, ] |>
         as.list()
 
       cell_content <-
@@ -455,8 +453,8 @@ get_multiagent_report <- function(
     }
 
     val_set <-
-      val_set %>%
-      dplyr::mutate(!!i_name := html_cells) %>%
+      val_set |>
+      dplyr::mutate(!!i_name := html_cells) |>
       dplyr::select(
         -c(
           i, eval_active, eval_error, eval_warning, all_passed,
@@ -470,7 +468,7 @@ get_multiagent_report <- function(
     }
 
     report_tbl <-
-      report_tbl %>%
+      report_tbl |>
       dplyr::full_join(val_set, by = "sha1")
   }
 
@@ -483,10 +481,10 @@ get_multiagent_report <- function(
       i_name <- rlang::quo_name(i_names[j])
 
       report_tbl <-
-        report_tbl %>%
+        report_tbl |>
         dplyr::bind_cols(
           dplyr::tibble(pb_extra_ = rep(NA_character_, nrow(report_tbl)))
-        ) %>%
+        ) |>
         dplyr::rename(!!i_name := "pb_extra_")
     }
 
@@ -501,10 +499,10 @@ get_multiagent_report <- function(
       i_name <- rlang::quo_name(i_names[j])
 
       report_tbl <-
-        report_tbl %>%
+        report_tbl |>
         dplyr::bind_cols(
           dplyr::tibble(pb_extra_ = rep(NA_character_, nrow(report_tbl)))
-        ) %>%
+        ) |>
         dplyr::rename(!!i_name := "pb_extra_")
     }
 
@@ -519,10 +517,10 @@ get_multiagent_report <- function(
       i_name <- rlang::quo_name(i_names[j])
 
       report_tbl <-
-        report_tbl %>%
+        report_tbl |>
         dplyr::bind_cols(
           dplyr::tibble(pb_extra_ = rep(NA_character_, nrow(report_tbl)))
-        ) %>%
+        ) |>
         dplyr::rename(!!i_name := "pb_extra_")
     }
 
@@ -621,15 +619,15 @@ get_multiagent_report <- function(
     assertion_tbl <-
       dplyr::bind_rows(
         assertion_tbl,
-        multiagent[["agents"]][[x]][["validation_set"]] %>%
+        multiagent[["agents"]][[x]][["validation_set"]] |>
           dplyr::select(sha1, assertion_type)
       )
   }
 
   report_tbl <-
-    report_tbl %>%
+    report_tbl |>
     dplyr::left_join(
-      assertion_tbl %>% dplyr::distinct(),
+      assertion_tbl |> dplyr::distinct(),
       by = "sha1"
     )
 
@@ -652,18 +650,18 @@ get_multiagent_report <- function(
 
   # Overall width should be 875px (agent report is 876px)
   report_tbl <-
-    report_tbl %>%
-    dplyr::select(-assertion_type) %>%
+    report_tbl |>
+    dplyr::select(-assertion_type) |>
     gt::gt(id = "report")
 
   if (layout_type == "4UP") {
 
     report_tbl <-
-      report_tbl %>%
+      report_tbl |>
       gt::cols_width(
         gt::matches("[0-9]{3}") ~ gt::px(200),
         gt::everything() ~ gt::px(75)
-      ) %>%
+      ) |>
       gt::tab_style(
         list(
           style = gt::cell_text(
@@ -675,11 +673,11 @@ get_multiagent_report <- function(
           )
         ),
         locations = gt::cells_column_labels(columns = gt::everything())
-      ) %>%
+      ) |>
       gt::tab_style(
         style = gt::cell_text(weight = "bold", color = "#666666"),
         locations = gt::cells_column_labels(columns = "sha1")
-      ) %>%
+      ) |>
       gt::tab_style(
         locations = gt::cells_body(columns = gt::everything()),
         style = "height: 56px; margin: 0;"
@@ -688,11 +686,11 @@ get_multiagent_report <- function(
   } else if (layout_type == "8UP") {
 
     report_tbl <-
-      report_tbl %>%
+      report_tbl |>
       gt::cols_width(
         gt::matches("[0-9]{3}") ~ gt::px(100),
         gt::everything() ~ gt::px(75)
-      ) %>%
+      ) |>
       gt::tab_style(
         list(
           style = gt::cell_text(
@@ -707,7 +705,7 @@ get_multiagent_report <- function(
           )
         ),
         locations = gt::cells_column_labels(columns = gt::everything())
-      ) %>%
+      ) |>
       gt::tab_style(
         style = gt::cell_text(
           weight = "bold",
@@ -717,7 +715,7 @@ get_multiagent_report <- function(
           align = "left"
         ),
         locations = gt::cells_column_labels(columns = "sha1")
-      ) %>%
+      ) |>
       gt::tab_style(
         locations = gt::cells_body(columns = gt::everything()),
         style = "height: 56px; margin: 0;"
@@ -726,11 +724,11 @@ get_multiagent_report <- function(
   } else {
 
     report_tbl <-
-      report_tbl %>%
+      report_tbl |>
       gt::cols_width(
         gt::matches("[0-9]{3}") ~ gt::px(50),
         gt::everything() ~ gt::px(75)
-      ) %>%
+      ) |>
       gt::tab_style(
         list(
           style = gt::cell_text(
@@ -747,7 +745,7 @@ get_multiagent_report <- function(
           )
         ),
         locations = gt::cells_column_labels(columns = gt::everything())
-      ) %>%
+      ) |>
       gt::tab_style(
         list(
           style = gt::cell_text(
@@ -763,7 +761,7 @@ get_multiagent_report <- function(
           )
         ),
         locations = gt::cells_column_labels(columns = "sha1")
-      ) %>%
+      ) |>
       gt::tab_style(
         locations = gt::cells_body(columns = gt::everything()),
         style = "height: 56px; margin: 0;"
@@ -773,15 +771,15 @@ get_multiagent_report <- function(
   if (n_columns > 17) {
 
     report_tbl <-
-      report_tbl %>%
+      report_tbl |>
       gt::tab_style(
         style = "left: 0; position: sticky; background: white; z-index: 1;",
         locations = gt::cells_body(columns = 1)
-      ) %>%
+      ) |>
       gt::tab_style(
         style = "left: 0; position: sticky; background: white; z-index: 1;",
         locations = gt::cells_column_labels(columns = 1)
-      ) %>%
+      ) |>
       gt::tab_options(container.width = gt::px(875))
   }
 
@@ -795,20 +793,20 @@ get_multiagent_report <- function(
     )
 
   report_tbl <-
-    report_tbl %>%
+    report_tbl |>
     gt::tab_header(
       title = title_text,
       subtitle = gt::md(combined_subtitle)
-    ) %>%
+    ) |>
     gt::tab_source_note(
       source_note = gt::md(create_report_time_html(time = Sys.time()))
-    ) %>%
+    ) |>
     gt::tab_options(
       table.font.size = gt::pct(90),
       row.striping.include_table_body = FALSE
-    ) %>%
-    gt::fmt_markdown(columns = 2:n_columns) %>%
-    gt::fmt_markdown(columns = "sha1") %>%
+    ) |>
+    gt::fmt_markdown(columns = 2:n_columns) |>
+    gt::fmt_markdown(columns = "sha1") |>
     gt::sub_missing(
       columns = columns_used_tbl,
       missing_text = gt::html(
@@ -823,15 +821,15 @@ get_multiagent_report <- function(
           )
         )
       )
-    ) %>%
+    ) |>
     gt::sub_missing(
       columns = columns_not_used,
       missing_text = ""
-    ) %>%
+    ) |>
     gt::tab_style(
       style = gt::cell_text(font = "IBM Plex Mono", size = "small"),
       locations = gt::cells_body(columns = "sha1")
-    ) %>%
+    ) |>
     gt::tab_style(
       style = gt::cell_text(
         size = gt::px(28),
@@ -840,43 +838,43 @@ get_multiagent_report <- function(
         color = "#444444"
       ),
       locations = gt::cells_title("title")
-    ) %>%
+    ) |>
     gt::tab_style(
       style = gt::cell_text(
         size = gt::px(12),
         align = "left"
       ),
       locations = gt::cells_title("subtitle")
-    ) %>%
+    ) |>
     gt::tab_style(
       style = list(
         gt::cell_borders(sides = "right", color = "#D3D3D3"),
         gt::cell_fill(color = "#FCFCFC")
       ),
       locations = gt::cells_body(columns = "sha1")
-    ) %>%
+    ) |>
     gt::tab_style(
       style = list(
         gt::cell_borders(sides = "right", color = "#D3D3D3", style = "dotted"),
         gt::cell_fill(color = "#FCFCFC")
       ),
       locations = gt::cells_body(columns = gt::matches("[0-9]{3}"))
-    ) %>%
-    gt::cols_label(.list = date_time) %>%
-    gt::opt_align_table_header(align = "left") %>%
-    gt::opt_table_font(font = gt::google_font("IBM Plex Sans")) %>%
+    ) |>
+    gt::cols_label(.list = date_time) |>
+    gt::opt_align_table_header(align = "left") |>
+    gt::opt_table_font(font = gt::google_font("IBM Plex Sans")) |>
     gt::opt_css(
       paste0(
         "@import url(\"https://unpkg.com/",
         "balloon-css/balloon.min.css\");"
       )
-    ) %>%
+    ) |>
     gt::opt_css(
       paste0(
         "@import url(\"https://fonts.googleapis.com/",
         "css2?family=IBM+Plex+Mono&display=swap\");"
       )
-    ) %>%
+    ) |>
     gt::opt_css(
       css = "
           #pb_information {
@@ -909,7 +907,7 @@ get_multiagent_report <- function(
 
   if (layout_type == "16UP") {
     report_tbl <-
-      report_tbl %>%
+      report_tbl |>
       gt::cols_label(`001` = gt::html(date_time[[2]]))
   }
 
@@ -1197,7 +1195,7 @@ generate_cell_content <- function(
             )
           )
         )
-      ) %>%
+      ) |>
       as.character()
 
     return(cell_content)
@@ -1393,7 +1391,7 @@ generate_cell_content <- function(
             )
           )
         )
-      ) %>%
+      ) |>
       as.character()
 
     return(cell_content)
@@ -1505,7 +1503,7 @@ generate_cell_content <- function(
               )
             )
           )
-      ) %>%
+      ) |>
       as.character()
 
     return(cell_content)

--- a/R/get_sundered_data.R
+++ b/R/get_sundered_data.R
@@ -278,9 +278,9 @@ get_sundered_data <- function(
 
   # Get the row count of the input table
   row_count_input_tbl <-
-    input_tbl %>%
-    dplyr::count() %>%
-    dplyr::pull(n) %>%
+    input_tbl |>
+    dplyr::count() |>
+    dplyr::pull(n) |>
     as.numeric()
 
   # Keep only the validation steps that:
@@ -288,7 +288,7 @@ get_sundered_data <- function(
   # - are row-based (not including `rows_distinct()`)
   # - are `active`
   validation_set_prefiltered <-
-    agent$validation_set %>%
+    agent$validation_set |>
     dplyr::filter(
       !eval_error,
       assertion_type %in%
@@ -322,7 +322,7 @@ get_sundered_data <- function(
 
   # Obtain the validation steps that are to be used for sundering
   validation_steps_i <-
-    validation_set_prefiltered %>%
+    validation_set_prefiltered |>
     dplyr::pull(i)
 
   if (length(validation_steps_i) == 0) {
@@ -347,8 +347,8 @@ get_sundered_data <- function(
 
   # Get the stored `tbl_check` objects for `validation_steps_i`
   tbl_check_obj <-
-    agent$validation_set %>%
-    dplyr::filter(i %in% validation_steps_i) %>%
+    agent$validation_set |>
+    dplyr::filter(i %in% validation_steps_i) |>
     dplyr::pull(tbl_checked)
 
   for (i in seq(tbl_check_obj)) {
@@ -358,13 +358,13 @@ get_sundered_data <- function(
       new_col_i <- paste0("pb_is_good_", i)
 
       tbl_check_join <-
-        tbl_check_obj[[i]][[1]] %>%
+        tbl_check_obj[[i]][[1]] |>
         dplyr::rename(!!new_col_i := pb_is_good_)
 
       if (agent$tbl_src %in% c("tbl_df", "data.frame")) {
 
         tbl_check_join <-
-          tbl_check_join %>%
+          tbl_check_join |>
           tibble::rowid_to_column(var = "__pb_rowid__")
       }
     }
@@ -380,20 +380,20 @@ get_sundered_data <- function(
       by_cols <- id_cols
 
       tbl_check_join <-
-        tbl_check_join %>%
+        tbl_check_join |>
         dplyr::select(
           dplyr::all_of(by_cols), dplyr::starts_with("pb_is_good_")
-        ) %>%
+        ) |>
         dplyr::left_join(
-          tbl_check_join_r %>%
-            dplyr::rename(!!new_col_ii := pb_is_good_) %>%
+          tbl_check_join_r |>
+            dplyr::rename(!!new_col_ii := pb_is_good_) |>
             dplyr::select(
               dplyr::all_of(by_cols), dplyr::starts_with("pb_is_good_")
             ),
           by = by_cols
-        ) %>%
+        ) |>
         dplyr::left_join(
-          tbl_check_join %>%
+          tbl_check_join |>
             dplyr::select(-dplyr::starts_with("pb_is_good_")),
           by = by_cols
         )
@@ -401,15 +401,15 @@ get_sundered_data <- function(
     } else if (agent$tbl_src %in% c("tbl_df", "data.frame")) {
 
       tbl_check_join_r <-
-        tbl_check_join_r %>%
+        tbl_check_join_r |>
         tibble::rowid_to_column(var = "__pb_rowid__")
 
       by_cols <- c("__pb_rowid__", agent$col_names)
 
       tbl_check_join <-
-        tbl_check_join %>%
+        tbl_check_join |>
         dplyr::left_join(
-          tbl_check_join_r %>%
+          tbl_check_join_r |>
             dplyr::rename(!!new_col_ii := pb_is_good_),
           by = by_cols
         )
@@ -423,26 +423,26 @@ get_sundered_data <- function(
   validation_n <- length(seq(tbl_check_obj))
 
   tbl_check_join <-
-    tbl_check_join %>%
-    dplyr::mutate(pb_is_good_ = !!rlang::parse_expr(columns_str_add)) %>%
-    dplyr::select(-dplyr::all_of(columns_str_vec)) %>%
+    tbl_check_join |>
+    dplyr::mutate(pb_is_good_ = !!rlang::parse_expr(columns_str_add)) |>
+    dplyr::select(-dplyr::all_of(columns_str_vec)) |>
     dplyr::mutate(pb_is_good_ = dplyr::case_when(
       pb_is_good_ == validation_n ~ TRUE,
       TRUE ~ FALSE
-    )) %>%
+    )) |>
     dplyr::select(-dplyr::starts_with("__pb_rowid__"))
 
   if (!is.null(type) && type == "pass") {
 
     if (uses_numeric_logical(input_tbl)) {
       sundered_tbl_pass <-
-        tbl_check_join %>%
-        dplyr::filter(pb_is_good_ == 1) %>%
+        tbl_check_join |>
+        dplyr::filter(pb_is_good_ == 1) |>
         dplyr::select(-pb_is_good_)
     } else {
       sundered_tbl_pass <-
-        tbl_check_join %>%
-        dplyr::filter(pb_is_good_ == TRUE) %>%
+        tbl_check_join |>
+        dplyr::filter(pb_is_good_ == TRUE) |>
         dplyr::select(-pb_is_good_)
     }
 
@@ -453,13 +453,13 @@ get_sundered_data <- function(
 
     if (uses_numeric_logical(input_tbl)) {
       sundered_tbl_fail <-
-        tbl_check_join %>%
-        dplyr::filter(pb_is_good_ == 0) %>%
+        tbl_check_join |>
+        dplyr::filter(pb_is_good_ == 0) |>
         dplyr::select(-pb_is_good_)
     } else {
       sundered_tbl_fail <-
-        tbl_check_join %>%
-        dplyr::filter(pb_is_good_ == FALSE) %>%
+        tbl_check_join |>
+        dplyr::filter(pb_is_good_ == FALSE) |>
         dplyr::select(-pb_is_good_)
     }
 
@@ -469,12 +469,12 @@ get_sundered_data <- function(
   if (!is.null(type) && type == "combined") {
 
     sundered_tbl_combined <-
-      tbl_check_join %>%
+      tbl_check_join |>
       dplyr::mutate(pb_is_good_ = dplyr::case_when(
         pb_is_good_ ~ pass_fail[1],
         !pb_is_good_ ~ pass_fail[2],
         TRUE ~ pass_fail[1]
-      )) %>%
+      )) |>
       dplyr::rename(`.pb_combined` = pb_is_good_)
 
     return(sundered_tbl_combined)
@@ -485,21 +485,21 @@ get_sundered_data <- function(
     if (uses_numeric_logical(input_tbl)) {
       sundered_tbl_list <-
         list(
-          pass = tbl_check_join %>%
-            dplyr::filter(pb_is_good_ == 1) %>%
+          pass = tbl_check_join |>
+            dplyr::filter(pb_is_good_ == 1) |>
             dplyr::select(-pb_is_good_),
-          fail = tbl_check_join %>%
-            dplyr::filter(pb_is_good_ == 0) %>%
+          fail = tbl_check_join |>
+            dplyr::filter(pb_is_good_ == 0) |>
             dplyr::select(-pb_is_good_)
         )
     } else {
       sundered_tbl_list <-
         list(
-          pass = tbl_check_join %>%
-            dplyr::filter(pb_is_good_ == TRUE) %>%
+          pass = tbl_check_join |>
+            dplyr::filter(pb_is_good_ == TRUE) |>
             dplyr::select(-pb_is_good_),
-          fail = tbl_check_join %>%
-            dplyr::filter(pb_is_good_ == FALSE) %>%
+          fail = tbl_check_join |>
+            dplyr::filter(pb_is_good_ == FALSE) |>
             dplyr::select(-pb_is_good_)
         )
     }

--- a/R/incorporate.R
+++ b/R/incorporate.R
@@ -194,7 +194,7 @@ incorporate <- function(informant) {
 
       if (inherits(tbl, "read_fn")) {
         if (inherits(tbl, "with_tbl_name") && is.na(tbl_name)) {
-          tbl_name <- tbl %>% rlang::f_lhs() %>% as.character()
+          tbl_name <- as.character(rlang::f_lhs(tbl))
         }
         tbl <- eval_f_rhs(tbl)
       }
@@ -248,14 +248,10 @@ incorporate <- function(informant) {
 
   for (i in seq_along(meta_snippets)) {
 
-    snippet_fn <-
-      informant$meta_snippets[[i]] %>%
-      rlang::f_rhs()
+    snippet_fn <- rlang::f_rhs(informant$meta_snippets[[i]])
 
     snippet_f_rhs_str <-
-      informant$meta_snippets[[i]] %>%
-      rlang::f_rhs() %>%
-      as.character()
+      as.character(rlang::f_rhs(informant$meta_snippets[[i]]))
 
     if (
       any(grepl("pb_str_catalog", snippet_f_rhs_str)) &&
@@ -282,17 +278,19 @@ incorporate <- function(informant) {
       # Put the snippet back together as a formula and
       # get only the RHS
       snippet_fn <-
-        paste0(
-          "~",
-          snippet_f_rhs_str[select_call_idx],
-          " %>% ",
-          snippet_f_rhs_str[pb_str_catalog_call_idx]
-        ) %>%
-        stats::as.formula() %>%
-        rlang::f_rhs()
+        rlang::f_rhs(
+          stats::as.formula(
+            paste0(
+              "~",
+              snippet_f_rhs_str[select_call_idx],
+              " %>% ",
+              snippet_f_rhs_str[pb_str_catalog_call_idx]
+            )
+          )
+        )
     }
 
-    snippet_fn <- snippet_fn %>% rlang::eval_tidy()
+    snippet_fn <- rlang::eval_tidy(snippet_fn)
 
     if (inherits(snippet_fn, "fseq")) {
 
@@ -305,15 +303,11 @@ incorporate <- function(informant) {
 
         if (is.integer(snippet)) {
 
-          snippet <-
-            snippet %>%
-            pb_fmt_number(locale = locale, decimals = 0)
+          snippet <- pb_fmt_number(snippet, locale = locale, decimals = 0)
 
         } else {
 
-          snippet <-
-            snippet %>%
-            pb_fmt_number(locale = locale)
+          snippet <- pb_fmt_number(snippet, locale = locale)
         }
       }
 

--- a/R/info_add.R
+++ b/R/info_add.R
@@ -687,7 +687,7 @@ check_info_columns_tbl <- function(tbl) {
 
   # Filter out any missing or NA values in the `info` column
   tbl <-
-    tbl %>%
+    tbl |>
     dplyr::filter(!is.na(info) & !grepl("^\\s*$", info))
 
   colnames_in_tbl <- dplyr::pull(tbl, column)

--- a/R/interrogate.R
+++ b/R/interrogate.R
@@ -190,7 +190,7 @@ interrogate <- function(
 
       if (inherits(agent$tbl, "read_fn")) {
         if (inherits(agent$tbl, "with_tbl_name")) {
-          agent$tbl_name <- agent$tbl %>% rlang::f_lhs() %>% as.character()
+          agent$tbl_name <- agent$tbl |> rlang::f_lhs() |> as.character()
         }
         agent$tbl <- eval_f_rhs(agent$tbl)
       }
@@ -247,8 +247,8 @@ interrogate <- function(
     if (rlang::is_formula(agent$validation_set[[i, "active"]][[1]])) {
 
       is_active <-
-        agent$validation_set[[i, "active"]][[1]] %>%
-        rlang::f_rhs() %>%
+        agent$validation_set[[i, "active"]][[1]] |>
+        rlang::f_rhs() |>
         rlang::eval_tidy()
 
       agent$validation_set[[i, "eval_active"]] <- is_active(table)
@@ -315,8 +315,8 @@ interrogate <- function(
       validation_n <- length(validation_formulas)
 
       validation_fns <-
-        validation_formulas %>%
-        lapply(rlang::f_rhs) %>%
+        validation_formulas |>
+        lapply(rlang::f_rhs) |>
         vapply(
           FUN.VALUE = character(1),
           USE.NAMES = FALSE,
@@ -349,9 +349,9 @@ interrogate <- function(
           eval(
             expr = parse(
               text =
-                formula %>%
-                rlang::f_rhs() %>%
-                rlang::expr_deparse() %>%
+                formula |>
+                rlang::f_rhs() |>
+                rlang::expr_deparse() |>
                 tidy_gsub("(.", "(double_agent", fixed = TRUE)
             ),
             envir = NULL
@@ -388,16 +388,16 @@ interrogate <- function(
        } else {
 
          tbl_checked <-
-           tbl_checked %>%
+           tbl_checked |>
            dplyr::mutate(
-             pb_is_good_ = {{ tbl_check_t }} %>%
-               utils::head(1) %>%
+             pb_is_good_ = {{ tbl_check_t }} |>
+               utils::head(1) |>
                dplyr::pull(pb_is_good_)
            )
        }
 
         tbl_checked <-
-          tbl_checked %>%
+          tbl_checked |>
           dplyr::rename(!!new_col := pb_is_good_)
       }
 
@@ -415,9 +415,9 @@ interrogate <- function(
         # are entirely of the combined set of `col_vals_*()`, `col_is_*()`,
         # and `col_exists()`
 
-        tbl_checked %>%
-          dplyr::mutate(pb_is_good_ = !!rlang::parse_expr(columns_str_add)) %>%
-          dplyr::select(-dplyr::all_of(columns_str_vec)) %>%
+        tbl_checked |>
+          dplyr::mutate(pb_is_good_ = !!rlang::parse_expr(columns_str_add)) |>
+          dplyr::select(-dplyr::all_of(columns_str_vec)) |>
           dplyr::mutate(pb_is_good_ = pb_is_good_ == validation_n)
       }
 
@@ -442,10 +442,8 @@ interrogate <- function(
           FUN.VALUE = character(1),
           USE.NAMES = FALSE,
           FUN = function(x) {
-            x %>%
-              rlang::f_rhs() %>%
-              as.character() %>%
-              .[[1]]
+            chars <- as.character(rlang::f_rhs(x))
+            chars[[1]]
           }
         )
 
@@ -477,12 +475,12 @@ interrogate <- function(
           eval(
             expr = parse(
               text =
-                validation_formulas[[k]] %>%
-                rlang::f_rhs() %>%
-                rlang::expr_deparse() %>%
-                tidy_gsub("(.", "(double_agent", fixed = TRUE) %>%
-                tidy_gsub("^test_", "") %>%
-                tidy_gsub("threshold\\s+?=\\s.*$", ")") %>%
+                validation_formulas[[k]] |>
+                rlang::f_rhs() |>
+                rlang::expr_deparse() |>
+                tidy_gsub("(.", "(double_agent", fixed = TRUE) |>
+                tidy_gsub("^test_", "") |>
+                tidy_gsub("threshold\\s+?=\\s.*$", ")") |>
                 tidy_gsub(",\\s+?\\)$", ")")
 
             ),
@@ -499,30 +497,30 @@ interrogate <- function(
         double_agent <- create_agent(tbl = table, label = "::QUIET::")
 
         deparsed_call <-
-          validation_formulas[[k]] %>%
-          rlang::f_rhs() %>%
-          rlang::expr_deparse() %>%
+          validation_formulas[[k]] |>
+          rlang::f_rhs() |>
+          rlang::expr_deparse() |>
           paste(collapse = " ")
 
         if (grepl("threshold", deparsed_call)) {
 
           threshold_value <-
-            validation_formulas[[k]] %>%
-            rlang::f_rhs() %>%
-            rlang::expr_deparse() %>%
-            tidy_gsub(".*?(threshold\\s+?=\\s+[0-9\\.]+?).+?", "\\1") %>%
-            tidy_gsub("threshold\\s+?=\\s+?", "") %>%
+            validation_formulas[[k]] |>
+            rlang::f_rhs() |>
+            rlang::expr_deparse() |>
+            tidy_gsub(".*?(threshold\\s+?=\\s+[0-9\\.]+?).+?", "\\1") |>
+            tidy_gsub("threshold\\s+?=\\s+?", "") |>
             as.numeric()
 
           double_agent <-
             eval(
               expr = parse(
                 text =
-                  validation_formulas[[k]] %>%
-                  rlang::f_rhs() %>%
-                  rlang::expr_deparse() %>%
-                  tidy_gsub("(.", "(double_agent", fixed = TRUE) %>%
-                  tidy_gsub("^test_", "") %>%
+                  validation_formulas[[k]] |>
+                  rlang::f_rhs() |>
+                  rlang::expr_deparse() |>
+                  tidy_gsub("(.", "(double_agent", fixed = TRUE) |>
+                  tidy_gsub("^test_", "") |>
                   tidy_gsub(
                     "threshold\\s+?=\\s+?[0-9\\.]+?",
                     paste0(
@@ -542,11 +540,11 @@ interrogate <- function(
             eval(
               expr = parse(
                 text =
-                  validation_formulas[[k]] %>%
-                  rlang::f_rhs() %>%
-                  rlang::expr_deparse() %>%
-                  tidy_gsub("(.", "(double_agent", fixed = TRUE) %>%
-                  tidy_gsub("^test_", "") %>%
+                  validation_formulas[[k]] |>
+                  rlang::f_rhs() |>
+                  rlang::expr_deparse() |>
+                  tidy_gsub("(.", "(double_agent", fixed = TRUE) |>
+                  tidy_gsub("^test_", "") |>
                   tidy_gsub(
                     "\\)$",
                     paste0(
@@ -559,17 +557,17 @@ interrogate <- function(
             )
         }
 
-        double_agent <- double_agent %>% interrogate()
+        double_agent <- double_agent |> interrogate()
 
         serially_validation_set <-
           dplyr::bind_rows(
             serially_validation_set,
-            double_agent$validation_set %>%
+            double_agent$validation_set |>
               dplyr::select(
                 -c(step_id, sha1, -warn, -notify, -tbl_checked,
                    interrogation_notes
                 )
-              ) %>%
+              ) |>
               dplyr::mutate(i_o = .env$k)
           )
 
@@ -615,25 +613,25 @@ interrogate <- function(
           eval(
             expr = parse(
               text =
-                validation_formulas[[validation_n]] %>%
-                rlang::f_rhs() %>%
-                rlang::expr_deparse() %>%
+                validation_formulas[[validation_n]] |>
+                rlang::f_rhs() |>
+                rlang::expr_deparse() |>
                 tidy_gsub("(.", "(double_agent", fixed = TRUE)
             ),
             envir = NULL
           )
 
-        double_agent <- double_agent %>% interrogate()
+        double_agent <- double_agent |> interrogate()
 
         serially_validation_set <-
           dplyr::bind_rows(
             serially_validation_set,
-            double_agent$validation_set %>%
+            double_agent$validation_set |>
               dplyr::select(
                 -c(step_id, sha1, -warn, -notify, -tbl_checked,
                    interrogation_notes
                 )
-              ) %>%
+              ) |>
               dplyr::mutate(i_o = .env$k)
           )
 
@@ -656,8 +654,8 @@ interrogate <- function(
       # Renumber `i` in the `serially()` validation set so that
       # it is an ascending integer sequence
       serially_validation_set <-
-        serially_validation_set %>%
-        dplyr::mutate(i = seq_len(nrow(.)))
+        serially_validation_set |>
+        dplyr::mutate(i = seq_len(dplyr::n()))
 
       # Add interrogation notes
       agent$validation_set[[i, "interrogation_notes"]] <-
@@ -828,34 +826,34 @@ create_post_step_cli_output_a <- function(
   if (quiet) return()
 
   interrogation_evaluation <-
-    agent$validation_set[i, ] %>%
-    dplyr::select(eval_error, eval_warning) %>%
+    agent$validation_set[i, ] |>
+    dplyr::select(eval_error, eval_warning) |>
     dplyr::mutate(condition = dplyr::case_when(
       !eval_error & !eval_warning ~ "OK",
       eval_error & eval_warning ~ "{.yellow WARNING} + {.red ERROR}",
       eval_error ~ "{.red ERROR}",
       eval_warning ~ "{.yellow WARNING}"
-    )) %>%
+    )) |>
     dplyr::pull(condition)
 
   validation_condition <-
-    agent$validation_set[i, ] %>%
-    dplyr::select(warn, stop) %>%
+    agent$validation_set[i, ] |>
+    dplyr::select(warn, stop) |>
     dplyr::mutate(condition = dplyr::case_when(
       is.na(warn) & is.na(stop) ~ "NONE",
       !is.na(stop) && stop ~ "STOP",
       !is.na(warn) && warn ~ "WARN",
       TRUE ~ "NONE"
-    )) %>%
+    )) |>
     dplyr::pull(condition)
 
   notify_condition <-
-    agent$validation_set[i, ] %>%
-    dplyr::select(notify) %>%
+    agent$validation_set[i, ] |>
+    dplyr::select(notify) |>
     dplyr::mutate(condition = dplyr::case_when(
       !is.na(notify) && notify ~ "NOTIFY",
       TRUE ~ "NONE"
-    )) %>%
+    )) |>
     dplyr::pull(condition)
 
   label <- agent$validation_set[i, ]$label
@@ -1106,7 +1104,7 @@ interrogate_comparison <- function(
 
   # Obtain the target column as a label
   column <-
-    get_column_as_sym_at_idx(agent = agent, idx = idx) %>%
+    get_column_as_sym_at_idx(agent = agent, idx = idx) |>
     as.character()
 
   # Determine whether NAs should be allowed
@@ -1151,7 +1149,7 @@ tbl_val_comparison <- function(
     na_pass_num <- if (na_pass) 1 else 0
     col_sym <- as.symbol(column)
 
-    table %>%
+    table |>
       dplyr::mutate(pb_is_good_ = dplyr::case_when(
         !!expression ~ 1,
         is.na(!!col_sym) ~ na_pass_num,
@@ -1160,8 +1158,8 @@ tbl_val_comparison <- function(
 
   } else {
 
-    table %>%
-      dplyr::mutate(pb_is_good_ = !!expression) %>%
+    table |>
+      dplyr::mutate(pb_is_good_ = !!expression) |>
       dplyr::mutate(pb_is_good_ = dplyr::case_when(
         is.na(pb_is_good_) ~ na_pass,
         .default = pb_is_good_
@@ -1191,12 +1189,12 @@ interrogate_between <- function(
   # Normalize `left` and `right` to `name` objects
   # (if they are given as columns in `vars()`)
   if (inherits(left, "list")) {
-    left <- left[[1]] %>% rlang::get_expr()
+    left <- left[[1]] |> rlang::get_expr()
   } else {
     left <- unname(left)
   }
   if (inherits(right, "list")) {
-    right <- right[[1]] %>% rlang::get_expr()
+    right <- right[[1]] |> rlang::get_expr()
   } else {
     right <- unname(right)
   }
@@ -1254,7 +1252,7 @@ tbl_vals_between <- function(
     if (identical(inclusive, c(TRUE, TRUE))) {
 
       table <-
-        table %>%
+        table |>
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           `>=`({{ column }}, {{ left }}) &
             `<=`({{ column }}, {{ right }}) ~ {{ true }},
@@ -1267,7 +1265,7 @@ tbl_vals_between <- function(
     if (identical(inclusive, c(FALSE, TRUE))) {
 
       table <-
-        table %>%
+        table |>
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           `>`({{ column }}, {{ left }}) &
             `<=`({{ column }}, {{ right }}) ~ {{ true }},
@@ -1280,7 +1278,7 @@ tbl_vals_between <- function(
     if (identical(inclusive, c(TRUE, FALSE))) {
 
       table <-
-        table %>%
+        table |>
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           `>=`({{ column }}, {{ left }}) &
             `<`({{ column }}, {{ right }}) ~ {{ true }},
@@ -1293,7 +1291,7 @@ tbl_vals_between <- function(
     if (identical(inclusive, c(FALSE, FALSE))) {
 
       table <-
-        table %>%
+        table |>
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           `>`({{ column }}, {{ left }}) &
             `<`({{ column }}, {{ right }}) ~ {{ true }},
@@ -1308,7 +1306,7 @@ tbl_vals_between <- function(
     if (identical(inclusive, c(TRUE, TRUE))) {
 
       table <-
-        table %>%
+        table |>
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           `<`({{ column }}, {{ left }}) |
             `>`({{ column }}, {{ right }}) ~ {{ true }},
@@ -1321,7 +1319,7 @@ tbl_vals_between <- function(
     if (identical(inclusive, c(FALSE, TRUE))) {
 
       table <-
-        table %>%
+        table |>
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           `<=`({{ column }}, {{ left }}) |
             `>`({{ column }}, {{ right }}) ~ {{ true }},
@@ -1334,7 +1332,7 @@ tbl_vals_between <- function(
     if (identical(inclusive, c(TRUE, FALSE))) {
 
       table <-
-        table %>%
+        table |>
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           `<`({{ column }}, {{ left }}) |
             `>=`({{ column }}, {{ right }}) ~ {{ true }},
@@ -1347,7 +1345,7 @@ tbl_vals_between <- function(
     if (identical(inclusive, c(FALSE, FALSE))) {
 
       table <-
-        table %>%
+        table |>
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           `<=`({{ column }}, {{ left }}) |
             `>=`({{ column }}, {{ right }}) ~ {{ true }},
@@ -1357,7 +1355,7 @@ tbl_vals_between <- function(
     }
   }
 
-  table %>%
+  table |>
     dplyr::mutate(pb_is_good_ = dplyr::case_when(
       is.na({{ column }}) ~ na_pass_bool,
       .default = pb_is_good_
@@ -1399,11 +1397,11 @@ interrogate_set <- function(
       false <- if (uses_numeric_logical(table)) 0 else FALSE
       na_pass_bool <- if (na_pass) true else false
 
-      table %>%
+      table |>
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           {{ column }} %in% set ~ {{ true }},
           !({{ column }} %in% set) ~ {{ false }}
-        )) %>%
+        )) |>
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           is.na({{ column }}) ~ na_pass_bool,
           TRUE ~ pb_is_good_
@@ -1439,10 +1437,10 @@ interrogate_set <- function(
       # Define function to get distinct values from a column in the
       # order of first appearance
       table_col_distinct_values <-
-        table %>%
-        dplyr::select({{ column }}) %>%
-        dplyr::distinct({{ column }}) %>%
-        dplyr::collect() %>%
+        table |>
+        dplyr::select({{ column }}) |>
+        dplyr::distinct({{ column }}) |>
+        dplyr::collect() |>
         dplyr::pull({{ column }})
 
       if (na_pass) {
@@ -1461,23 +1459,23 @@ interrogate_set <- function(
         table_col_distinct_values[table_col_distinct_values %in% set]
 
       dplyr::bind_rows(
-        dplyr::tibble(set_element = as.character(set)) %>%
+        dplyr::tibble(set_element = as.character(set)) |>
           dplyr::left_join(
             dplyr::tibble(
               col_element = as.character(table_col_distinct_set),
               pb_is_good_ = TRUE
             ),
             by = c("set_element" = "col_element")
-          ) %>%
+          ) |>
           dplyr::mutate(
             pb_is_good_ = ifelse(is.na(pb_is_good_), FALSE, pb_is_good_)
           ),
         dplyr::tibble(
           set_element = "::outside_values::",
           pb_is_good_ = NA
-        ) %>%
+        ) |>
           dplyr::mutate(pb_is_good_ = length(extra_variables) == 0)
-      ) %>%
+      ) |>
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           is.na(pb_is_good_) ~ na_pass,
           TRUE ~ pb_is_good_
@@ -1513,10 +1511,10 @@ interrogate_set <- function(
       # Define function to get distinct values from a column in the
       # order of first appearance
       table_col_distinct_values <-
-        table %>%
-        dplyr::select({{ column }}) %>%
-        dplyr::distinct({{ column }}) %>%
-        dplyr::collect() %>%
+        table |>
+        dplyr::select({{ column }}) |>
+        dplyr::distinct({{ column }}) |>
+        dplyr::collect() |>
         dplyr::pull({{ column }})
 
       if (na_pass) {
@@ -1532,17 +1530,17 @@ interrogate_set <- function(
       table_col_distinct_set <-
         table_col_distinct_values[table_col_distinct_values %in% set]
 
-      dplyr::tibble(set_element = as.character(set)) %>%
+      dplyr::tibble(set_element = as.character(set)) |>
         dplyr::left_join(
           dplyr::tibble(
             col_element = as.character(table_col_distinct_set),
             pb_is_good_ = TRUE
           ),
           by = c("set_element" = "col_element")
-        ) %>%
+        ) |>
         dplyr::mutate(
           pb_is_good_ = ifelse(is.na(pb_is_good_), FALSE, pb_is_good_)
-        ) %>%
+        ) |>
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           is.na(pb_is_good_) ~ na_pass,
           TRUE ~ pb_is_good_
@@ -1579,11 +1577,11 @@ interrogate_set <- function(
       false <- if (uses_numeric_logical(table)) 0 else FALSE
       na_pass_bool <- if (na_pass) false else true
 
-      table %>%
+      table |>
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           !({{ column }} %in% set) ~ {{ true }},
           {{ column }} %in% set ~ {{ false }}
-        )) %>%
+        )) |>
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           is.na({{ column }}) ~ na_pass_bool,
           TRUE ~ pb_is_good_
@@ -1654,7 +1652,7 @@ interrogate_direction <- function(
     column_validity_checks_column(table = table, column = {{ column }})
 
     tbl <-
-      table %>%
+      table |>
       dplyr::mutate(
         pb_lagged_difference_ = {{ column }} - dplyr::lag({{ column }}))
 
@@ -1663,7 +1661,7 @@ interrogate_direction <- function(
       if (direction == "increasing") {
 
         tbl <-
-          tbl %>%
+          tbl |>
           dplyr::mutate(pb_is_good_ = dplyr::case_when(
             pb_lagged_difference_ > 0 ~ TRUE,
             pb_lagged_difference_ <= 0 ~ FALSE,
@@ -1673,7 +1671,7 @@ interrogate_direction <- function(
       } else {
 
         tbl <-
-          tbl %>%
+          tbl |>
           dplyr::mutate(pb_is_good_ = dplyr::case_when(
             pb_lagged_difference_ < 0 ~ TRUE,
             pb_lagged_difference_ >= 0 ~ FALSE,
@@ -1687,7 +1685,7 @@ interrogate_direction <- function(
       if (direction == "increasing") {
 
         tbl <-
-          tbl %>%
+          tbl |>
           dplyr::mutate(pb_is_good_ = dplyr::case_when(
             pb_lagged_difference_ >= 0 ~ TRUE,
             pb_lagged_difference_ < 0 ~ FALSE,
@@ -1697,7 +1695,7 @@ interrogate_direction <- function(
       } else {
 
         tbl <-
-          tbl %>%
+          tbl |>
           dplyr::mutate(pb_is_good_ = dplyr::case_when(
             pb_lagged_difference_ <= 0 ~ TRUE,
             pb_lagged_difference_ > 0 ~ FALSE,
@@ -1713,7 +1711,7 @@ interrogate_direction <- function(
       if (direction == "increasing") {
 
         tbl <-
-          tbl %>%
+          tbl |>
           dplyr::mutate(pb_is_good_ = ifelse(
             !is.na(pb_lagged_difference_) &
               pb_lagged_difference_ >= (-abs(stat_tol[2])), TRUE, pb_is_good_
@@ -1722,7 +1720,7 @@ interrogate_direction <- function(
       } else {
 
         tbl <-
-          tbl %>%
+          tbl |>
           dplyr::mutate(pb_is_good_ = ifelse(
             !is.na(pb_lagged_difference_) &
               pb_lagged_difference_ <= abs(stat_tol[2]), TRUE, pb_is_good_
@@ -1731,10 +1729,10 @@ interrogate_direction <- function(
     }
 
     tbl <-
-      tbl %>%
+      tbl |>
       dplyr::mutate(pb_is_good_ = ifelse(
         is.na(pb_lagged_difference_) & is.na(pb_is_good_), TRUE, pb_is_good_
-      )) %>%
+      )) |>
       dplyr::select(-pb_lagged_difference_)
   }
 
@@ -1805,11 +1803,11 @@ interrogate_regex <- function(
     if (tbl_type == "tbl_spark") {
 
       tbl <-
-        table %>%
+        table |>
         dplyr::mutate(
           pb_is_good_ = ifelse(
             !is.na({{ column }}), RLIKE({{ column }}, regex), NA)
-        ) %>%
+        ) |>
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           is.na(pb_is_good_) ~ na_pass,
           TRUE ~ pb_is_good_
@@ -1818,10 +1816,10 @@ interrogate_regex <- function(
     } else if (tbl_type == "mysql") {
 
       tbl <-
-        table %>%
+        table |>
         dplyr::mutate(pb_is_good_ = ifelse(
           !is.na({{ column }}), {{ column }} %REGEXP% regex, NA)
-        ) %>%
+        ) |>
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           is.na(pb_is_good_) ~ na_pass,
           TRUE ~ pb_is_good_
@@ -1830,11 +1828,11 @@ interrogate_regex <- function(
     } else if (tbl_type == "bigquery") {
 
       tbl <-
-        table %>%
+        table |>
         dplyr::mutate(
           pb_is_good_ = ifelse(
             !is.na({{ column }}), REGEXP_CONTAINS({{ column }}, regex), NA)
-        ) %>%
+        ) |>
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           is.na(pb_is_good_) ~ na_pass,
           TRUE ~ pb_is_good_
@@ -1843,10 +1841,10 @@ interrogate_regex <- function(
     } else if (tbl_type == "duckdb") {
 
       tbl <-
-        table %>%
+        table |>
         dplyr::mutate(pb_is_good_ = ifelse(
           !is.na({{ column }}), regexp_matches({{ column }}, regex), NA)
-        ) %>%
+        ) |>
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           is.na(pb_is_good_) ~ na_pass,
           TRUE ~ pb_is_good_
@@ -1856,10 +1854,10 @@ interrogate_regex <- function(
 
       # This works for postgres and local tables; untested so far in other DBs
       tbl <-
-        table %>%
+        table |>
         dplyr::mutate(pb_is_good_ = ifelse(
           !is.na({{ column }}), grepl(regex, {{ column }}, perl = TRUE), NA)
-        ) %>%
+        ) |>
         dplyr::mutate(pb_is_good_ = dplyr::case_when(
           is.na(pb_is_good_) ~ na_pass,
           TRUE ~ pb_is_good_
@@ -1911,7 +1909,7 @@ interrogate_str_len <- function(
     column_validity_checks_column(table = table, column = {{ column }})
 
     tbl <-
-      table %>%
+      table |>
       dplyr::mutate(
         pb_is_good_ = ifelse(
           !is.na({{ column }}) & is.character({{ column }}),
@@ -1924,7 +1922,7 @@ interrogate_str_len <- function(
           },
           ifelse(is.na({{ column }}), NA, FALSE)
         )
-      ) %>%
+      ) |>
       dplyr::mutate(pb_is_good_ = dplyr::case_when(
         is.na(pb_is_good_) ~ na_pass,
         TRUE ~ pb_is_good_
@@ -2031,11 +2029,11 @@ interrogate_within_spec <- function(
         if (tbl_type == "tbl_spark") {
 
           tbl <-
-            table %>%
+            table |>
             dplyr::mutate(
               pb_is_good_ = ifelse(
                 !is.na({{ column }}), RLIKE({{ column }}, regex), NA)
-            ) %>%
+            ) |>
             dplyr::mutate(pb_is_good_ = dplyr::case_when(
               is.na(pb_is_good_) ~ na_pass,
               TRUE ~ pb_is_good_
@@ -2044,10 +2042,10 @@ interrogate_within_spec <- function(
         } else if (tbl_type == "mysql") {
 
           tbl <-
-            table %>%
+            table |>
             dplyr::mutate(pb_is_good_ = ifelse(
               !is.na({{ column }}), {{ column }} %REGEXP% regex, NA)
-            ) %>%
+            ) |>
             dplyr::mutate(pb_is_good_ = dplyr::case_when(
               is.na(pb_is_good_) ~ na_pass,
               TRUE ~ pb_is_good_
@@ -2056,10 +2054,10 @@ interrogate_within_spec <- function(
         } else if (tbl_type == "duckdb") {
 
           tbl <-
-            table %>%
+            table |>
             dplyr::mutate(pb_is_good_ = ifelse(
               !is.na({{ column }}), regexp_matches({{ column }}, regex), NA)
-            ) %>%
+            ) |>
             dplyr::mutate(pb_is_good_ = dplyr::case_when(
               is.na(pb_is_good_) ~ na_pass,
               TRUE ~ pb_is_good_
@@ -2070,10 +2068,10 @@ interrogate_within_spec <- function(
           # This works for postgres and local tables;
           # untested so far in other DBs
           tbl <-
-            table %>%
+            table |>
             dplyr::mutate(pb_is_good_ = ifelse(
               !is.na({{ column }}), grepl(regex, {{ column }}), NA)
-            ) %>%
+            ) |>
             dplyr::mutate(pb_is_good_ = dplyr::case_when(
               is.na(pb_is_good_) ~ na_pass,
               TRUE ~ pb_is_good_
@@ -2086,7 +2084,7 @@ interrogate_within_spec <- function(
       if (spec == "vin") {
 
         tbl <-
-          check_vin_db(table, column = {{ column }}) %>%
+          check_vin_db(table, column = {{ column }}) |>
           dplyr::mutate(pb_is_good_ = dplyr::case_when(
             is.na(pb_is_good_) ~ na_pass,
             .default = pb_is_good_
@@ -2185,7 +2183,7 @@ interrogate_expr <- function(
 
     expr <- expr[[1]]
 
-    tbl <- table %>%
+    tbl <- table |>
       dplyr::mutate(pb_is_good_ = !!expr)
 
     if (anyNA(tbl$pb_is_good_)) {
@@ -2302,7 +2300,7 @@ interrogate_null <- function(
     true <- if (uses_numeric_logical(table)) 1 else TRUE
     false <- if (uses_numeric_logical(table)) 0 else FALSE
 
-    table %>%
+    table |>
       dplyr::mutate(pb_is_good_ = dplyr::case_when(
         is.na({{ column }}) ~ {{ true }},
         TRUE ~ {{ false }}
@@ -2337,7 +2335,7 @@ interrogate_not_null <- function(
     true <- if (uses_numeric_logical(table)) 1 else TRUE
     false <- if (uses_numeric_logical(table)) 0 else FALSE
 
-    table %>%
+    table |>
       dplyr::mutate(pb_is_good_ = dplyr::case_when(
         is.na({{ column }}) ~ {{ false }},
         TRUE ~ {{ true }}
@@ -2416,11 +2414,11 @@ interrogate_col_type <- function(
     column_validity_checks_column(table = table, column = {{ column }})
 
     column_class <-
-      table %>%
-      dplyr::select({{ column }}) %>%
-      utils::head(1) %>%
-      dplyr::as_tibble() %>%
-      dplyr::pull({{ column }}) %>%
+      table |>
+      dplyr::select({{ column }}) |>
+      utils::head(1) |>
+      dplyr::as_tibble() |>
+      dplyr::pull({{ column }}) |>
       class()
 
     validation_res <-
@@ -2457,12 +2455,12 @@ interrogate_distinct <- function(
 ) {
 
   column_names <-
-    get_column_as_sym_at_idx(agent = agent, idx = idx) %>%
+    get_column_as_sym_at_idx(agent = agent, idx = idx) |>
     as.character()
 
   if (grepl("(,|&)", column_names)) {
     column_names <-
-      strsplit(split = "(, |,|&)", column_names) %>%
+      strsplit(split = "(, |,|&)", column_names) |>
       unlist()
   }
 
@@ -2484,9 +2482,9 @@ interrogate_distinct <- function(
     tbl_validity_check(table = table)
     column_validity_has_columns(columns = column_names)
 
-    table %>%
-      dplyr::group_by(!!!col_syms) %>%
-      dplyr::mutate(`pb_is_good_` = dplyr::n() == 1L) %>%
+    table |>
+      dplyr::group_by(!!!col_syms) |>
+      dplyr::mutate(`pb_is_good_` = dplyr::n() == 1L) |>
       dplyr::ungroup()
   }
 
@@ -2504,13 +2502,13 @@ interrogate_distinct <- function(
     tbl_validity_check(table = table)
 
     unduplicated <-
-      table %>%
-      dplyr::count(!!!col_syms, name = "pb_is_good_") %>%
-      dplyr::mutate(`pb_is_good_` = `pb_is_good_` == 1L) %>%
+      table |>
+      dplyr::count(!!!col_syms, name = "pb_is_good_") |>
+      dplyr::mutate(`pb_is_good_` = `pb_is_good_` == 1L) |>
       dplyr::filter(`pb_is_good_`)
 
-    table %>%
-      dplyr::left_join(unduplicated, by = column_names) %>%
+    table |>
+      dplyr::left_join(unduplicated, by = column_names) |>
       dplyr::mutate(`pb_is_good_` = !is.na(`pb_is_good_`))
   }
 
@@ -2543,12 +2541,12 @@ interrogate_complete <- function(
 ) {
 
   column_names <-
-    get_column_as_sym_at_idx(agent = agent, idx = idx) %>%
+    get_column_as_sym_at_idx(agent = agent, idx = idx) |>
     as.character()
 
   if (grepl("(,|&)", column_names)) {
     column_names <-
-      strsplit(split = "(, |,|&)", column_names) %>%
+      strsplit(split = "(, |,|&)", column_names) |>
       unlist()
   }
 
@@ -2578,13 +2576,13 @@ interrogate_complete <- function(
         )
 
       table_check <-
-        table %>%
+        table |>
         dplyr::mutate(pb_is_good_ = !!col_expr)
 
     } else {
 
       table_check <-
-        table %>%
+        table |>
         dplyr::mutate(
           pb_is_good_ = stats::complete.cases(dplyr::pick({{ column_names }}))
         )
@@ -2903,9 +2901,9 @@ interrogate_tbl_match <- function(
         dplyr::bind_cols(
           dplyr::collect(dplyr::rename(dplyr::select(table, i), a = 1)),
           dplyr::collect(dplyr::rename(dplyr::select(tbl_compare, i), b = 1))
-        ) %>%
-        dplyr::mutate(pb_is_good_ = identical(a, b)) %>%
-        dplyr::pull(pb_is_good_) %>%
+        ) |>
+        dplyr::mutate(pb_is_good_ = identical(a, b)) |>
+        dplyr::pull(pb_is_good_) |>
         all()
 
       column_all_matched <- c(column_all_matched, col_pair_match)
@@ -3088,9 +3086,9 @@ add_reporting_data <- function(
 
   # Get total count of rows
   row_count <-
-    tbl_checked %>%
-    dplyr::count() %>%
-    dplyr::pull(n) %>%
+    tbl_checked |>
+    dplyr::count() |>
+    dplyr::pull(n) |>
     as.numeric()
 
   #
@@ -3102,10 +3100,10 @@ add_reporting_data <- function(
     # nocov start
 
     n_passed <-
-      tbl_checked %>%
-      dplyr::filter(pb_is_good_ == 1) %>%
-      dplyr::count() %>%
-      dplyr::pull(n) %>%
+      tbl_checked |>
+      dplyr::filter(pb_is_good_ == 1) |>
+      dplyr::count() |>
+      dplyr::pull(n) |>
       as.numeric()
 
     # nocov end
@@ -3113,10 +3111,10 @@ add_reporting_data <- function(
   } else {
 
     n_passed <-
-      tbl_checked %>%
-      dplyr::filter(pb_is_good_ == TRUE) %>%
-      dplyr::count() %>%
-      dplyr::pull(n) %>%
+      tbl_checked |>
+      dplyr::filter(pb_is_good_ == TRUE) |>
+      dplyr::count() |>
+      dplyr::pull(n) |>
       as.numeric()
   }
 
@@ -3129,10 +3127,10 @@ add_reporting_data <- function(
     # nocov start
 
     n_failed <-
-      tbl_checked %>%
-      dplyr::filter(pb_is_good_ == 0) %>%
-      dplyr::count() %>%
-      dplyr::pull(n) %>%
+      tbl_checked |>
+      dplyr::filter(pb_is_good_ == 0) |>
+      dplyr::count() |>
+      dplyr::pull(n) |>
       as.numeric()
 
     # nocov end
@@ -3140,10 +3138,10 @@ add_reporting_data <- function(
   } else {
 
     n_failed <-
-      tbl_checked %>%
-      dplyr::filter(pb_is_good_ == FALSE) %>%
-      dplyr::count() %>%
-      dplyr::pull(n) %>%
+      tbl_checked |>
+      dplyr::filter(pb_is_good_ == FALSE) |>
+      dplyr::count() |>
+      dplyr::pull(n) |>
       as.numeric()
   }
 
@@ -3169,7 +3167,7 @@ perform_action <- function(
 ) {
 
   actions <-
-    agent$validation_set[[idx, "actions"]] %>%
+    agent$validation_set[[idx, "actions"]] |>
     unlist(recursive = FALSE)
 
   .warn <- agent$validation_set[[idx, "warn"]]
@@ -3188,9 +3186,9 @@ perform_action <- function(
 
   .i <- idx
   .type <- agent$validation_set[[idx, "assertion_type"]]
-  .column <- agent$validation_set[[idx, "column"]] %>% unlist()
-  .values <- agent$validation_set[[idx, "values"]] %>% unlist()
-  .actions <- agent$validation_set[[idx, "actions"]] %>% unlist()
+  .column <- agent$validation_set[[idx, "column"]] |> unlist()
+  .values <- agent$validation_set[[idx, "values"]] |> unlist()
+  .actions <- agent$validation_set[[idx, "actions"]] |> unlist()
   .brief <- agent$validation_set[[idx, "brief"]]
 
   .eval_error <- agent$validation_set[[idx, "eval_error"]]
@@ -3240,7 +3238,7 @@ perform_action <- function(
     x$this_type <- "warn"
     if (!is.na(.warn) && .warn) {
       if ("warn" %in% names(actions$fns) && !is.null(actions$fns$warn)) {
-        actions$fns$warn %>% rlang::f_rhs() %>% rlang::eval_tidy()
+        actions$fns$warn |> rlang::f_rhs() |> rlang::eval_tidy()
       }
     }
   } else if (type == "notify") {
@@ -3248,7 +3246,7 @@ perform_action <- function(
     if (!is.na(.notify) && .notify) {
       fn_critical <- actions$fns$critical %||% actions$fns$notify
       if (!is.null(fn_critical)) {
-        fn_critical %>% rlang::f_rhs() %>% rlang::eval_tidy()
+        fn_critical |> rlang::f_rhs() |> rlang::eval_tidy()
       }
     }
   } else if (type == "stop") {
@@ -3256,7 +3254,7 @@ perform_action <- function(
     if (!is.na(.stop) && .stop) {
       fn_error <- actions$fns$error %||% actions$fns$stop
       if (!is.null(fn_error)) {
-        fn_error %>% rlang::f_rhs() %>% rlang::eval_tidy()
+        fn_error |> rlang::f_rhs() |> rlang::eval_tidy()
       }
     }
   }
@@ -3266,7 +3264,7 @@ perform_action <- function(
 
 perform_end_action <- function(agent) {
 
-  actions <- agent$end_fns %>% unlist()
+  actions <- agent$end_fns |> unlist()
 
   .warn <- agent$validation_set$warn
   .notify <- agent$validation_set$notify
@@ -3355,7 +3353,7 @@ perform_end_action <- function(agent) {
     )
 
   lapply(actions, FUN = function(y) {
-    y %>% rlang::f_rhs() %>% rlang::eval_tidy()
+    y |> rlang::f_rhs() |> rlang::eval_tidy()
   })
 
   NULL
@@ -3382,15 +3380,15 @@ add_table_extract <- function(
 
   tbl_checked <- tbl_checked$value
 
-  tbl_type <- tbl_checked %>% class()
+  tbl_type <- tbl_checked |> class()
 
   if (uses_numeric_logical(tbl_checked)) {
 
     # nocov start
 
     problem_rows <-
-      tbl_checked %>%
-      dplyr::filter(pb_is_good_ == 0) %>%
+      tbl_checked |>
+      dplyr::filter(pb_is_good_ == 0) |>
       dplyr::select(-pb_is_good_)
 
     # nocov end
@@ -3398,16 +3396,16 @@ add_table_extract <- function(
   } else {
 
     problem_rows <-
-      tbl_checked %>%
-      dplyr::filter(pb_is_good_ == FALSE) %>%
+      tbl_checked |>
+      dplyr::filter(pb_is_good_ == FALSE) |>
       dplyr::select(-pb_is_good_)
   }
 
   if (!is.null(get_first_n)) {
 
     problem_rows <-
-      problem_rows %>%
-      utils::head(get_first_n) %>%
+      problem_rows |>
+      utils::head(get_first_n) |>
       dplyr::as_tibble()
 
   } else if (
@@ -3421,7 +3419,7 @@ add_table_extract <- function(
       dplyr::slice_sample(
         problem_rows,
         n = sample_n,
-        replace = FALSE) %>%
+        replace = FALSE) |>
       dplyr::as_tibble()
 
   } else if (
@@ -3435,15 +3433,15 @@ add_table_extract <- function(
       dplyr::slice_sample(
         problem_rows,
         prop = sample_frac,
-        replace = FALSE) %>%
-      dplyr::as_tibble() %>%
+        replace = FALSE) |>
+      dplyr::as_tibble() |>
       utils::head(sample_limit)
 
   } else {
 
     problem_rows <-
-      problem_rows %>%
-      utils::head(5000) %>%
+      problem_rows |>
+      utils::head(5000) |>
       dplyr::as_tibble()
   }
 
@@ -3465,7 +3463,7 @@ determine_action <- function(
     false_count
 ) {
 
-  al <- agent$validation_set[[idx, "actions"]] %>% unlist(recursive = FALSE)
+  al <- agent$validation_set[[idx, "actions"]] |> unlist(recursive = FALSE)
   n <- agent$validation_set[[idx, "n"]]
 
   warn <- stop <- notify <- FALSE

--- a/R/object_ops.R
+++ b/R/object_ops.R
@@ -326,7 +326,7 @@ x_write_disk <- function(
     x$validation_set$tbl_checked <- NULL
 
     x$validation_set <-
-      x$validation_set %>%
+      x$validation_set |>
       dplyr::mutate(tbl_checked = list(NULL))
 
     if (keep_tbl) {
@@ -759,67 +759,67 @@ export_report <- function(
 
     object_type <- "agent"
 
-    x %>%
-      get_agent_report() %>%
-      htmltools::as.tags() %>%
+    x |>
+      get_agent_report() |>
+      htmltools::as.tags() |>
       htmltools::save_html(file = filename)
 
   } else if (inherits(x, "ptblank_informant")) {
 
     object_type <- "informant"
 
-    x %>%
-      get_informant_report() %>%
-      htmltools::as.tags() %>%
+    x |>
+      get_informant_report() |>
+      htmltools::as.tags() |>
       htmltools::save_html(file = filename)
 
   } else if (inherits(x, "ptblank_multiagent")) {
 
     object_type <- "multiagent"
 
-    x %>%
-      get_multiagent_report() %>%
-      htmltools::as.tags() %>%
+    x |>
+      get_multiagent_report() |>
+      htmltools::as.tags() |>
       htmltools::save_html(file = filename)
 
   } else if (inherits(x, "ptblank_tbl_scan")) {
 
     object_type <- "table scan"
 
-    x %>%
-      htmltools::as.tags() %>%
+    x |>
+      htmltools::as.tags() |>
       htmltools::save_html(file = filename)
 
   } else if (inherits(x, "ptblank_agent_report")) {
 
     object_type <- "agent report"
 
-    x %>%
-      htmltools::as.tags() %>%
+    x |>
+      htmltools::as.tags() |>
       htmltools::save_html(file = filename)
 
   } else if (inherits(x, "ptblank_informant_report")) {
 
     object_type <- "informant report"
 
-    x %>%
-      htmltools::as.tags() %>%
+    x |>
+      htmltools::as.tags() |>
       htmltools::save_html(file = filename)
 
   } else if (inherits(x, "ptblank_multiagent_report.wide")) {
 
     object_type <- "multiagent report (wide)"
 
-    x %>%
-      htmltools::as.tags() %>%
+    x |>
+      htmltools::as.tags() |>
       htmltools::save_html(file = filename)
 
   } else if (inherits(x, "ptblank_multiagent_report.long")) {
 
     object_type <- "multiagent report (long)"
 
-    x %>%
-      htmltools::as.tags() %>%
+    x |>
+      htmltools::as.tags() |>
       htmltools::save_html(file = filename)
   }
 

--- a/R/remove_deactivate.R
+++ b/R/remove_deactivate.R
@@ -95,7 +95,7 @@ activate_steps <- function(
 
   if (!is.null(i)) {
     agent$validation_set <-
-      agent$validation_set %>%
+      agent$validation_set |>
       dplyr::mutate(active = ifelse(i %in% {{ i }}, list(TRUE), active))
   }
 
@@ -178,7 +178,7 @@ deactivate_steps <- function(
 
   if (!is.null(i)) {
     agent$validation_set <-
-      agent$validation_set %>%
+      agent$validation_set |>
       dplyr::mutate(active = ifelse(i %in% {{ i }}, list(FALSE), active))
   }
 
@@ -263,7 +263,7 @@ remove_steps <- function(
   # TODO: Allow for removal of multiple steps (e.g., `i = 1:3`)
   if (!is.null(i)) {
     agent$validation_set <-
-      agent$validation_set %>%
+      agent$validation_set |>
       dplyr::slice(-{{ i }})
   }
 

--- a/R/row_count_match.R
+++ b/R/row_count_match.R
@@ -345,7 +345,7 @@ row_count_match <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       row_count_match(
         count = count,
         preconditions = preconditions,
@@ -354,7 +354,7 @@ row_count_match <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -440,16 +440,16 @@ expect_row_count_match <- function(
   fn_name <- "expect_row_count_match"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     row_count_match(
       count = {{ count }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
-  x <- vs$notify %>% all()
+  x <- vs$notify |> all()
 
   threshold_type <- get_threshold_type(threshold = threshold)
 
@@ -510,14 +510,14 @@ test_row_count_match <- function(
   }
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     row_count_match(
       count = {{ count }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/rows_complete.R
+++ b/R/rows_complete.R
@@ -310,7 +310,7 @@ rows_complete <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       rows_complete(
         columns = tidyselect::all_of(columns),
         preconditions = preconditions,
@@ -319,7 +319,7 @@ rows_complete <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -392,16 +392,16 @@ expect_rows_complete <- function(
   fn_name <- "expect_rows_complete"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     rows_complete(
       columns = {{ columns }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
-  x <- vs$notify %>% all()
+  x <- vs$notify |> all()
 
   threshold_type <- get_threshold_type(threshold = threshold)
 
@@ -445,14 +445,14 @@ test_rows_complete <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     rows_complete(
       columns = {{ columns }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/rows_distinct.R
+++ b/R/rows_distinct.R
@@ -311,7 +311,7 @@ rows_distinct <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       rows_distinct(
         columns = tidyselect::all_of(columns),
         preconditions = preconditions,
@@ -320,7 +320,7 @@ rows_distinct <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -393,16 +393,16 @@ expect_rows_distinct <- function(
   fn_name <- "expect_rows_distinct"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     rows_distinct(
       columns = {{ columns }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
-  x <- vs$notify %>% all()
+  x <- vs$notify |> all()
 
   threshold_type <- get_threshold_type(threshold = threshold)
 
@@ -446,14 +446,14 @@ test_rows_distinct <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     rows_distinct(
       columns = {{ columns }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/scan_data.R
+++ b/R/scan_data.R
@@ -329,7 +329,7 @@ probe_overview_stats <- function(
         n_cols, n_rows, na_cells, duplicate_rows
       ),
       pct = NA_real_
-    ) %>%
+    ) |>
     dplyr::mutate(pct = dplyr::case_when(
       dplyr::row_number() == 3 ~ na_cells / (n_cols * n_rows),
       dplyr::row_number() == 4 ~ duplicate_rows / n_rows,
@@ -337,29 +337,29 @@ probe_overview_stats <- function(
     ))
 
   r_col_types_tbl <-
-    dplyr::tibble(r_col_types = r_col_types) %>%
-    dplyr::count(r_col_types, name = "count", sort = TRUE) %>%
+    dplyr::tibble(r_col_types = r_col_types) |>
+    dplyr::count(r_col_types, name = "count", sort = TRUE) |>
     utils::head(6E8)
 
   data_overview_gt <-
-    gt::gt(data_overview_tbl, locale = locale) %>%
-    gt::fmt_markdown(columns = "label") %>%
-    gt::fmt_integer(columns = "value") %>%
-    gt::fmt_percent(columns = "pct", decimals = 2) %>%
-    gt::cols_merge(columns = c("value", "pct"), pattern = "{1} ({2})") %>%
-    gt::cols_align(align = "right", columns = "value") %>%
+    gt::gt(data_overview_tbl, locale = locale) |>
+    gt::fmt_markdown(columns = "label") |>
+    gt::fmt_integer(columns = "value") |>
+    gt::fmt_percent(columns = "pct", decimals = 2) |>
+    gt::cols_merge(columns = c("value", "pct"), pattern = "{1} ({2})") |>
+    gt::cols_align(align = "right", columns = "value") |>
     gt::text_transform(
       locations = gt::cells_body(columns = "value", rows = 1:2),
       fn = function(x) {
         gsub(" (NA)", "", x, fixed = TRUE)
       }
-    ) %>%
+    ) |>
     gt::text_transform(
       locations = gt::cells_body(columns = "value", rows = 3:4),
       fn = function(x) {
         gsub("^0 \\(.*", "0", x)
       }
-    ) %>%
+    ) |>
     gt::tab_options(
       column_labels.hidden = TRUE,
       table.border.top.style = "none",
@@ -367,9 +367,9 @@ probe_overview_stats <- function(
     )
 
   r_col_types_gt <-
-    gt::gt(r_col_types_tbl) %>%
-    gt::fmt_number(columns = "count", decimals = 0, locale = locale) %>%
-    gt::cols_align(align = "right", columns = "count") %>%
+    gt::gt(r_col_types_tbl) |>
+    gt::fmt_number(columns = "count", decimals = 0, locale = locale) |>
+    gt::cols_align(align = "right", columns = "count") |>
     gt::tab_options(
       column_labels.hidden = TRUE,
       table.border.top.style = "none",
@@ -387,16 +387,15 @@ probe_overview_stats <- function(
       value = c(
         paste0("`", strftime(Sys.time()), "`"),
         paste0("`", as.character(utils::packageVersion("pointblank")), "`"),
-        paste0(
+        gsub("-", "&ndash;", paste0(
           R.version$version.string,
           "<br><span style=\"font-size: smaller;\"><em>",
-          R.version$nickname, "</em></span>") %>%
-          gsub("-", "&ndash;", .),
+          R.version$nickname, "</em></span>")),
         paste0("`", R.version$platform, "`")
       )
-    ) %>%
-    gt::gt() %>%
-    gt::fmt_markdown(columns = gt::everything()) %>%
+    ) |>
+    gt::gt() |>
+    gt::fmt_markdown(columns = gt::everything()) |>
     gt::tab_options(
       column_labels.hidden = TRUE,
       table.border.top.style = "none",
@@ -531,9 +530,9 @@ get_column_description_gt <- function(
     )
 
   column_description_gt <-
-    gt::gt(column_description_tbl) %>%
-    gt::fmt_markdown(columns = "label") %>%
-    gt::fmt_number(columns = "value", decimals = 0, locale = locale) %>%
+    gt::gt(column_description_tbl) |>
+    gt::fmt_markdown(columns = "label") |>
+    gt::fmt_number(columns = "value", decimals = 0, locale = locale) |>
     gt::tab_options(
       column_labels.hidden = TRUE,
       table.border.top.style = "none",
@@ -566,14 +565,14 @@ get_numeric_stats_gt <- function(
     )
 
   column_stats_gt <-
-    gt::gt(column_stats_tbl) %>%
-    gt::fmt_markdown(columns = "label") %>%
+    gt::gt(column_stats_tbl) |>
+    gt::fmt_markdown(columns = "label") |>
     gt::fmt_number(
       columns = "value",
       decimals = 2,
       drop_trailing_zeros = TRUE,
       locale = locale
-    ) %>%
+    ) |>
     gt::tab_options(
       column_labels.hidden = TRUE,
       table.border.top.style = "none",
@@ -632,12 +631,12 @@ get_quantile_stats_gt <- function(
     )
 
   quantile_stats_gt <-
-    gt::gt(quantile_stats_tbl) %>%
+    gt::gt(quantile_stats_tbl) |>
     gt::fmt_number(
       columns = "value",
       decimals = 2,
       locale = locale
-    ) %>%
+    ) |>
     gt::tab_options(
       column_labels.hidden = TRUE,
       table.border.top.style = "none",
@@ -720,13 +719,13 @@ get_descriptive_stats_gt <- function(
       )
     )
 
-  gt::gt(descriptive_stats_tbl) %>%
+  gt::gt(descriptive_stats_tbl) |>
     gt::fmt_number(
       columns = "value",
       decimals = 2,
       drop_trailing_zeros = FALSE,
       locale = locale
-    ) %>%
+    ) |>
     gt::tab_options(
       column_labels.hidden = TRUE,
       table.border.top.style = "none",
@@ -773,14 +772,14 @@ get_common_values_gt <- function(
 
     common_values_tbl <-
       dplyr::bind_rows(
-        top_ten_rows %>%
-          utils::head(9) %>%
-          dplyr::collect() %>%
+        top_ten_rows |>
+          utils::head(9) |>
+          dplyr::collect() |>
           dplyr::mutate(
             n = as.numeric(n),
             frequency = n / n_rows
-          ) %>%
-          dplyr::rename(value = 1) %>%
+          ) |>
+          dplyr::rename(value = 1) |>
           dplyr::mutate(value = as.character(value)),
         dplyr::tibble(
           value = paste0(
@@ -796,14 +795,14 @@ get_common_values_gt <- function(
     n_rows_summary_tbl <- nrow(common_values_tbl)
 
     common_values_gt <-
-      common_values_tbl %>%
-      gt::gt() %>%
+      common_values_tbl |>
+      gt::gt() |>
       gt::cols_label(
         value = get_lsv("table_scan/tbl_lab_value")[[lang]],
         n = get_lsv("table_scan/tbl_lab_count")[[lang]],
         frequency = get_lsv("table_scan/tbl_lab_frequency")[[lang]],
-      ) %>%
-      gt::sub_missing(columns = "value", missing_text = "**NA**") %>%
+      ) |>
+      gt::sub_missing(columns = "value", missing_text = "**NA**") |>
       gt::text_transform(
         locations = gt::cells_body(columns = "value"),
         fn = function(x) {
@@ -813,16 +812,16 @@ get_common_values_gt <- function(
             x
           )
         }
-      ) %>%
+      ) |>
       gt::fmt_percent(
         columns = "frequency",
         decimals = 1,
         locale = locale
-      ) %>%
+      ) |>
       gt::fmt_markdown(
         columns = "value",
         rows = n_rows_summary_tbl
-      ) %>%
+      ) |>
       gt::tab_options(
         table.border.top.style = "none",
         table.width = "100%"
@@ -831,27 +830,27 @@ get_common_values_gt <- function(
   } else {
 
     common_values_gt <-
-      dplyr::collect(common_values_tbl) %>%
-      dplyr::mutate(frequency = n / n_rows) %>%
-      dplyr::rename(value = 1) %>%
-      dplyr::mutate(value = as.character(value)) %>%
-      gt::gt() %>%
+      dplyr::collect(common_values_tbl) |>
+      dplyr::mutate(frequency = n / n_rows) |>
+      dplyr::rename(value = 1) |>
+      dplyr::mutate(value = as.character(value)) |>
+      gt::gt() |>
       gt::cols_label(
         value = get_lsv("table_scan/tbl_lab_value")[[lang]],
         n = get_lsv("table_scan/tbl_lab_count")[[lang]],
         frequency = get_lsv("table_scan/tbl_lab_frequency")[[lang]],
-      ) %>%
-      gt::sub_missing(columns = "value", missing_text = "**NA**") %>%
+      ) |>
+      gt::sub_missing(columns = "value", missing_text = "**NA**") |>
       gt::text_transform(
         locations = gt::cells_body(columns = "value"),
         fn = function(x) ifelse(x == "**NA**", "<code>NA</code>", x)
-      ) %>%
+      ) |>
       gt::fmt_percent(
         columns = "frequency",
         decimals = 1,
         locale = locale
-      ) %>%
-      gt::fmt_markdown(columns = "value") %>%
+      ) |>
+      gt::fmt_markdown(columns = "value") |>
       gt::tab_options(
         table.border.top.style = "none",
         table.width = "100%"
@@ -877,7 +876,7 @@ get_top_bottom_slice <- function(
   n_rows <- get_table_total_rows(data = data_column)
 
   data_column_freq <-
-    data_column %>%
+    data_column |>
     dplyr::count(dplyr::pick(1))
 
   name_1 <- rlang::sym(get_lsv("table_scan/tbl_lab_value")[[lang]])
@@ -930,18 +929,18 @@ get_character_nchar_stats_gt <- function(
 ) {
 
   character_nchar_stats <-
-    data_column %>%
-    dplyr::mutate_all(.funs = nchar) %>%
-    dplyr::rename(nchar = 1) %>%
+    data_column |>
+    dplyr::mutate_all(.funs = nchar) |>
+    dplyr::rename(nchar = 1) |>
     dplyr::summarize_all(
       .funs = list(
         mean = ~ mean(., na.rm = TRUE),
         min = ~ min(., na.rm = TRUE),
         max = ~ max(., na.rm = TRUE)
       )
-    ) %>%
-    dplyr::collect() %>%
-    dplyr::mutate_all(.funs = as.numeric) %>%
+    ) |>
+    dplyr::collect() |>
+    dplyr::mutate_all(.funs = as.numeric) |>
     as.list()
 
   dplyr::tribble(
@@ -949,13 +948,13 @@ get_character_nchar_stats_gt <- function(
     get_lsv("table_scan/tbl_lab_mean")[[lang]],     character_nchar_stats$mean,
     get_lsv("table_scan/tbl_lab_minimum")[[lang]],  character_nchar_stats$min,
     get_lsv("table_scan/tbl_lab_maximum")[[lang]],  character_nchar_stats$max
-  ) %>%
-    gt::gt() %>%
+  ) |>
+    gt::gt() |>
     gt::fmt_number(
       columns = "value",
       decimals = 1,
       locale = locale
-    ) %>%
+    ) |>
     gt::tab_options(
       column_labels.hidden = TRUE,
       table.border.top.style = "none",
@@ -995,11 +994,10 @@ get_character_nchar_plot <- function(
     htmltools::tags$div(
       style = "text-align: center",
       htmltools::HTML(
-        gt::local_image(
-          filename = "temp_histogram_ggplot.png",
-          height = "500px"
-        ) %>%
-          gsub("height:500px", "width: 100%", .)
+        gsub(
+          "height:500px", "width: 100%",
+          gt::local_image(filename = "temp_histogram_ggplot.png", height = "500px")
+        )
       )
     )
 
@@ -1109,7 +1107,7 @@ probe_columns_character <- function(
     locale
 ) {
 
-  data_column <- data %>% dplyr::select(tidyselect::any_of(column))
+  data_column <- data |> dplyr::select(tidyselect::any_of(column))
 
   column_description_gt <-
     get_column_description_gt(
@@ -1160,7 +1158,7 @@ probe_columns_logical <- function(
     locale
 ) {
 
-  data_column <- data %>% dplyr::select(tidyselect::any_of(column))
+  data_column <- data |> dplyr::select(tidyselect::any_of(column))
 
   column_description_gt <-
     get_column_description_gt(
@@ -1187,7 +1185,7 @@ probe_columns_factor <- function(
     locale
 ) {
 
-  data_column <- data %>% dplyr::select(tidyselect::any_of(column))
+  data_column <- data |> dplyr::select(tidyselect::any_of(column))
 
   column_description_gt <-
     get_column_description_gt(
@@ -1214,7 +1212,7 @@ probe_columns_date <- function(
     locale
 ) {
 
-  data_column <- data %>% dplyr::select(tidyselect::any_of(column))
+  data_column <- data |> dplyr::select(tidyselect::any_of(column))
 
   column_description_gt <-
     get_column_description_gt(
@@ -1241,7 +1239,7 @@ probe_columns_posix <- function(
     locale
 ) {
 
-  data_column <- data %>% dplyr::select(tidyselect::any_of(column))
+  data_column <- data |> dplyr::select(tidyselect::any_of(column))
 
   column_description_gt <-
     get_column_description_gt(
@@ -1266,7 +1264,7 @@ probe_columns_other <- function(
     n_rows
 ) {
 
-  data_column <- data %>% dplyr::select(tidyselect::any_of(column))
+  data_column <- data |> dplyr::select(tidyselect::any_of(column))
 
   column_classes <- paste(class(data_column), collapse = ", ")
 
@@ -1293,10 +1291,10 @@ probe_interactions <- function(data) {
     vapply(
       columns_char, FUN.VALUE = integer(1), USE.NAMES = FALSE,
       FUN = function(x) {
-        data %>%
-          dplyr::select(dplyr::all_of(x)) %>%
-          dplyr::distinct() %>%
-          dplyr::count() %>%
+        data |>
+          dplyr::select(dplyr::all_of(x)) |>
+          dplyr::distinct() |>
+          dplyr::count() |>
           dplyr::pull(n)
       }
     )
@@ -1304,7 +1302,7 @@ probe_interactions <- function(data) {
   # Remove the character-based columns from the vector of
   # `col_names` if there are too many categories
   col_names <-
-    col_names %>%
+    col_names |>
     base::setdiff(columns_char[columns_char_distinct_count > category_cutoff])
 
   # Limit the number of variables to prevent plot size issues
@@ -1314,8 +1312,8 @@ probe_interactions <- function(data) {
 
   # Create a ggplot2 plot matrix with the data
   plot_matrix <-
-    data %>%
-    dplyr::select(dplyr::all_of(col_names)) %>%
+    data |>
+    dplyr::select(dplyr::all_of(col_names)) |>
     ggplot2::ggplot(ggplot2::aes(x = .panel_x, y = .panel_y)) +
     ggplot2::geom_point(alpha = 0.50, shape = 16, size = 1) +
     ggforce::geom_autodensity() +
@@ -1352,11 +1350,10 @@ probe_interactions <- function(data) {
     htmltools::tags$div(
       style = "text-align: center",
       htmltools::HTML(
-        gt::local_image(
-          filename = "temp_matrix_ggplot.png",
-          height = "500px"
-        ) %>%
-          gsub("height:500px", "width: 100%", .)
+        gsub(
+          "height:500px", "width: 100%",
+          gt::local_image(filename = "temp_matrix_ggplot.png", height = "500px")
+        )
       )
     )
 
@@ -1418,7 +1415,7 @@ get_corr_plot <- function(
 ) {
 
   corr_df <-
-    as.data.frame(as.table(mat)) %>%
+    as.data.frame(as.table(mat)) |>
     dplyr::mutate(
       Freq = ifelse(Var1 == Var2, NA_real_, Freq),
       Var1 = factor(Var1, levels = names(labels_vec)),
@@ -1426,7 +1423,7 @@ get_corr_plot <- function(
     )
 
   plot_missing <-
-    corr_df %>%
+    corr_df |>
     ggplot2::ggplot(ggplot2::aes(x = Var1, y = Var2, fill = Freq)) +
     ggplot2::geom_tile(color = "white", linejoin = "bevel") +
     ggplot2::scale_fill_gradientn(
@@ -1470,8 +1467,10 @@ get_corr_plot <- function(
     htmltools::tags$div(
       style = "text-align: center",
       htmltools::HTML(
-        gt::local_image(filename = temp_filename, height = "500px") %>%
-          gsub("height:500px", "width: 100%", .)
+        gsub(
+          "height:500px", "width: 100%",
+          gt::local_image(filename = temp_filename, height = "500px")
+        )
       )
     )
 
@@ -1523,11 +1522,10 @@ probe_missing <- function(data) {
     htmltools::tags$div(
       style = "text-align: center",
       htmltools::HTML(
-        gt::local_image(
-          filename = "temp_missing_ggplot.png",
-          height = "500px"
-        ) %>%
-          gsub("height:500px", "width: 100%", .)
+        gsub(
+          "height:500px", "width: 100%",
+          gt::local_image(filename = "temp_missing_ggplot.png", height = "500px")
+        )
       )
     )
 
@@ -1539,21 +1537,21 @@ probe_missing <- function(data) {
 probe_sample <- function(data) {
 
   probe_sample <-
-    data %>%
-    gt::gt_preview(top_n = 5, bottom_n = 5) %>%
-    gt::sub_missing(columns = gt::everything(), missing_text = "**NA**") %>%
+    data |>
+    gt::gt_preview(top_n = 5, bottom_n = 5) |>
+    gt::sub_missing(columns = gt::everything(), missing_text = "**NA**") |>
     gt::text_transform(
       locations = gt::cells_body(columns = gt::everything()),
       fn = function(x) ifelse(x == "**NA**", "<code>NA</code>", x)
-    ) %>%
-    gt::tab_options(table.width = "100%") %>%
+    ) |>
+    gt::tab_options(table.width = "100%") |>
     gt::tab_style(
       style = gt::cell_text(font = "monospace"),
       locations = list(
         gt::cells_column_labels(),
         gt::cells_body()
       )
-    ) %>%
+    ) |>
     gt::text_transform(
       locations = gt::cells_body(),
       fn = function(x) {
@@ -1598,7 +1596,7 @@ build_table_scan_page <- function(
   }
 
   probe_list <-
-    sections %>%
+    sections |>
     lapply(
       FUN = function(x) {
         switch(
@@ -2755,7 +2753,7 @@ navbar <- function(
 
   # Compose the list of navigational links for the navbar
   item_list <-
-    sections %>%
+    sections |>
     lapply(
       FUN = function(x) {
 

--- a/R/scan_data.R
+++ b/R/scan_data.R
@@ -996,7 +996,9 @@ get_character_nchar_plot <- function(
       htmltools::HTML(
         gsub(
           "height:500px", "width: 100%",
-          gt::local_image(filename = "temp_histogram_ggplot.png", height = "500px")
+          gt::local_image(
+            filename = "temp_histogram_ggplot.png", height = "500px"
+          )
         )
       )
     )
@@ -1524,7 +1526,9 @@ probe_missing <- function(data) {
       htmltools::HTML(
         gsub(
           "height:500px", "width: 100%",
-          gt::local_image(filename = "temp_missing_ggplot.png", height = "500px")
+          gt::local_image(
+            filename = "temp_missing_ggplot.png", height = "500px"
+          )
         )
       )
     )

--- a/R/serially.R
+++ b/R/serially.R
@@ -393,11 +393,8 @@ serially <- function(
       FUN.VALUE = character(1),
       USE.NAMES = FALSE,
       FUN = function(x) {
-
-        x %>%
-          rlang::f_rhs() %>%
-          as.character() %>%
-          .[[1]]
+        chars <- as.character(rlang::f_rhs(x))
+        chars[[1]]
       }
     )
 
@@ -469,9 +466,9 @@ serially <- function(
 
     # Check [3]: the validation function call cannot yield multiple steps
     validation_step_call_args <-
-      validation_formulas[length(validation_formulas)][[1]] %>%
-      as.call() %>%
-      rlang::call_args()
+      rlang::call_args(
+        as.call(validation_formulas[length(validation_formulas)][[1]])
+      )
 
     # Check the first argument
     if (!as.character(validation_step_call_args[[1]]) == ".") {
@@ -497,10 +494,11 @@ serially <- function(
 
     if (has_expandable_cols_arg) {
 
-      has_multiple_cols <-
-        rlang::as_label(validation_step_call_args[[2]]) %>%
-        gsub("^\"|\"$", "", .) %>%
-        grepl(",", x = .)
+      lbl <- gsub(
+        "^\"|\"$", "",
+        rlang::as_label(validation_step_call_args[[2]])
+      )
+      has_multiple_cols <- grepl(",", x = lbl)
 
       if (has_multiple_cols) {
 
@@ -524,7 +522,7 @@ serially <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       serially(
         .list = .list,
         preconditions = preconditions,
@@ -533,7 +531,7 @@ serially <- function(
         label = label,
         brief = brief,
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -551,10 +549,8 @@ serially <- function(
         FUN.VALUE = character(1),
         USE.NAMES = FALSE,
         FUN = function(x) {
-          x %>%
-            rlang::f_rhs() %>%
-            as.character() %>%
-            .[[1]]
+          chars <- as.character(rlang::f_rhs(x))
+          chars[[1]]
         }
       )
 
@@ -582,12 +578,12 @@ serially <- function(
         eval(
           expr = parse(
             text =
-              validation_formulas[[k]] %>%
-              rlang::f_rhs() %>%
-              rlang::expr_deparse() %>%
-              tidy_gsub("(.", "(double_agent", fixed = TRUE) %>%
-              tidy_gsub("^test_", "") %>%
-              tidy_gsub("threshold\\s+?=\\s.*$", ")") %>%
+              validation_formulas[[k]] |>
+              rlang::f_rhs() |>
+              rlang::expr_deparse() |>
+              tidy_gsub("(.", "(double_agent", fixed = TRUE) |>
+              tidy_gsub("^test_", "") |>
+              tidy_gsub("threshold\\s+?=\\s.*$", ")") |>
               tidy_gsub(",\\s+?\\)$", ")")
 
           ),
@@ -607,12 +603,12 @@ serially <- function(
         eval(
           expr = parse(
             text =
-              validation_formulas[[length(validation_formulas)]] %>%
-              rlang::f_rhs() %>%
-              rlang::expr_deparse() %>%
-              tidy_gsub("(.", "(double_agent", fixed = TRUE) %>%
-              tidy_gsub("^test_", "") %>%
-              tidy_gsub("threshold\\s+?=\\s.*$", ")") %>%
+              validation_formulas[[length(validation_formulas)]] |>
+              rlang::f_rhs() |>
+              rlang::expr_deparse() |>
+              tidy_gsub("(.", "(double_agent", fixed = TRUE) |>
+              tidy_gsub("^test_", "") |>
+              tidy_gsub("threshold\\s+?=\\s.*$", ")") |>
               tidy_gsub(",\\s+?\\)$", ")")
 
           ),
@@ -702,16 +698,16 @@ expect_serially <- function(
   fn_name <- "expect_serially"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     serially(
       .list = .list,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
-  x <- vs$notify %>% all()
+  x <- all(vs$notify)
 
   threshold_type <- get_threshold_type(threshold = threshold)
 
@@ -753,14 +749,14 @@ test_serially <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     serially(
       .list = .list,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/specially.R
+++ b/R/specially.R
@@ -338,7 +338,7 @@ specially <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       specially(
         fn = fn,
         preconditions = preconditions,
@@ -346,7 +346,7 @@ specially <- function(
         label = label,
         brief = brief,
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -416,16 +416,16 @@ expect_specially <- function(
   fn_name <- "expect_specially"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     specially(
       fn = fn,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
-  x <- vs$notify %>% all()
+  x <- vs$notify |> all()
 
   threshold_type <- get_threshold_type(threshold = threshold)
 
@@ -464,14 +464,14 @@ test_specially <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     specially(
       fn = fn,
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/steps_and_briefs.R
+++ b/R/steps_and_briefs.R
@@ -331,11 +331,9 @@ create_autobrief <- function(
 
   if (assertion_type == "col_exists") {
 
-    autobrief <-
-      tidy_gsub(
-        as.character(prep_col_exists_expectation_text(column_text, lang = lang)),
-        "\\s{2,}", " "
-      )
+    col_exists_text <-
+      as.character(prep_col_exists_expectation_text(column_text, lang = lang))
+    autobrief <- tidy_gsub(col_exists_text, "\\s{2,}", " ")
   }
 
   if (assertion_type %in% c("col_vals_in_set", "col_vals_not_in_set")) {

--- a/R/steps_and_briefs.R
+++ b/R/steps_and_briefs.R
@@ -332,9 +332,10 @@ create_autobrief <- function(
   if (assertion_type == "col_exists") {
 
     autobrief <-
-      prep_col_exists_expectation_text(column_text, lang = lang) %>%
-      as.character() %>%
-      tidy_gsub("\\s{2,}", " ")
+      tidy_gsub(
+        as.character(prep_col_exists_expectation_text(column_text, lang = lang)),
+        "\\s{2,}", " "
+      )
   }
 
   if (assertion_type %in% c("col_vals_in_set", "col_vals_not_in_set")) {
@@ -400,8 +401,9 @@ create_autobrief <- function(
 
     values_text <- prep_values_text(values = values, lang = lang)
 
-    value_1 <- strsplit(values_text, ", ") %>% unlist() %>% .[1]
-    value_2 <- strsplit(values_text, ", ") %>% unlist() %>% .[2]
+    parts <- unlist(strsplit(values_text, ", "))
+    value_1 <- parts[1]
+    value_2 <- parts[2]
 
     expectation_text <-
       prep_between_expectation_text(
@@ -558,8 +560,7 @@ create_autobrief <- function(
   if (assertion_type == "conjointly") {
 
     values_text <-
-      prep_values_text(values = values, lang = lang) %>%
-      tidy_gsub("\"", "'")
+      tidy_gsub(prep_values_text(values = values, lang = lang), "\"", "'")
 
     expectation_text <-
       prep_conjointly_expectation_text(values_text, lang = lang)
@@ -604,9 +605,10 @@ finalize_autobrief <- function(
     precondition_text
 ) {
 
-  glue::glue("{expectation_text} {precondition_text}") %>%
-    as.character() %>%
-    tidy_gsub("\\s{2,}", " ")
+  tidy_gsub(
+    as.character(glue::glue("{expectation_text} {precondition_text}")),
+    "\\s{2,}", " "
+  )
 }
 
 generate_autobriefs <- function(
@@ -672,9 +674,9 @@ prep_precondition_text <- function(
   if (is.null(preconditions)) return("")
 
   if (rlang::is_formula(preconditions)) {
-    precondition_label <- preconditions %>% rlang::f_rhs() %>% rlang::as_label()
+    precondition_label <- rlang::as_label(rlang::f_rhs(preconditions))
   } else {
-    precondition_label <- preconditions %>% rlang::as_label()
+    precondition_label <- rlang::as_label(preconditions)
   }
 
   paste0(

--- a/R/table_transformers.R
+++ b/R/table_transformers.R
@@ -571,7 +571,7 @@ tt_time_shift <- function(
         as.integer(round(as.numeric(time_shift, units = "days"), digits = 0))
 
       tbl <-
-        tbl %>%
+        tbl |>
         dplyr::mutate(
           dplyr::across(
             .cols = tidyselect::all_of(time_columns),
@@ -582,7 +582,7 @@ tt_time_shift <- function(
     } else {
 
       tbl <-
-        tbl %>%
+        tbl |>
         dplyr::mutate(
           dplyr::across(
             .cols = tidyselect::all_of(time_columns),
@@ -631,7 +631,7 @@ tt_time_shift <- function(
 
         # Apply the time change for the particular time basis to all columns
         tbl <-
-          tbl %>%
+          tbl |>
           dplyr::mutate(
             dplyr::across(
               .cols = tidyselect::all_of(time_columns),
@@ -773,15 +773,15 @@ tt_time_slice <- function(
   col_sym <- rlang::sym(time_column)
 
   time_bounds <-
-    tbl %>%
-    dplyr::select(!!col_sym) %>%
+    tbl |>
+    dplyr::select(!!col_sym) |>
     dplyr::summarize_all(
       .funs = list(
         ~ min(., na.rm = TRUE),
         ~ max(., na.rm = TRUE)
       )
-    ) %>%
-    dplyr::collect() %>%
+    ) |>
+    dplyr::collect() |>
     as.list()
 
   if (is.numeric(slice_point)) {
@@ -1035,9 +1035,9 @@ get_tt_param <- function(
 
     # Obtain the value from the `tbl` through a `select()`, `filter()`, `pull()`
     param_value <-
-      tbl %>%
-      dplyr::select(.param., tidyselect::all_of(column)) %>%
-      dplyr::filter(.param. == .env$param) %>%
+      tbl |>
+      dplyr::select(.param., tidyselect::all_of(column)) |>
+      dplyr::filter(.param. == .env$param) |>
       dplyr::pull(tidyselect::all_of(column))
 
   } else if (tt_type == "tbl_dims") {
@@ -1052,8 +1052,8 @@ get_tt_param <- function(
 
     # Obtain the value from the `tbl` through a `filter()` and `pull()`
     param_value <-
-      tbl %>%
-      dplyr::filter(.param. == .env$param) %>%
+      tbl |>
+      dplyr::filter(.param. == .env$param) |>
       dplyr::pull(value)
 
   } else if (tt_type == "tbl_colnames") {
@@ -1070,8 +1070,8 @@ get_tt_param <- function(
 
     # Obtain the value from the `tbl` through a `filter()` and `pull()`
     param_value <-
-      tbl %>%
-      dplyr::filter(.param. == as.integer(.env$param)) %>%
+      tbl |>
+      dplyr::filter(.param. == as.integer(.env$param)) |>
       dplyr::pull(value)
   }
 

--- a/R/tbl_from_file.R
+++ b/R/tbl_from_file.R
@@ -544,9 +544,9 @@ from_github <- function(
 
     # Resolve the PR number to a merge commit SHA
     ref_res <-
-      (jsonlite::fromJSON(pulls_doc_tempfile, flatten = TRUE) %>%
-         dplyr::select(number, merge_commit_sha, head.ref) %>%
-         dplyr::filter(number == as.integer(pr_number)) %>%
+      (jsonlite::fromJSON(pulls_doc_tempfile, flatten = TRUE) |>
+         dplyr::select(number, merge_commit_sha, head.ref) |>
+         dplyr::filter(number == as.integer(pr_number)) |>
          dplyr::pull(merge_commit_sha))[1]
 
   } else {

--- a/R/tbl_match.R
+++ b/R/tbl_match.R
@@ -317,7 +317,7 @@ tbl_match <- function(
   if (is_a_table_object(x)) {
 
     secret_agent <-
-      create_agent(x, label = "::QUIET::") %>%
+      create_agent(x, label = "::QUIET::") |>
       tbl_match(
         tbl_compare = tbl_compare,
         preconditions = preconditions,
@@ -326,7 +326,7 @@ tbl_match <- function(
         brief = brief,
         actions = prime_actions(actions),
         active = active
-      ) %>%
+      ) |>
       interrogate()
 
     return(x)
@@ -394,16 +394,16 @@ expect_tbl_match <- function(
   fn_name <- "expect_tbl_match"
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     tbl_match(
       tbl_compare = {{ tbl_compare }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
-  x <- vs$notify %>% all()
+  x <- vs$notify |> all()
 
   threshold_type <- get_threshold_type(threshold = threshold)
 
@@ -447,14 +447,14 @@ test_tbl_match <- function(
 ) {
 
   vs <-
-    create_agent(tbl = object, label = "::QUIET::") %>%
+    create_agent(tbl = object, label = "::QUIET::") |>
     tbl_match(
       tbl_compare = {{ tbl_compare }},
       preconditions = {{ preconditions }},
       actions = action_levels(critical = threshold)
-    ) %>%
-    interrogate() %>%
-    .$validation_set
+    ) |>
+    interrogate() |>
+    (\(x) x$validation_set)()
 
   if (inherits(vs$capture_stack[[1]]$warning, "simpleWarning")) {
     warning(conditionMessage(vs$capture_stack[[1]]$warning))

--- a/R/tbl_store.R
+++ b/R/tbl_store.R
@@ -878,9 +878,7 @@ tbl_get <- function(
   }
 
   # Obtain the table object
-  tbl_obj <-
-    rlang::f_rhs(tbl_entry) %>%
-    rlang::eval_tidy()
+  tbl_obj <- rlang::eval_tidy(rlang::f_rhs(tbl_entry))
 
   # Add the in-store table name to the `pb_tbl_name` attribute
   # of the retrieved table
@@ -928,10 +926,7 @@ yaml_read_tbl_store <- function(filename) {
       if (is.null(init)) "\n)" else paste0(",\n  .init = ", init, "\n)")
     )
 
-  tbl_store <-
-    expr_str %>%
-    rlang::parse_expr() %>%
-    rlang::eval_tidy()
+  tbl_store <- rlang::eval_tidy(rlang::parse_expr(expr_str))
 
   tbl_store
 }

--- a/R/utils-output.R
+++ b/R/utils-output.R
@@ -30,7 +30,7 @@ create_rds_tbl <- function(path = NULL, files = NULL) {
         "agent.*?[0-9]{4}-[0-9]{2}-[0-9]{2}_",
         "[0-9]{2}-[0-9]{2}-[0-9]{2}.rds$"
       )
-    ) %>%
+    ) |>
     basename()
 
   agent_rds_tbl_names <-
@@ -52,7 +52,7 @@ create_rds_tbl <- function(path = NULL, files = NULL) {
         "informant.*?[0-9]{4}-[0-9]{2}-[0-9]{2}_",
         "[0-9]{2}-[0-9]{2}-[0-9]{2}.rds$"
       ),
-    ) %>%
+    ) |>
     basename()
 
   informant_rds_tbl_names <-
@@ -109,7 +109,7 @@ create_rds_tbl <- function(path = NULL, files = NULL) {
       }
 
       agent_tbl <-
-        agent_tbl %>%
+        agent_tbl |>
         dplyr::arrange(dplyr::desc(time_str))
     }
 
@@ -134,7 +134,7 @@ create_rds_tbl <- function(path = NULL, files = NULL) {
       }
 
       informant_tbl <-
-        informant_tbl %>%
+        informant_tbl |>
         dplyr::arrange(dplyr::desc(time_str))
     }
 

--- a/R/utils-profiling.R
+++ b/R/utils-profiling.R
@@ -97,9 +97,9 @@ get_table_column_inf_values <- function(data_column) {
       !inherits(data_column, "tbl_spark")) {
 
     inf_cells <-
-      data_column %>%
-      dplyr::pull(1) %>%
-      is.infinite() %>%
+      data_column |>
+      dplyr::pull(1) |>
+      is.infinite() |>
       sum()
 
   } else {
@@ -115,16 +115,16 @@ get_table_column_inf_values <- function(data_column) {
 # - returns 'tibble' of 1 row, 3 columns
 get_table_column_summary <- function(data_column, round = 2) {
 
-  data_column %>%
+  data_column |>
     dplyr::summarize_all(
       .funs = list(
         ~ mean(., na.rm = TRUE),
         ~ min(., na.rm = TRUE),
         ~ max(., na.rm = TRUE)
       )
-    ) %>%
-    dplyr::collect() %>%
-    dplyr::summarize_all(~ round(., round)) %>%
+    ) |>
+    dplyr::collect() |>
+    dplyr::summarize_all(~ round(., round)) |>
     dplyr::mutate_all(.funs = as.numeric)
 }
 
@@ -134,7 +134,7 @@ get_table_column_summary <- function(data_column, round = 2) {
 # - returns a 'list' with 9 elements
 get_df_column_qtile_stats <- function(data_column) {
 
-  data_column %>%
+  data_column |>
     dplyr::summarize_all(
       .funs = list(
         min = ~ min(., na.rm = TRUE),
@@ -146,9 +146,9 @@ get_df_column_qtile_stats <- function(data_column) {
         max = ~ max(., na.rm = TRUE),
         iqr = ~ stats::IQR(., na.rm = TRUE)
       )
-    ) %>%
-    dplyr::mutate(range = max - min) %>%
-    round(2) %>%
+    ) |>
+    dplyr::mutate(range = max - min) |>
+    round(2) |>
     as.list()
 }
 
@@ -227,7 +227,7 @@ get_spark_column_qtile_stats <- function(data_column) {
     max = quantiles[7],
     iqr = quantiles[5] - quantiles[3],
     range = quantiles[7] - quantiles[1]
-  ) %>%
+  ) |>
     lapply(FUN = function(x) round(x, 2))
 }
 
@@ -240,10 +240,10 @@ get_spark_column_qtile_stats <- function(data_column) {
 get_dbi_column_qtile_stats <- function(data_column) {
 
   data_arranged <-
-    data_column %>%
-    dplyr::rename(a = 1) %>%
-    dplyr::filter(!is.na(a)) %>%
-    dplyr::arrange(a) %>%
+    data_column |>
+    dplyr::rename(a = 1) |>
+    dplyr::filter(!is.na(a)) |>
+    dplyr::arrange(a) |>
     utils::head(6E8)
 
   n_rows <- get_table_total_rows(data = data_arranged)
@@ -254,67 +254,67 @@ get_dbi_column_qtile_stats <- function(data_column) {
   quantile_rows[quantile_rows == 0] <- 1
 
   dplyr::tibble(
-    min = data_arranged %>%
-      dplyr::summarize(a = min(a, na.rm = TRUE)) %>%
-      dplyr::pull(a) %>%
+    min = data_arranged |>
+      dplyr::summarize(a = min(a, na.rm = TRUE)) |>
+      dplyr::pull(a) |>
       as.numeric(),
-    p05 = data_arranged %>%
-      utils::head(quantile_rows[1]) %>%
-      dplyr::arrange(dplyr::desc(a)) %>%
-      utils::head(1) %>%
-      dplyr::pull(a) %>%
+    p05 = data_arranged |>
+      utils::head(quantile_rows[1]) |>
+      dplyr::arrange(dplyr::desc(a)) |>
+      utils::head(1) |>
+      dplyr::pull(a) |>
       as.numeric(),
-    q_1 = data_arranged %>%
-      utils::head(quantile_rows[2]) %>%
-      dplyr::arrange(dplyr::desc(a)) %>%
-      utils::head(1) %>%
-      dplyr::pull(a) %>%
+    q_1 = data_arranged |>
+      utils::head(quantile_rows[2]) |>
+      dplyr::arrange(dplyr::desc(a)) |>
+      utils::head(1) |>
+      dplyr::pull(a) |>
       as.numeric(),
-    med = data_arranged %>%
-      utils::head(quantile_rows[3]) %>%
-      dplyr::arrange(dplyr::desc(a)) %>%
-      utils::head(1) %>%
-      dplyr::pull(a) %>%
+    med = data_arranged |>
+      utils::head(quantile_rows[3]) |>
+      dplyr::arrange(dplyr::desc(a)) |>
+      utils::head(1) |>
+      dplyr::pull(a) |>
       as.numeric(),
-    q_3 = data_arranged %>%
-      utils::head(quantile_rows[4]) %>%
-      dplyr::arrange(dplyr::desc(a)) %>%
-      utils::head(1) %>%
-      dplyr::pull(a) %>%
+    q_3 = data_arranged |>
+      utils::head(quantile_rows[4]) |>
+      dplyr::arrange(dplyr::desc(a)) |>
+      utils::head(1) |>
+      dplyr::pull(a) |>
       as.numeric(),
-    p95 = data_arranged %>%
-      utils::head(quantile_rows[5]) %>%
-      dplyr::arrange(dplyr::desc(a)) %>%
-      utils::head(1) %>%
-      dplyr::pull(a) %>%
+    p95 = data_arranged |>
+      utils::head(quantile_rows[5]) |>
+      dplyr::arrange(dplyr::desc(a)) |>
+      utils::head(1) |>
+      dplyr::pull(a) |>
       as.numeric(),
-    max = data_arranged %>%
-      dplyr::summarize(a = max(a, na.rm = TRUE)) %>%
-      dplyr::pull(a) %>%
+    max = data_arranged |>
+      dplyr::summarize(a = max(a, na.rm = TRUE)) |>
+      dplyr::pull(a) |>
       as.numeric()
-  ) %>%
+  ) |>
     dplyr::mutate(
       iqr = q_3 - q_1,
       range = max - min
-    ) %>%
-    round(2) %>%
+    ) |>
+    round(2) |>
     as.list()
 }
 
 get_table_column_nchar_stats <- function(data_column) {
 
-  data_column %>%
-    dplyr::mutate_all(.funs = nchar) %>%
-    dplyr::rename(nchar = 1) %>%
+  data_column |>
+    dplyr::mutate_all(.funs = nchar) |>
+    dplyr::rename(nchar = 1) |>
     dplyr::summarize_all(
       .funs = list(
         mean = ~ mean(., na.rm = TRUE),
         min = ~ min(., na.rm = TRUE),
         max = ~ max(., na.rm = TRUE)
       )
-    ) %>%
-    dplyr::collect() %>%
-    dplyr::mutate_all(.funs = as.numeric) %>%
+    ) |>
+    dplyr::collect() |>
+    dplyr::mutate_all(.funs = as.numeric) |>
     as.list()
 }
 
@@ -330,13 +330,13 @@ get_table_column_histogram <- function(data_column, lang, locale) {
   y_label <- get_lsv("table_scan/plot_lab_count")[[lang]]
 
   suppressWarnings(
-    data_column %>%
-      dplyr::mutate_all(.funs = nchar) %>%
-      dplyr::rename(nchar = 1) %>%
-      dplyr::count(nchar) %>%
-      dplyr::collect() %>%
-      dplyr::filter(!is.na(nchar)) %>%
-      dplyr::mutate_all(.funs = as.numeric) %>%
+    data_column |>
+      dplyr::mutate_all(.funs = nchar) |>
+      dplyr::rename(nchar = 1) |>
+      dplyr::count(nchar) |>
+      dplyr::collect() |>
+      dplyr::filter(!is.na(nchar)) |>
+      dplyr::mutate_all(.funs = as.numeric) |>
       ggplot2::ggplot(ggplot2::aes(x = nchar, y = n)) +
       ggplot2::geom_col(fill = "steelblue", width = 0.5) +
       ggplot2::geom_hline(yintercept = 0, color = "#B2B2B2") +
@@ -385,7 +385,7 @@ get_tbl_dbi_missing_tbl <- function(data) {
             FUN = function(x) {
 
               missing_n_span <-
-                data %>%
+                data |>
                 dplyr::select(1, dplyr::all_of(x__))
 
               if (ncol(missing_n_span) == 1) {
@@ -398,12 +398,12 @@ get_tbl_dbi_missing_tbl <- function(data) {
               }
 
               missing_n_span <-
-                missing_n_span %>%
-                utils::head(cuts[x]) %>%
+                missing_n_span |>
+                utils::head(cuts[x]) |>
                 dplyr::summarize_all(
                   ~ sum(ifelse(is.na(.), 1, 0), na.rm = TRUE)
-                ) %>%
-                dplyr::pull(a) %>%
+                ) |>
+                dplyr::pull(a) |>
                 as.integer()
 
               missing_bin <- missing_n_span - missing_tally
@@ -423,8 +423,8 @@ get_tbl_dbi_missing_tbl <- function(data) {
       }
     )
 
-  frequency_list %>%
-    dplyr::bind_rows() %>%
+  frequency_list |>
+    dplyr::bind_rows() |>
     dplyr::mutate(
       value = ifelse(value == 0, NA_real_, value),
       col_name = factor(col_name, levels = colnames(data))
@@ -619,14 +619,14 @@ get_missing_value_plot <- function(data, frequency_tbl, missing_by_column_tbl) {
 get_table_slice_gt <- function(data_column,
                                locale) {
 
-  data_column %>%
-    gt::gt() %>%
-    gt::fmt_percent(columns = 3, locale = locale) %>%
-    gt::sub_missing(columns = 1, missing_text = "**NA**") %>%
+  data_column |>
+    gt::gt() |>
+    gt::fmt_percent(columns = 3, locale = locale) |>
+    gt::sub_missing(columns = 1, missing_text = "**NA**") |>
     gt::text_transform(
       locations = gt::cells_body(columns = 1),
       fn = function(x) ifelse(x == "**NA**", "<code>NA</code>", x)
-    ) %>%
+    ) |>
     gt::tab_options(
       table.border.top.style = "none",
       table.width = "100%"

--- a/R/utils-specifications.R
+++ b/R/utils-specifications.R
@@ -275,7 +275,7 @@ check_vin_db <- function(table,
   tbl_colnames <- get_table_column_names(data = table)
 
   table <-
-    table %>%
+    table |>
     dplyr::mutate(
       pb_vin_all_ = {{ column }},
       pb_vin_all_ = tolower(as.character((pb_vin_all_))),
@@ -352,7 +352,7 @@ check_vin_db <- function(table,
     )
 
   table <-
-    table %>% dplyr::select(dplyr::all_of(c(tbl_colnames, "pb_is_good_")))
+    table |> dplyr::select(dplyr::all_of(c(tbl_colnames, "pb_is_good_")))
 
   table
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1769,7 +1769,9 @@ print_time <- function(time_diff_s) {
 
   paste0(
     " {.time_taken (",
-    formatC(round(time_diff_s, 1), format = "f", drop0trailing = FALSE, digits = 1),
+    formatC(
+      round(time_diff_s, 1), format = "f", drop0trailing = FALSE, digits = 1
+    ),
     " s)}"
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -174,7 +174,7 @@ interrogation_time <- function(agent) {
 }
 
 number_of_validation_steps <- function(agent) {
-  if (is_ptblank_agent(agent)) agent$validation_set %>% nrow() else NA
+  if (is_ptblank_agent(agent)) nrow(agent$validation_set) else NA
 }
 
 # Get the next step number for the `validation_set` tibble
@@ -405,9 +405,9 @@ resolve_segments <- function(x, seg_expr, preconditions) {
         column_name <- rlang::as_label(seg_expr[[i]][[j]])
 
         col_seg_vals <-
-          tbl %>%
-          dplyr::select(tidyselect::all_of(column_name)) %>%
-          dplyr::distinct() %>%
+          tbl |>
+          dplyr::select(tidyselect::all_of(column_name)) |>
+          dplyr::distinct() |>
           dplyr::pull()
 
         names(col_seg_vals) <- rep(column_name, length(col_seg_vals))
@@ -607,7 +607,7 @@ process_table_input <- function(tbl, tbl_name) {
     if (inherits(read_fn, "read_fn")) {
 
       if (inherits(read_fn, "with_tbl_name") && is.na(tbl_name)) {
-        tbl_name <- read_fn %>% rlang::f_lhs() %>% as.character()
+        tbl_name <- as.character(rlang::f_lhs(read_fn))
       }
     }
 
@@ -801,7 +801,7 @@ column_expansion_fns_vec <- function() {
 }
 
 get_tbl_dbi_src_info <- function(tbl) {
-  utils::capture.output(tbl %>% unclass() %>% .$src)
+  utils::capture.output(unclass(tbl)$src)
 }
 
 get_tbl_dbi_src_details <- function(tbl) {
@@ -821,8 +821,8 @@ get_r_column_names_types <- function(tbl) {
 
   suppressWarnings(
     column_header <-
-      tbl %>%
-      utils::head(1) %>%
+      tbl |>
+      utils::head(1) |>
       dplyr::collect()
   )
   column_names_types <-
@@ -899,11 +899,7 @@ get_tbl_information_spark <- function(tbl) {
 
   tbl_schema <- sparklyr::sdf_schema(tbl)
 
-  db_col_types <-
-    lapply(tbl_schema, `[[`, 2) %>%
-    unlist() %>%
-    unname() %>%
-    tolower()
+  db_col_types <- tolower(unname(unlist(lapply(tbl_schema, `[[`, 2))))
 
   list(
     tbl_src = "tbl_spark",
@@ -1077,9 +1073,7 @@ get_tbl_information_dbi <- function(tbl) {
     # nocov start
 
     db_col_types <-
-      DBI::dbGetQuery(tbl_connection, q_types) %>%
-      dplyr::pull(data_type) %>%
-      tolower()
+      tolower(dplyr::pull(DBI::dbGetQuery(tbl_connection, q_types), data_type))
 
     # nocov end
   }
@@ -1089,9 +1083,7 @@ get_tbl_information_dbi <- function(tbl) {
     # nocov start
 
     db_col_types <-
-      DBI::dbGetQuery(tbl_connection, q_types) %>%
-      dplyr::pull(DATA_TYPE) %>%
-      tolower()
+      tolower(dplyr::pull(DBI::dbGetQuery(tbl_connection, q_types), DATA_TYPE))
 
     # nocov end
   }
@@ -1107,14 +1099,14 @@ get_tbl_information_dbi <- function(tbl) {
 
           DBI::dbDataType(
             tbl_connection,
-            tbl %>%
-              dplyr::select(tidyselect::all_of(x)) %>%
-              utils::head(1) %>%
-              dplyr::collect() %>%
+            tbl |>
+              dplyr::select(tidyselect::all_of(x)) |>
+              utils::head(1) |>
+              dplyr::collect() |>
               dplyr::pull(x)
           )
         }
-      ) %>%
+      ) |>
       tolower()
   }
 
@@ -1123,9 +1115,9 @@ get_tbl_information_dbi <- function(tbl) {
     # nocov start
 
     db_col_types <-
-      DBI::dbGetQuery(tbl_connection, q_types) %>%
-      dplyr::collect() %>%
-      dplyr::pull(ifelse(tbl_src == "bigquery", "data_type", "DATA_TYPE")) %>%
+      DBI::dbGetQuery(tbl_connection, q_types) |>
+      dplyr::collect() |>
+      dplyr::pull(ifelse(tbl_src == "bigquery", "data_type", "DATA_TYPE")) |>
       tolower()
 
     # nocov end
@@ -1293,11 +1285,11 @@ add_icon_svg <- function(
       `vertical-align` = "middle"
     ),
     htmltools::HTML(
-      paste(readLines(con = file, warn = FALSE), collapse = "") %>%
-        tidy_gsub("width=\"[0-9]*?px", paste0("width=\"", height, "px")) %>%
+      paste(readLines(con = file, warn = FALSE), collapse = "") |>
+        tidy_gsub("width=\"[0-9]*?px", paste0("width=\"", height, "px")) |>
         tidy_gsub("height=\"[0-9]*?px", paste0("height=\"", height, "px"))
     )
-  ) %>%
+  ) |>
     as.character()
 }
 
@@ -1335,7 +1327,7 @@ capture_formula <- function(
     if (grepl("^~", output)) {
       output <- c(NA_character_, output)
     } else {
-      output <- strsplit(output, " ~ ") %>% unlist()
+      output <- unlist(strsplit(output, " ~ "))
       output[2] <- paste("~", output[2])
     }
   }
@@ -1450,8 +1442,8 @@ pb_str_catalog <- function(
     }
   }
 
-  surround_str_1 <- rev(surround) %>% paste(collapse = "")
-  surround_str_2 <- surround %>% paste(collapse = "")
+  surround_str_1 <- paste(rev(surround), collapse = "")
+  surround_str_2 <- paste(surround, collapse = "")
 
   cat_str <- paste0(surround_str_1, item_vector, surround_str_2)
 
@@ -1489,9 +1481,7 @@ pb_str_catalog <- function(
 
     } else {
 
-      cat_str <-
-        paste0(cat_str, separators) %>%
-        paste(collapse = "")
+      cat_str <- paste(paste0(cat_str, separators), collapse = "")
     }
 
     cat_str <- paste(cat_str, n_overlimit)
@@ -1657,8 +1647,8 @@ pb_quantile_stats <- function(
       sparklyr::sdf_quantile(
         data_column, column_name,
         probabilities = quantile
-      ) %>%
-      unname() %>%
+      ) |>
+      unname() |>
       round(2)
 
     return(quantile)
@@ -1668,55 +1658,55 @@ pb_quantile_stats <- function(
   } else if (inherits(data_column, "data.frame")) {
 
     quantile <-
-      data_column %>%
-      stats::quantile(probs = quantile, na.rm = TRUE) %>%
-      unname() %>%
+      data_column |>
+      stats::quantile(probs = quantile, na.rm = TRUE) |>
+      unname() |>
       round(2)
 
   } else if (is_tbl_dbi(data_column)) {
 
-    data_column <- data_column %>% dplyr::filter(!is.na(1))
+    data_column <- dplyr::filter(data_column, !is.na(1))
 
     n_rows <-
-      data_column %>%
-      dplyr::count(name = "n") %>%
-      dplyr::pull(n) %>%
+      data_column |>
+      dplyr::count(name = "n") |>
+      dplyr::pull(n) |>
       as.numeric()
 
     if (n_rows <= 5000) {
 
-      data_column <- data_column %>% dplyr::collect()
+      data_column <- dplyr::collect(data_column)
 
       quantile <-
-        data_column %>%
-        stats::quantile(probs = quantile, na.rm = TRUE) %>%
-        unname() %>%
+        data_column |>
+        stats::quantile(probs = quantile, na.rm = TRUE) |>
+        unname() |>
         round(2)
 
     } else {
 
       data_arranged <-
-        data_column %>%
-        dplyr::rename(a = 1) %>%
-        dplyr::filter(!is.na(a)) %>%
-        dplyr::arrange(a) %>%
+        data_column |>
+        dplyr::rename(a = 1) |>
+        dplyr::filter(!is.na(a)) |>
+        dplyr::arrange(a) |>
         utils::head(6E8)
 
       n_rows_data <-
-        data_arranged %>%
-        dplyr::count(name = "n") %>%
-        dplyr::pull(n) %>%
+        data_arranged |>
+        dplyr::count(name = "n") |>
+        dplyr::pull(n) |>
         as.numeric()
 
       quantile_row <- floor(quantile * n_rows_data)
 
       quantile <-
-        data_arranged %>%
-        utils::head(quantile_row) %>%
-        dplyr::arrange(desc(a)) %>%
-        utils::head(1) %>%
-        dplyr::pull(a) %>%
-        as.numeric() %>%
+        data_arranged |>
+        utils::head(quantile_row) |>
+        dplyr::arrange(desc(a)) |>
+        utils::head(1) |>
+        dplyr::pull(a) |>
+        as.numeric() |>
         round(2)
     }
 
@@ -1730,16 +1720,16 @@ pb_quantile_stats <- function(
 
 pb_min_max_stats <- function(data_column) {
 
-  data_column %>%
+  data_column |>
     dplyr::summarize_all(
       .funs = list(
         ~ min(., na.rm = TRUE),
         ~ max(., na.rm = TRUE)
       )
-    ) %>%
-    dplyr::collect() %>%
-    dplyr::summarize_all(~ round(., 2)) %>%
-    dplyr::mutate_all(.funs = as.numeric) %>%
+    ) |>
+    dplyr::collect() |>
+    dplyr::summarize_all(~ round(., 2)) |>
+    dplyr::mutate_all(.funs = as.numeric) |>
     as.list()
 }
 
@@ -1779,8 +1769,7 @@ print_time <- function(time_diff_s) {
 
   paste0(
     " {.time_taken (",
-    round(time_diff_s, 1) %>%
-      formatC(format = "f", drop0trailing = FALSE, digits = 1),
+    formatC(round(time_diff_s, 1), format = "f", drop0trailing = FALSE, digits = 1),
     " s)}"
   )
 }

--- a/R/validate_rmd.R
+++ b/R/validate_rmd.R
@@ -254,8 +254,8 @@ knitr_error_hook <- function(previous_hook) {
       increment_count("error")
 
       error_message <-
-        x %>%
-        tidy_gsub("##", "") %>%
+        x |>
+        tidy_gsub("##", "") |>
         tidy_gsub("\n", "")
 
       log4r_error(message = error_message)
@@ -330,8 +330,8 @@ knitr_chunk_hook <- function(x, options) {
 
     matches <- gregexpr(pattern = "```r(.|\n)*?```", x)
 
-    regmatches(x = x, m = matches) %>%
-      unlist() %>%
+    regmatches(x = x, m = matches) |>
+      unlist() |>
       tidy_gsub("(```r\\n|\\n```)", "")
   }
 
@@ -342,8 +342,8 @@ knitr_chunk_hook <- function(x, options) {
       # This is an HTML report for a validation
 
       output <-
-        x %>%
-        tidy_gsub("^\n\n(.|\n)*?```\\{=html\\}", "") %>%
+        x |>
+        tidy_gsub("^\n\n(.|\n)*?```\\{=html\\}", "") |>
         tidy_gsub("```\n", "")
 
     } else {
@@ -353,8 +353,8 @@ knitr_chunk_hook <- function(x, options) {
       matches <- gregexpr(pattern = "```\n##(.|\n)*?```", x)
 
       output <-
-        regmatches(x = x, m = matches) %>%
-        unlist() %>%
+        regmatches(x = x, m = matches) |>
+        unlist() |>
         tidy_gsub("(```\\n|\\n```)", "")
     }
 
@@ -554,7 +554,7 @@ knitr_chunk_hook <- function(x, options) {
       }
 
       content <-
-        c(content, as.character(output_content)) %>%
+        c(content, as.character(output_content)) |>
         as.character()
     }
 

--- a/R/write_testthat_file.R
+++ b/R/write_testthat_file.R
@@ -344,7 +344,7 @@ write_testthat_file <- function(
 
   # Select only the necessary columns from the agent's `validation_set`
   agent_validation_set <-
-    agent$validation_set %>%
+    agent$validation_set |>
     dplyr::select(
       i, assertion_type, brief, eval_active
     )
@@ -366,11 +366,9 @@ write_testthat_file <- function(
   # Using the `expanded = TRUE` option in `agent_get_exprs()` so that
   # that the expanded form of the validation steps is available
   # (same number of steps as in the validation report)
-  agent_exprs_raw <-
-    agent_get_exprs(agent, expanded = TRUE) %>%
-    strsplit("%>%") %>%
-    unlist() %>%
-    gsub("^\n", "", .)
+  agent_exprs_raw <- agent_get_exprs(agent, expanded = TRUE)
+  agent_exprs_raw <- unlist(strsplit(agent_exprs_raw, "%>%"))
+  agent_exprs_raw <- gsub("^\n", "", agent_exprs_raw)
 
   if (grepl("^create_agent", agent_exprs_raw[1])) {
     agent_exprs_raw <- agent_exprs_raw[-1]
@@ -408,11 +406,10 @@ write_testthat_file <- function(
     )
 
   # Generate descriptions for each test
-  test_that_desc <-
-    agent_validation_set$brief %>%
-    gsub("(Expect that |Expect )", "", .) %>%
-    gsub(" $", "", .) %>%
-    gsub("\\.$", "", .)
+  test_that_desc <- agent_validation_set$brief
+  test_that_desc <- gsub("(Expect that |Expect )", "", test_that_desc)
+  test_that_desc <- gsub(" $", "", test_that_desc)
+  test_that_desc <- gsub("\\.$", "", test_that_desc)
 
   # Initialize vector of `test_that()` tests
   test_that_tests <- c()
@@ -426,11 +423,13 @@ write_testthat_file <- function(
           "test_that(\"",
           test_that_desc[i],
           "\", {\n\n",
-          agent_exprs_raw[i] %>%
-            gsub("^", "  ", .) %>%
-            gsub("\n  ", "\n    ", .) %>%
-            gsub("\n\\)", "\n  )", .) %>%
-            gsub("    #", "  #", .),
+          {
+            expr_i <- agent_exprs_raw[i]
+            expr_i <- gsub("^", "  ", expr_i)
+            expr_i <- gsub("\n  ", "\n    ", expr_i)
+            expr_i <- gsub("\n\\)", "\n  )", expr_i)
+            gsub("    #", "  #", expr_i)
+          },
           "\n})\n\n"
         )
       )
@@ -570,8 +569,11 @@ insert_threshold_values <- function(
         threshold_val <- 1
       }
 
-      agent_exprs_raw[x] %>%
-        gsub("\n\\)", paste0(",\n  threshold = ", threshold_val, "\n\\)"), .)
+      gsub(
+        "\n\\)",
+        paste0(",\n  threshold = ", threshold_val, "\n\\)"),
+        agent_exprs_raw[x]
+      )
     }
   )
 }
@@ -587,12 +589,9 @@ resolve_test_filename <- function(agent, name) {
 
     } else {
 
-      file_name <-
-        agent$tbl_name %>%
-        fs::path_sanitize() %>%
-        gsub("(\\.| |'|:)", "_", .) %>%
-        paste0("test-", .) %>%
-        paste0(., ".R")
+      file_name <- fs::path_sanitize(agent$tbl_name)
+      file_name <- gsub("(\\.| |'|:)", "_", file_name)
+      file_name <- paste0("test-", file_name, ".R")
     }
 
   } else {
@@ -604,12 +603,9 @@ resolve_test_filename <- function(agent, name) {
       )
     }
 
-    file_name <-
-      name[1] %>%
-      fs::path_sanitize() %>%
-      gsub("(\\.| |'|:)", "_", .) %>%
-      paste0("test-", .) %>%
-      paste0(., ".R")
+    file_name <- fs::path_sanitize(name[1])
+    file_name <- gsub("(\\.| |'|:)", "_", file_name)
+    file_name <- paste0("test-", file_name, ".R")
   }
 
   file_name

--- a/R/yaml_read_agent.R
+++ b/R/yaml_read_agent.R
@@ -147,9 +147,11 @@ yaml_read_agent <- function(
 
   file_to_read <- basename(filename)
 
-  expr_from_agent_yaml(path = file_to_read, interrogate = FALSE) %>%
-    rlang::parse_expr() %>%
-    rlang::eval_tidy()
+  rlang::eval_tidy(
+    rlang::parse_expr(
+      expr_from_agent_yaml(path = file_to_read, interrogate = FALSE)
+    )
+  )
 }
 
 #' Get an *agent* from **pointblank** YAML and `interrogate()`
@@ -257,9 +259,11 @@ yaml_agent_interrogate <- function(
     filename <- file.path(path, filename)
   }
 
-  expr_from_agent_yaml(path = filename, interrogate = TRUE) %>%
-    rlang::parse_expr() %>%
-    rlang::eval_tidy()
+  rlang::eval_tidy(
+    rlang::parse_expr(
+      expr_from_agent_yaml(path = filename, interrogate = TRUE)
+    )
+  )
 }
 
 #' Display validation expressions using **pointblank** YAML
@@ -705,14 +709,12 @@ make_validation_steps <- function(steps) {
 
         args <- args[args != ""]
 
-        args %>%
-          paste(collapse = ",\n") %>%
-          paste0("%>%\n", step_fn, "(\n", ., "\n)")
+        paste0("%>%\n", step_fn, "(\n", paste(args, collapse = ",\n"), "\n)")
       }
-    ) %>%
-    unlist() %>%
-    paste(collapse = " ") %>%
-    paste0(., " ")
+    ) |>
+    unlist() |>
+    paste(collapse = " ")
+  str_exprs <- paste0(str_exprs, " ")
 
   # nolint end
 

--- a/R/yaml_read_informant.R
+++ b/R/yaml_read_informant.R
@@ -113,8 +113,8 @@ yaml_read_informant <- function(
     expr_from_informant_yaml(path = file_to_read, incorporate = FALSE)
 
   informant <-
-    informant_list$expr_str %>%
-    rlang::parse_expr() %>%
+    informant_list$expr_str |>
+    rlang::parse_expr() |>
     rlang::eval_tidy()
 
   informant$metadata <- informant_list$metadata
@@ -203,13 +203,13 @@ yaml_informant_incorporate <- function(
     expr_from_informant_yaml(path = filename)
 
   informant <-
-    informant_list$expr_str %>%
-    rlang::parse_expr() %>%
+    informant_list$expr_str |>
+    rlang::parse_expr() |>
     rlang::eval_tidy()
 
   informant$metadata <- informant_list$metadata
 
-  informant <- informant %>% incorporate()
+  informant <- informant |> incorporate()
   informant
 }
 
@@ -273,7 +273,7 @@ expr_from_informant_yaml <- function(path, incorporate = FALSE) {
   # Add the `incorporate()` statement if needed (this is
   # for the `yaml_informant_incorporate()` function)
   if (incorporate) {
-    expr_str <- paste0(expr_str, "%>%\nincorporate()")
+    expr_str <- paste0(expr_str, "|>\nincorporate()")
   }
 
   y$tbl <- NULL
@@ -427,7 +427,7 @@ make_info_snippets <- function(snippets) {
         snippet_fun <- snippets[[x]]
 
         paste0(
-          "%>% info_snippet(",
+          "|> info_snippet(",
           "snippet_name = \"", snippet_name, "\", ",
           "fn = ", snippet_fun, ")"
         )

--- a/R/yaml_write.R
+++ b/R/yaml_write.R
@@ -657,7 +657,7 @@ yaml_agent_string <- function(
       as_agent_yaml_list(
         agent = agent,
         expanded = expanded
-      ) %>%
+      ) |>
         yaml::as.yaml(
           handlers = list(
             logical = function(x) {
@@ -675,8 +675,7 @@ yaml_agent_string <- function(
       if (!is.null(path)) {
         filename <- file.path(path, filename)
       }
-      readLines(filename) %>%
-        paste(collapse = "\n")
+      paste(readLines(filename), collapse = "\n")
     }
   )
 
@@ -699,8 +698,11 @@ as_list_preconditions <- function(preconditions) {
   } else if (is.function(preconditions[[1]])) {
 
     return(
-      paste(deparse(preconditions[[1]]), collapse = "\n") %>%
-        gsub("function (x) \n{", "function(x) {", ., fixed = TRUE)
+      gsub(
+        "function (x) \n{", "function(x) {",
+        paste(deparse(preconditions[[1]]), collapse = "\n"),
+        fixed = TRUE
+      )
     )
 
   }
@@ -758,7 +760,7 @@ to_list_action_levels <- function(actions) {
       lapply(
         agent_actions$fns,
         FUN = function(x) {
-          if (!is.null(x)) x %>% as.character() %>% paste(collapse = "")
+          if (!is.null(x)) paste(as.character(x), collapse = "")
         }
       )
   }
@@ -779,7 +781,7 @@ as_action_levels <- function(actions, actions_default = NULL) {
       lapply(
         agent_actions$fns,
         FUN = function(x) {
-          if (!is.null(x)) x %>% as.character() %>% paste(collapse = "")
+          if (!is.null(x)) paste(as.character(x), collapse = "")
         }
       )
   }
@@ -966,7 +968,7 @@ as_agent_yaml_list <- function(agent, expanded) {
   check_lazy_tbl(agent, "agent")
 
   action_levels_default <- as_action_levels(agent$actions)
-  end_fns <- agent$end_fns %>% unlist()
+  end_fns <- unlist(agent$end_fns)
 
   lst_label <- to_list_label(agent$label)
   lst_tbl_name <- to_list_tbl_name(agent$tbl_name)
@@ -1011,14 +1013,14 @@ as_agent_yaml_list <- function(agent, expanded) {
     # and doesn't split `vars()`)
 
     agent_validation_set <-
-      agent$validation_set %>%
+      agent$validation_set |>
       dplyr::select(
         i_o, assertion_type, columns_expr, column, values, na_pass,
         preconditions, seg_expr, actions, label, brief, active
-      ) %>%
-      dplyr::group_by(i_o) %>%
-      dplyr::filter(dplyr::row_number() == 1) %>%
-      dplyr::ungroup() %>%
+      ) |>
+      dplyr::group_by(i_o) |>
+      dplyr::filter(dplyr::row_number() == 1) |>
+      dplyr::ungroup() |>
       dplyr::rename(i = i_o)
 
     # Temporary conversion of `$label` to list-column
@@ -1037,7 +1039,7 @@ as_agent_yaml_list <- function(agent, expanded) {
     # evaluated and split into a validation step per target column
 
     agent_validation_set <-
-      agent$validation_set %>%
+      agent$validation_set |>
       dplyr::select(
         i, assertion_type, columns_expr, column, values, na_pass,
         preconditions, seg_expr, actions, label, brief, active
@@ -1048,7 +1050,7 @@ as_agent_yaml_list <- function(agent, expanded) {
 
   for (i in seq_len(nrow(agent_validation_set))) {
 
-    step_list <- agent_validation_set[i, ] %>% as.list()
+    step_list <- as.list(agent_validation_set[i, ])
 
     validation_fn <- step_list$assertion_type
 


### PR DESCRIPTION
This PR refactors several R functions to adopt the native pipe operator (`|>`) instead of the magrittr pipe (`%>%`). These changes are meant to modernize the codebase, improve readability, and align with current R best practices.