### PR TITLE
fix: simplify syntax for row-based validations in YAML

### DIFF
--- a/R/yaml_read_agent.R
+++ b/R/yaml_read_agent.R
@@ -562,6 +562,12 @@ make_validation_steps <- function(steps) {
       FUN = function(x) {
 
         step_i <- steps[[x]]
+
+        # Handle scalar steps (no arguments): `- rows_distinct` in YAML
+        if (is.character(step_i)) {
+          return(paste0("%>%\n", step_i, "()"))
+        }
+
         step_fn <- names(step_i)
 
         args <-

--- a/R/yaml_write.R
+++ b/R/yaml_write.R
@@ -181,9 +181,8 @@
 #'     columns: c(date, date_time)
 #' - col_vals_regex:
 #'     columns: c(b)
-#'     regex: '[0-9]-[a-z]{3}-[0-9]{3}'
-#' - rows_distinct:
-#'     columns: ~
+#'     pattern: '[0-9]-[a-z]{3}-[0-9]{3}'
+#' - rows_distinct
 #' - col_vals_gt:
 #'     columns: c(d)
 #'     value: 100.0
@@ -621,9 +620,8 @@ yaml_write <- function(
 #'     columns: vars(date_time)
 #' - col_vals_regex:
 #'     columns: vars(b)
-#'     regex: '[0-9]-[a-z]{3}-[0-9]{3}'
-#' - rows_distinct:
-#'     columns: ~
+#'     pattern: '[0-9]-[a-z]{3}-[0-9]{3}'
+#' - rows_distinct
 #' - col_vals_gt:
 #'     columns: vars(d)
 #'     value: 100.0

--- a/inst/yaml/agent-small_table.yml
+++ b/inst/yaml/agent-small_table.yml
@@ -16,8 +16,7 @@ steps:
 - col_vals_regex:
     columns: vars(b)
     pattern: '[0-9]-[a-z]{3}-[0-9]{3}'
-- rows_distinct:
-    columns: ~
+- rows_distinct
 - col_vals_gt:
     columns: vars(d)
     value: 100.0

--- a/vignettes/YAML.Rmd
+++ b/vignettes/YAML.Rmd
@@ -170,8 +170,7 @@ steps:
       pattern: '^[0-9]-[a-z]{3}-[0-9]{3}$'
 
   # rows_distinct()
-  - rows_distinct:
-      columns: ~
+  - rows_distinct
 ```
 
 Arguments that use R expressions (like column selections via `vars()`) are stored as strings and evaluated when the YAML is read back.


### PR DESCRIPTION
This PR updates the handling of YAML validation steps in the agent, specifically improving support for scalar steps (steps without arguments) and updating documentation and example files to reflect this change. Scalar steps like `- rows_distinct` are now supported and processed correctly, rather than requiring a `columns: ~` argument.

Fixes: https://github.com/rstudio/pointblank/issues/688